### PR TITLE
feat: Opencode vendor, MCP tooling, and vendor polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ This writes the following files into `~/code/my-api`:
 
 ```
 my-api/
-├── AGENTS.md                                  # canonical — read by Claude, Codex, and others
+├── AGENTS.md                                  # canonical — read by Claude, Codex, Opencode, and others
 ├── CLAUDE.md                                  # symlink → AGENTS.md (Claude Code)
+├── opencode.json                              # Opencode config: model, permissions, MCP block
 ├── .github/
 │   ├── copilot-instructions.md                # global Copilot instructions
 │   └── instructions/
@@ -93,6 +94,7 @@ just dry-run typescript-hexagonal-microservice
 | **GitHub Copilot** | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | Global always-on instructions + glob-scoped per-language files with `applyTo` frontmatter |
 | **OpenAI Codex** | `AGENTS.md` | Native passthrough — Codex reads `AGENTS.md` hierarchically (supports monorepo subdirectories) |
 | **Gemini CLI** | `.gemini/systemPrompt.md` | All sections concatenated into a single system prompt file |
+| **Opencode** | `AGENTS.md`, `opencode.json` | Reads `AGENTS.md` natively; `opencode.json` generated with model defaults, permission settings, and empty MCP block. Skills land in `.claude/skills/` (Opencode reads this path for Claude compatibility) |
 
 ---
 
@@ -197,6 +199,16 @@ just lint                   # validate all fragments, profiles, and vendor adapt
 just test                   # run the integration test suite
 just index                  # rebuild index/skills.json and index/fragments.json
 ```
+
+### MCP servers
+
+```bash
+just mcp-add TARGET                     # interactive wizard: add an MCP server to a project
+just mcp-remove TARGET SERVER_NAME      # remove an MCP server from a project
+just mcp-list TARGET                    # list all configured MCP servers in a project
+```
+
+Writes `.mcp.json` in the target project (Claude standard format) and optionally syncs to `opencode.json` and `.gemini/settings.json`.
 
 ---
 

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-01T18:30:18Z",
+  "generated_at": "2026-03-01T23:04:26Z",
   "fragments": [
     {
       "name": "bff",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-01T18:30:18Z",
+  "generated_at": "2026-03-01T23:04:26Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -11,6 +11,18 @@
       "tags": [
         "agentic",
         "meta",
+        "setup"
+      ]
+    },
+    {
+      "name": "configure-mcp",
+      "group": "agentic",
+      "path": "skills/agentic/configure-mcp/SKILL.md",
+      "description": ">",
+      "version": "1.0.0",
+      "tags": [
+        "agentic",
+        "mcp",
         "setup"
       ]
     },

--- a/justfile
+++ b/justfile
@@ -134,3 +134,18 @@ dry-run profile:
         --profile "{{profile}}" \
         --target /dev/stdout \
         --dry-run
+
+# Manage MCP servers in a target project (interactive wizard)
+# Usage: just mcp-add /path/to/project
+mcp-add target:
+    @"{{LIBRARY_ROOT}}/tooling/lib/mcp.sh" --action add --target "{{target}}"
+
+# Remove an MCP server from a target project
+# Usage: just mcp-remove /path/to/project github
+mcp-remove target name:
+    @"{{LIBRARY_ROOT}}/tooling/lib/mcp.sh" --action remove --target "{{target}}" --name "{{name}}"
+
+# List MCP servers configured in a target project
+# Usage: just mcp-list /path/to/project
+mcp-list target:
+    @"{{LIBRARY_ROOT}}/tooling/lib/mcp.sh" --action list --target "{{target}}"

--- a/profiles/go-hexagonal-microservice.yaml
+++ b/profiles/go-hexagonal-microservice.yaml
@@ -47,3 +47,4 @@ vendors:
     - copilot
     - codex
     - gemini
+    - opencode

--- a/profiles/php-hexagonal-ddd.yaml
+++ b/profiles/php-hexagonal-ddd.yaml
@@ -47,3 +47,4 @@ vendors:
     - copilot
     - codex
     - gemini
+    - opencode

--- a/profiles/python-fastapi-microservice.yaml
+++ b/profiles/python-fastapi-microservice.yaml
@@ -45,3 +45,4 @@ vendors:
     - copilot
     - codex
     - gemini
+    - opencode

--- a/profiles/typescript-bff.yaml
+++ b/profiles/typescript-bff.yaml
@@ -46,3 +46,4 @@ vendors:
     - copilot
     - codex
     - gemini
+    - opencode

--- a/profiles/typescript-hexagonal-microservice.yaml
+++ b/profiles/typescript-hexagonal-microservice.yaml
@@ -47,3 +47,4 @@ vendors:
     - copilot
     - codex
     - gemini
+    - opencode

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -100,7 +100,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["claude", "copilot", "codex", "gemini"]
+            "enum": ["claude", "copilot", "codex", "gemini", "opencode"]
           },
           "description": "Which vendor adapter files to generate"
         }

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -43,6 +43,11 @@
           "enum": ["native", "prompt-inject", "unsupported"],
           "description": "How this skill is deployed for Claude Code"
         },
+        "opencode": {
+          "type": "string",
+          "enum": ["native", "prompt-inject", "unsupported"],
+          "description": "How this skill is deployed for Opencode"
+        },
         "copilot": {
           "type": "string",
           "enum": ["native", "prompt-inject", "unsupported"],

--- a/skills/agentic/compose-agents-md/SKILL.md
+++ b/skills/agentic/compose-agents-md/SKILL.md
@@ -13,6 +13,7 @@ tags:
 resources: []
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/agentic/configure-mcp/SKILL.md
+++ b/skills/agentic/configure-mcp/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: configure-mcp
+description: >
+  Guides the user through selecting and configuring an MCP (Model Context Protocol)
+  server for a project. Recommends servers based on the stack, then walks through
+  the just mcp-add wizard. Invoked when the user asks to set up MCP, add a tool
+  integration, or configure external service access for AI agents.
+version: 1.0.0
+tags:
+  - agentic
+  - mcp
+  - setup
+resources: []
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Configure MCP Skill
+
+Guide the user through selecting and configuring an MCP server for their project.
+
+### Step 1 — Understand the Stack
+
+Ask the user:
+- What language and framework is the project using?
+- What external services or data sources does it interact with? (GitHub, databases, browser automation, documentation lookup, etc.)
+- What tasks should the AI agent be able to help with?
+
+### Step 2 — Recommend Servers
+
+Based on the stack, recommend from the canonical short-list:
+
+| Server | When to use it |
+|---|---|
+| `github` | GitHub repos, issues, PRs, CI status |
+| `filesystem` | Direct file system access within a bounded path |
+| `postgres` | Query and inspect a PostgreSQL database |
+| `context7` | Live documentation lookup for libraries and frameworks |
+| `playwright` | Browser automation and end-to-end testing |
+
+Explain which servers apply to the user's project and why.
+
+### Step 3 — Run the Wizard
+
+Tell the user to run the interactive wizard:
+
+```bash
+just mcp-add /path/to/project
+```
+
+Walk them through the prompts:
+1. Enter the server name (e.g. `github`)
+2. Choose transport: `stdio` for local executables, `http` for remote servers
+3. Enter the command (e.g. `npx -y @modelcontextprotocol/server-github`)
+4. Add environment variables (e.g. `GITHUB_TOKEN`)
+5. Confirm the write to `.mcp.json`
+6. Optionally sync to `opencode.json` and/or `.gemini/settings.json`
+
+### Step 4 — Verify
+
+After the wizard completes, verify with:
+
+```bash
+just mcp-list /path/to/project
+```
+
+This should show the newly configured server in the table.
+
+### Step 5 — Environment Setup
+
+Remind the user: environment variables referenced in the MCP config (e.g. `${GITHUB_TOKEN}`) must be set in the shell before starting the AI tool. They are **not** stored in `.mcp.json` — only the variable references are.
+
+Add them to the project's `.env` or the system environment as appropriate.

--- a/skills/agentic/deploy-config/SKILL.md
+++ b/skills/agentic/deploy-config/SKILL.md
@@ -12,6 +12,7 @@ tags:
 resources: []
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/data/relational-database-design/SKILL.md
+++ b/skills/data/relational-database-design/SKILL.md
@@ -15,6 +15,7 @@ tags:
 resources: []
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/development/add-tests/SKILL.md
+++ b/skills/development/add-tests/SKILL.md
@@ -13,6 +13,7 @@ tags:
 resources: []
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/development/code-review/SKILL.md
+++ b/skills/development/code-review/SKILL.md
@@ -14,6 +14,7 @@ resources:
   - checklist.md
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/development/fix-bug/SKILL.md
+++ b/skills/development/fix-bug/SKILL.md
@@ -12,6 +12,7 @@ tags:
 resources: []
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/development/refactor/SKILL.md
+++ b/skills/development/refactor/SKILL.md
@@ -12,6 +12,7 @@ tags:
 resources: []
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/devops/write-dockerfile/SKILL.md
+++ b/skills/devops/write-dockerfile/SKILL.md
@@ -13,6 +13,7 @@ tags:
 resources: []
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/documentation/write-adr/SKILL.md
+++ b/skills/documentation/write-adr/SKILL.md
@@ -13,6 +13,7 @@ resources:
   - adr-template.md
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/documentation/write-changelog/SKILL.md
+++ b/skills/documentation/write-changelog/SKILL.md
@@ -13,6 +13,7 @@ tags:
 resources: []
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/skills/documentation/write-readme/SKILL.md
+++ b/skills/documentation/write-readme/SKILL.md
@@ -12,6 +12,7 @@ tags:
 resources: []
 vendor_support:
   claude: native
+  opencode: native
   copilot: prompt-inject
   codex: prompt-inject
   gemini: prompt-inject

--- a/tooling/lib/lint.sh
+++ b/tooling/lib/lint.sh
@@ -93,7 +93,7 @@ done < <(find "$LIBRARY/profiles" -name "*.yaml" | sort)
 # ── Vendor adapter validation ─────────────────────────────────────────────────
 echo ""
 echo "Validating vendor adapters..."
-for vendor in claude copilot codex gemini; do
+for vendor in claude copilot codex gemini opencode; do
   adapter_file="$LIBRARY/vendors/$vendor/adapter.json"
   if [[ ! -f "$adapter_file" ]]; then
     warn "vendors/$vendor/adapter.json — not found"

--- a/tooling/lib/mcp.sh
+++ b/tooling/lib/mcp.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+# mcp.sh — Manage MCP servers in a target project
+# Called by: just mcp-add <target> | just mcp-remove <target> <name> | just mcp-list <target>
+set -euo pipefail
+
+ACTION=""
+TARGET=""
+NAME=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --action) ACTION="$2"; shift 2 ;;
+    --target) TARGET="$2"; shift 2 ;;
+    --name)   NAME="$2";   shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -z "$ACTION" ]] && { echo "Error: --action required (add|remove|list)" >&2; exit 1; }
+[[ -z "$TARGET" ]] && { echo "Error: --target required" >&2; exit 1; }
+
+MCP_FILE="$TARGET/.mcp.json"
+OPENCODE_FILE="$TARGET/opencode.json"
+GEMINI_SETTINGS="$TARGET/.gemini/settings.json"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Atomic JSON write: write to tmp then move
+write_json() {
+  local file="$1"
+  local content="$2"
+  local tmp
+  tmp=$(mktemp)
+  printf '%s\n' "$content" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+# Ensure .mcp.json exists with base structure
+ensure_mcp_file() {
+  if [[ ! -f "$MCP_FILE" ]]; then
+    write_json "$MCP_FILE" '{"mcpServers":{}}'
+  fi
+}
+
+# Prompt [Y/n] — default Yes
+confirm_yes() {
+  local prompt="$1"
+  local answer
+  printf '%s [Y/n]: ' "$prompt"
+  read -r answer </dev/tty
+  [[ -z "$answer" || "$answer" =~ ^[Yy]$ ]]
+}
+
+# Prompt [y/N] — default No
+confirm_no() {
+  local prompt="$1"
+  local answer
+  printf '%s [y/N]: ' "$prompt"
+  read -r answer </dev/tty
+  [[ "$answer" =~ ^[Yy]$ ]]
+}
+
+# ── Action: list ──────────────────────────────────────────────────────────────
+action_list() {
+  if [[ ! -f "$MCP_FILE" ]]; then
+    echo "No MCP servers configured (no .mcp.json found in $TARGET)"
+    return
+  fi
+
+  local count
+  count=$(jq '.mcpServers | length' "$MCP_FILE")
+  if [[ "$count" -eq 0 ]]; then
+    echo "No MCP servers configured."
+    return
+  fi
+
+  printf '%-20s %-8s %s\n' "NAME" "TYPE" "COMMAND / URL"
+  printf '%-20s %-8s %s\n' "----" "----" "-------------"
+
+  jq -r '.mcpServers | to_entries[] | [.key, (.value.type // "stdio"), (if .value.url then .value.url elif .value.command then (.value.command + " " + ((.value.args // []) | join(" "))) else "" end)] | @tsv' "$MCP_FILE" | \
+  while IFS=$'\t' read -r name type cmd; do
+    printf '%-20s %-8s %s\n' "$name" "$type" "$cmd"
+  done
+}
+
+# ── Action: add ───────────────────────────────────────────────────────────────
+action_add() {
+  echo ""
+  echo "🔌 MCP Server Setup"
+  echo "──────────────────────────────────────────"
+
+  # Server name
+  printf 'Server name (e.g. github, postgres, context7): '
+  read -r server_name </dev/tty
+  [[ -z "$server_name" ]] && { echo "Error: server name is required." >&2; exit 1; }
+
+  # Check for duplicate
+  ensure_mcp_file
+  existing=$(jq -r --arg n "$server_name" '.mcpServers[$n] // ""' "$MCP_FILE")
+  if [[ -n "$existing" ]]; then
+    echo "Error: server '$server_name' already exists in .mcp.json" >&2
+    exit 1
+  fi
+
+  # Transport type
+  echo ""
+  echo "Transport type:"
+  echo "  1) stdio  — local executable (subprocess)"
+  echo "  2) http   — remote server (URL)"
+  printf 'Choice [1]: '
+  read -r transport_choice </dev/tty
+  transport_choice="${transport_choice:-1}"
+
+  local entry=""
+
+  if [[ "$transport_choice" == "2" ]]; then
+    # HTTP transport
+    printf 'Server URL: '
+    read -r server_url </dev/tty
+    [[ -z "$server_url" ]] && { echo "Error: URL is required for http transport." >&2; exit 1; }
+
+    # Env vars
+    local env_json="{}"
+    echo ""
+    echo "Environment variables (enter empty key to finish):"
+    while true; do
+      printf '  Key: '
+      read -r env_key </dev/tty
+      [[ -z "$env_key" ]] && break
+      printf '  Value for %s: ' "$env_key"
+      read -r env_val </dev/tty
+      env_json=$(printf '%s' "$env_json" | jq --arg k "$env_key" --arg v "$env_val" '. + {($k): $v}')
+    done
+
+    # Build entry
+    if [[ "$env_json" == "{}" ]]; then
+      entry=$(jq -n --arg url "$server_url" '{"type":"http","url":$url}')
+    else
+      entry=$(jq -n --arg url "$server_url" --argjson env "$env_json" '{"type":"http","url":$url,"env":$env}')
+    fi
+
+  else
+    # stdio transport
+    printf 'Command (e.g. npx -y @modelcontextprotocol/server-github): '
+    read -r full_command </dev/tty
+    [[ -z "$full_command" ]] && { echo "Error: command is required for stdio transport." >&2; exit 1; }
+
+    local cmd_bin args_json
+    cmd_bin=$(printf '%s' "$full_command" | awk '{print $1}')
+    local args_str
+    args_str=$(printf '%s' "$full_command" | cut -d' ' -f2- | xargs -n1 2>/dev/null || true)
+
+    # Build args array safely (bash 3.2 compatible)
+    args_json="[]"
+    if [[ "$full_command" == *" "* ]]; then
+      args_json=$(printf '%s' "$full_command" | awk '{for(i=2;i<=NF;i++) printf "%s\n",$i}' | \
+        jq -Rsc 'split("\n") | map(select(. != ""))')
+    fi
+
+    # Env vars
+    local env_json="{}"
+    echo ""
+    echo "Environment variables (enter empty key to finish):"
+    while true; do
+      printf '  Key: '
+      read -r env_key </dev/tty
+      [[ -z "$env_key" ]] && break
+      printf '  Value for %s: ' "$env_key"
+      read -r env_val </dev/tty
+      env_json=$(printf '%s' "$env_json" | jq --arg k "$env_key" --arg v "$env_val" '. + {($k): $v}')
+    done
+
+    # Build entry
+    if [[ "$env_json" == "{}" ]]; then
+      entry=$(jq -n \
+        --arg bin "$cmd_bin" \
+        --argjson args "$args_json" \
+        '{"type":"stdio","command":$bin,"args":$args}')
+    else
+      entry=$(jq -n \
+        --arg bin "$cmd_bin" \
+        --argjson args "$args_json" \
+        --argjson env "$env_json" \
+        '{"type":"stdio","command":$bin,"args":$args,"env":$env}')
+    fi
+  fi
+
+  # Preview
+  echo ""
+  echo "── Preview ───────────────────────────────"
+  printf '  "%s": %s\n' "$server_name" "$(printf '%s' "$entry" | jq -c .)"
+  echo "──────────────────────────────────────────"
+  echo ""
+
+  # Write to .mcp.json
+  if confirm_yes "Add to $TARGET/.mcp.json?"; then
+    local updated
+    updated=$(jq --arg n "$server_name" --argjson e "$entry" '.mcpServers[$n] = $e' "$MCP_FILE")
+    write_json "$MCP_FILE" "$updated"
+    echo "  ✔  Written to .mcp.json"
+  else
+    echo "Aborted."
+    exit 0
+  fi
+
+  # Sync to opencode.json
+  if [[ -f "$OPENCODE_FILE" ]]; then
+    echo ""
+    if confirm_yes "Sync to opencode.json (mcp.$server_name)?"; then
+      local oc_updated
+      oc_updated=$(jq --arg n "$server_name" --argjson e "$entry" '.mcp[$n] = $e' "$OPENCODE_FILE")
+      write_json "$OPENCODE_FILE" "$oc_updated"
+      echo "  ✔  Synced to opencode.json"
+    fi
+  fi
+
+  # Sync to .gemini/settings.json
+  if [[ -f "$GEMINI_SETTINGS" ]]; then
+    echo ""
+    if confirm_yes "Sync to .gemini/settings.json (mcpServers.$server_name)?"; then
+      local gs_updated
+      gs_updated=$(jq --arg n "$server_name" --argjson e "$entry" '.mcpServers[$n] = $e' "$GEMINI_SETTINGS")
+      write_json "$GEMINI_SETTINGS" "$gs_updated"
+      echo "  ✔  Synced to .gemini/settings.json"
+    fi
+  fi
+
+  echo ""
+  # Print env var reminders
+  local env_keys
+  env_keys=$(printf '%s' "$entry" | jq -r '.env // {} | keys[]' 2>/dev/null || true)
+  if [[ -n "$env_keys" ]]; then
+    echo "Done. Remember to set the following in your environment before starting:"
+    while IFS= read -r k; do
+      echo "  $k"
+    done <<< "$env_keys"
+  else
+    echo "Done."
+  fi
+}
+
+# ── Action: remove ────────────────────────────────────────────────────────────
+action_remove() {
+  [[ -z "$NAME" ]] && { echo "Error: --name required for remove action" >&2; exit 1; }
+
+  if [[ ! -f "$MCP_FILE" ]]; then
+    echo "Error: no .mcp.json found in $TARGET" >&2
+    exit 1
+  fi
+
+  existing=$(jq -r --arg n "$NAME" '.mcpServers[$n] // ""' "$MCP_FILE")
+  if [[ -z "$existing" ]]; then
+    echo "Error: server '$NAME' not found in .mcp.json" >&2
+    exit 1
+  fi
+
+  local updated
+  updated=$(jq --arg n "$NAME" 'del(.mcpServers[$n])' "$MCP_FILE")
+  write_json "$MCP_FILE" "$updated"
+  echo "  ✔  Removed '$NAME' from .mcp.json"
+
+  # Sync removal to opencode.json
+  if [[ -f "$OPENCODE_FILE" ]]; then
+    echo ""
+    if confirm_yes "Remove from opencode.json (mcp.$NAME)?"; then
+      local oc_updated
+      oc_updated=$(jq --arg n "$NAME" 'del(.mcp[$n])' "$OPENCODE_FILE")
+      write_json "$OPENCODE_FILE" "$oc_updated"
+      echo "  ✔  Removed from opencode.json"
+    fi
+  fi
+
+  # Sync removal to .gemini/settings.json
+  if [[ -f "$GEMINI_SETTINGS" ]]; then
+    echo ""
+    if confirm_yes "Remove from .gemini/settings.json (mcpServers.$NAME)?"; then
+      local gs_updated
+      gs_updated=$(jq --arg n "$NAME" 'del(.mcpServers[$n])' "$GEMINI_SETTINGS")
+      write_json "$GEMINI_SETTINGS" "$gs_updated"
+      echo "  ✔  Removed from .gemini/settings.json"
+    fi
+  fi
+
+  echo ""
+  echo "Done."
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+case "$ACTION" in
+  add)    action_add    ;;
+  remove) action_remove ;;
+  list)   action_list   ;;
+  *) echo "Error: unknown action '$ACTION' (expected add|remove|list)" >&2; exit 1 ;;
+esac

--- a/tooling/lib/vendor-gen.sh
+++ b/tooling/lib/vendor-gen.sh
@@ -39,7 +39,7 @@ PROFILE_VER="unknown"
 # ── Resolve which vendors to generate ─────────────────────────────────────────
 resolve_vendors() {
   if [[ "$VENDORS" == "all" ]]; then
-    echo "claude copilot codex gemini"
+    echo "claude copilot codex gemini opencode"
   else
     echo "${VENDORS//,/ }"
   fi
@@ -160,14 +160,33 @@ gen_gemini() {
   echo "  Created: .gemini/systemPrompt.md"
 }
 
+# ── Opencode adapter ──────────────────────────────────────────────────────────
+gen_opencode() {
+  echo "  Generating Opencode adapter..."
+  local template="$LIBRARY/vendors/opencode/template.opencode.json"
+  local out_file="$TARGET/opencode.json"
+
+  sed \
+    -e "s/{{PROJECT_NAME}}/${PROJECT_NAME}/g" \
+    -e "s/{{PROFILE_NAME}}/${PROFILE}/g" \
+    -e "s/{{PROFILE_VERSION}}/${PROFILE_VER}/g" \
+    -e "s/{{GENERATED_AT}}/${GENERATED_AT}/g" \
+    -e "s|{{TARGET_PATH}}|${TARGET}|g" \
+    "$template" > "$out_file"
+
+  echo "  Created: opencode.json"
+  echo "  Opencode reads AGENTS.md natively — AGENTS.md is already the Opencode-compatible file."
+}
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 for vendor in $(resolve_vendors); do
   echo "Generating vendor files: $vendor"
   case "$vendor" in
-    claude)  gen_claude  ;;
-    copilot) gen_copilot ;;
-    codex)   gen_codex   ;;
-    gemini)  gen_gemini  ;;
+    claude)   gen_claude   ;;
+    copilot)  gen_copilot  ;;
+    codex)    gen_codex    ;;
+    gemini)   gen_gemini   ;;
+    opencode) gen_opencode ;;
     *) echo "Warning: unknown vendor '$vendor' — skipping" >&2 ;;
   esac
 done

--- a/vendors/_schema/adapter.schema.json
+++ b/vendors/_schema/adapter.schema.json
@@ -9,7 +9,7 @@
   "properties": {
     "vendor": {
       "type": "string",
-      "enum": ["claude", "copilot", "codex", "gemini"],
+      "enum": ["claude", "copilot", "codex", "gemini", "opencode"],
       "description": "The vendor this adapter targets"
     },
     "version": {

--- a/vendors/_schema/capability-matrix.md
+++ b/vendors/_schema/capability-matrix.md
@@ -4,37 +4,40 @@ This document records what each vendor supports so adapter authors know what is 
 
 ## File Format Support
 
-| Feature | Claude | Copilot | Codex | Gemini |
-|---|---|---|---|---|
-| Reads AGENTS.md natively | Yes (also CLAUDE.md) | No | Yes | No |
-| Custom instructions file | CLAUDE.md | `.github/copilot-instructions.md` | AGENTS.md | `.gemini/systemPrompt.md` |
-| Per-file scoping (glob) | No | Yes (`.github/instructions/*.instructions.md`) | No | No |
-| Multiple rules files | Yes (`.claude/` dir) | Yes (`.github/instructions/`) | No | No |
-| Skills / slash commands | Yes (`.claude/skills/`) | No | No | No |
+| Feature | Claude | Copilot | Codex | Gemini | Opencode |
+|---|---|---|---|---|---|
+| Reads AGENTS.md natively | Yes (also CLAUDE.md) | No | Yes | No | Yes |
+| Custom instructions file | CLAUDE.md | `.github/copilot-instructions.md` | AGENTS.md | `.gemini/systemPrompt.md` | AGENTS.md |
+| Per-file scoping (glob) | No | Yes (`.github/instructions/*.instructions.md`) | No | No | No |
+| Multiple rules files | Yes (`.claude/` dir) | Yes (`.github/instructions/`) | No | No | No |
+| Skills / slash commands | Yes (`.claude/skills/`) | No | No | No | Yes (`.claude/skills/`) |
+| Config file generated | CLAUDE.md | — | — | — | `opencode.json` |
 
 ## Context Window and Limits
 
-| Limit | Claude | Copilot | Codex | Gemini |
-|---|---|---|---|---|
-| Instruction file size limit | ~200KB practical | ~64KB practical | ~32KB | ~32KB |
-| Hard per-file char limit | None documented | None documented | None documented | None documented |
-| Notes | Reads multiple files; total context is shared with conversation | Content prepended to every request | Reads AGENTS.md hierarchically | Reads systemPrompt.md once per session |
+| Limit | Claude | Copilot | Codex | Gemini | Opencode |
+|---|---|---|---|---|---|
+| Instruction file size limit | ~200KB practical | ~64KB practical | ~32KB | ~32KB | ~200KB practical |
+| Hard per-file char limit | None documented | None documented | None documented | None documented | None documented |
+| Notes | Reads multiple files; total context is shared with conversation | Content prepended to every request | Reads AGENTS.md hierarchically | Reads systemPrompt.md once per session | Reads AGENTS.md natively; config in opencode.json |
 
 ## Section Type Support
 
-| Section | Claude | Copilot | Codex | Gemini |
-|---|---|---|---|---|
-| Git conventions | Yes | Yes | Yes | Yes |
-| Language rules | Yes | Yes | Yes | Yes |
-| Architecture rules | Yes | Yes | Yes | Yes |
-| Practice rules | Yes | Yes | Yes | Yes |
-| Build/test commands | Yes | Yes | Yes | Yes |
-| Skills (native) | Yes | No* | No* | No* |
-| Glob-scoped rules | No† | Yes | No | No |
-| Domain context | Yes | Yes | Yes | Yes |
+| Section | Claude | Copilot | Codex | Gemini | Opencode |
+|---|---|---|---|---|---|
+| Git conventions | Yes | Yes | Yes | Yes | Yes |
+| Language rules | Yes | Yes | Yes | Yes | Yes |
+| Architecture rules | Yes | Yes | Yes | Yes | Yes |
+| Practice rules | Yes | Yes | Yes | Yes | Yes |
+| Build/test commands | Yes | Yes | Yes | Yes | Yes |
+| Skills (native) | Yes | No* | No* | No* | Yes |
+| Glob-scoped rules | No† | Yes | No | No | No |
+| Domain context | Yes | Yes | Yes | Yes | Yes |
 
-`*` Injected as prompt text for non-Claude vendors
-`†` Claude Code applies rules globally; scoping is via tool configuration
+`*` Injected as prompt text for non-native vendors
+`†` Claude Code and Opencode apply rules globally; scoping is via tool configuration
+
+**Note on Gemini:** `gen_gemini()` uses `awk` to extract all H2 sections from `AGENTS.md` regardless of the adapter's `section_mappings` entries. The 8 mappings in `vendors/gemini/adapter.json` are informational only and are not used during generation.
 
 ## Deployment Artifacts per Vendor
 
@@ -54,8 +57,14 @@ This document records what each vendor supports so adapter authors know what is 
 - `.gemini/systemPrompt.md` (loaded at session start)
 - `GEMINI.md` (alternative location at project root)
 
+### Opencode
+- `AGENTS.md` (primary, read natively)
+- `opencode.json` (starter config: model, permissions, empty MCP block)
+- `.claude/skills/{skill-name}/` (skill directories; Opencode reads this Claude-compatible path)
+
 ## Update Log
 
 | Date | Change |
 |---|---|
 | 2026-03-01 | Initial capability matrix created |
+| 2026-03-02 | Added Opencode column; added Gemini awk note |

--- a/vendors/opencode/README.md
+++ b/vendors/opencode/README.md
@@ -1,0 +1,45 @@
+# Opencode Vendor Adapter
+
+This adapter generates Opencode-compatible files from an assembled `AGENTS.md`.
+
+## How Opencode reads instructions
+
+Opencode reads `AGENTS.md` natively (same as Claude Code and OpenAI Codex). No transformation of the instruction content is needed — the adapter is a passthrough.
+
+## Output files
+
+| File | Path | Purpose |
+|---|---|---|
+| `AGENTS.md` | project root | Canonical instructions, read natively by Opencode |
+| `opencode.json` | project root | Starter config: model, permissions, and empty MCP block |
+| `.claude/skills/` | project root | Skills directory (Opencode reads this Claude-compatible path) |
+
+## MCP setup
+
+The generated `opencode.json` includes an empty `mcp: {}` block. To populate it interactively:
+
+```bash
+just mcp-add /path/to/project
+```
+
+This wizard writes `.mcp.json` (Claude standard format) and optionally syncs the entry to `opencode.json`.
+
+List configured servers:
+
+```bash
+just mcp-list /path/to/project
+```
+
+Remove a server:
+
+```bash
+just mcp-remove /path/to/project github
+```
+
+## The `_meta` object
+
+`opencode.json` uses a `_meta` object instead of JSONC comments for generation metadata. This keeps the file valid JSON (compatible with `jq` and all JSON parsers). Do not edit the `_meta` fields manually — they are overwritten on each `just vendor-gen` run.
+
+## Skills
+
+Skills deploy to `.claude/skills/` (not `.opencode/skills/`). Opencode reads the `.claude/skills/` path for Claude compatibility. The `.opencode/skills/` path declared in `output_paths.skills` is reserved for Opencode-native skills only.

--- a/vendors/opencode/adapter.json
+++ b/vendors/opencode/adapter.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "../_schema/adapter.schema.json",
+  "vendor": "opencode",
+  "version": "1.0.0",
+  "output_paths": {
+    "base": ".",
+    "skills": ".opencode/skills"
+  },
+  "section_mappings": [
+    {
+      "agents_md_heading": "## Git Conventions",
+      "output_file": "AGENTS.md",
+      "activation_mode": "passthrough",
+      "frontmatter": {}
+    },
+    {
+      "agents_md_heading": "## Security",
+      "output_file": "AGENTS.md",
+      "activation_mode": "passthrough",
+      "frontmatter": {}
+    },
+    {
+      "agents_md_heading": "## Code Review",
+      "output_file": "AGENTS.md",
+      "activation_mode": "passthrough",
+      "frontmatter": {}
+    },
+    {
+      "agents_md_heading": "## Testing Philosophy",
+      "output_file": "AGENTS.md",
+      "activation_mode": "passthrough",
+      "frontmatter": {}
+    },
+    {
+      "agents_md_heading": "## Documentation",
+      "output_file": "AGENTS.md",
+      "activation_mode": "passthrough",
+      "frontmatter": {}
+    }
+  ],
+  "unsupported_sections": [],
+  "character_limit_per_file": null,
+  "total_character_limit": null,
+  "notes": "Opencode reads AGENTS.md natively. gen_opencode() generates a starter opencode.json. Skills deploy to .claude/skills/ (Claude-compat path that Opencode also reads). The .opencode/skills path is reserved for Opencode-native skills only."
+}

--- a/vendors/opencode/template.opencode.json
+++ b/vendors/opencode/template.opencode.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "_meta": {
+    "generated_by": "agentic library",
+    "profile": "{{PROFILE_NAME}}",
+    "profile_version": "{{PROFILE_VERSION}}",
+    "generated_at": "{{GENERATED_AT}}",
+    "note": "DO NOT EDIT — regenerate with: just vendor-gen {{TARGET_PATH}}"
+  },
+  "model": "anthropic/claude-sonnet-4-20250514",
+  "autoupdate": true,
+  "permission": {
+    "edit": "ask",
+    "bash": "ask",
+    "webfetch": "allow"
+  },
+  "mcp": {}
+}


### PR DESCRIPTION
## Summary

- **Opencode vendor** — new `vendors/opencode/` adapter (passthrough, reads `AGENTS.md` natively); `gen_opencode()` generates a starter `opencode.json` with model defaults, permissions, and an empty `mcp` block ready for `just mcp-add`
- **Vendor polish** — `opencode: native` added to all 11 existing skills; `opencode` added to all 5 profiles and all three schemas (`adapter.schema.json`, `profile.schema.json`, `skill.schema.json`)
- **MCP tooling** — `tooling/lib/mcp.sh` interactive wizard (`add`/`remove`/`list`), writes `.mcp.json` and optionally syncs to `opencode.json` and `.gemini/settings.json`; wired via `just mcp-add/remove/list`
- **New skill** — `skills/agentic/configure-mcp` guides users through MCP server selection and wizard usage
- **Docs** — capability matrix updated with Opencode column and Gemini awk note; README updated with Opencode row, `opencode.json` in file tree, and MCP command reference section
- **Index** — rebuilt: 21 fragments (unchanged), 12 skills (+1 configure-mcp)

## Test plan

- [x] `just lint` — passes (5 vendors × adapter OK, 12 skills OK, all profiles OK)
- [x] `just test` — 29/29 assertions pass
- [x] `just index` — 21 fragments, 12 skills
- [x] `just dry-run typescript-hexagonal-microservice` — produces correct output
- [x] `just mcp-list <empty-dir>` — prints "no .mcp.json found"
- [x] `just mcp-list <dir-with-.mcp.json>` — prints aligned NAME/TYPE/COMMAND table
- [x] `just mcp-remove <dir> github` — removes entry, prints confirmation