### PR TITLE
fix(ci): fix two Linux CI failures

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,6 +35,13 @@ jobs:
 
       - name: Check index files are up to date
         run: |
+          # generated_at is a wall-clock timestamp that always differs in CI.
+          # Restore it to the committed value before diffing so only substantive
+          # changes (added/removed fragments or skills) cause a failure.
+          for file in index/fragments.json index/skills.json; do
+            committed_at=$(git show HEAD:"$file" | jq -r '.generated_at')
+            jq --arg t "$committed_at" '.generated_at = $t' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+          done
           if ! git diff --quiet index/; then
             echo "Index files are out of date. Run 'just index' and commit the result."
             git diff index/

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -106,7 +106,7 @@ fi
 
 # ── Output ────────────────────────────────────────────────────────────────────
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "$OUTPUT"
+  printf '%s\n' "$OUTPUT"
 else
   mkdir -p "$TARGET"
   echo "$OUTPUT" > "$TARGET/AGENTS.md"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -143,16 +143,18 @@ assert_file_not_contains "$TMP/t02/AGENTS.md" "## TypeScript" "T02"
 
 # T03 — compose: dry-run produces stdout, no files written
 run_test "T03 — compose: dry-run produces stdout, no files written"
-DRY_OUT=$(bash "$COMPOSE" \
+DRY_TMPFILE=$(mktemp)
+T03_EXIT=0
+bash "$COMPOSE" \
   --library "$LIBRARY" \
   --profile typescript-hexagonal-microservice \
   --target "$TMP/t03" \
-  --dry-run 2>&1)
-T03_EXIT=$?
+  --dry-run > "$DRY_TMPFILE" 2>/dev/null || T03_EXIT=$?
 
 assert_exit_code 0 "$T03_EXIT" "T03"
 assert_file_not_exists "$TMP/t03" "T03"
-assert_stdout_contains "$DRY_OUT" "## Git Conventions" "T03"
+assert_file_contains "$DRY_TMPFILE" "## Git Conventions" "T03"
+rm -f "$DRY_TMPFILE"
 
 # T04 — compose: unknown profile fails with exit code 1
 run_test "T04 — compose: unknown profile fails"


### PR DESCRIPTION
## Summary

- **T03 bash compatibility** (`compose.sh` + `test.sh`): `echo` behaves differently between bash 3.2 (macOS) and bash 5.x (Linux CI). Switched to `printf '%s\n'` in the dry-run output path and changed T03 to redirect to a temp file instead of capturing to a variable.
- **Index check false positive** (`validate.yml`): `index.sh` writes a wall-clock `generated_at` on every run, so the committed timestamp always differs from what CI produces. The check now restores `generated_at` to the committed value before diffing, so only substantive changes (added/removed fragments or skills) fail the gate.

## Test plan

- [x] `validate` CI job goes green on this PR
- [x] All 29 assertions pass (`just test`)
- [x] Index check passes without timestamp false positive