### PR TITLE
feat: modular AGENTS.md, tech stack profiles & framework fragments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,16 @@ project repositories via the tooling provided here.
 - Always run `just index` after adding or modifying skills or fragments.
 - The index files are committed to the repo so they are available without running tooling.
 
+### Testing & Quality
+
+- **Always run `just test` before committing any change to `tooling/`.** All 29 (or more) assertions must pass.
+- **When adding or changing behaviour in `compose.sh`, `vendor-gen.sh`, `deploy-skills.sh`, or any other script, add corresponding assertions to `tooling/lib/test.sh`.**
+  - New compose feature (e.g. a new generated section)? Add a `T##` test that composes a suitable profile and asserts the section is present.
+  - New flag or mode? Add a test that exercises the flag, checks the output file(s) exist (or don't), and verifies the content.
+  - New error path? Add a test that triggers the error and asserts exit code 1.
+- **Run `just lint` after adding or modifying any fragment, profile, skill, or vendor adapter** to catch schema violations and missing H2 headings before committing.
+- **Run `just index` after adding or modifying any fragment or skill**, then commit the updated index files together with the source change in the same commit.
+
 ## Commit Conventions
 
 Follow Conventional Commits format:

--- a/agents/frameworks/cobra.md
+++ b/agents/frameworks/cobra.md
@@ -1,0 +1,54 @@
+## Cobra CLI (Go)
+
+### Command Structure
+
+- One `rootCmd` per binary. All subcommands are composed via `rootCmd.AddCommand(subCmd)`.
+- Define each command in its own file under `internal/cli/` or `cmd/`. Never put all commands in a single file.
+- Use `cobra.Command.RunE` (not `Run`) so errors propagate properly. Call `cobra.CheckErr(err)` in `main()` as the single exit point.
+
+```go
+func main() {
+    cobra.CheckErr(rootCmd.Execute())
+}
+```
+
+### Persistent Setup
+
+- Use `PersistentPreRunE` on `rootCmd` for shared initialization that must run before any subcommand: loading config, initialising the logger, opening a database connection.
+- Avoid `init()` functions — they run at package load time and are hard to test or override.
+
+### Flags & Configuration
+
+- Bind Cobra flags to Viper with `viper.BindPFlag("key", cmd.Flags().Lookup("flag-name"))` so both CLI flags and environment variables work transparently.
+- Environment variables are automatically read when you call `viper.AutomaticEnv()` and set the prefix with `viper.SetEnvPrefix("APP")`.
+- Persistent flags (available to all subcommands): declare on `rootCmd.PersistentFlags()`.
+- Local flags (specific to one command): declare on the subcommand's `Flags()`.
+
+### Structured Output
+
+- Support a global `--output` flag with values `json`, `table`, and `plain`.
+- Implement an `output.Writer` interface (or equivalent) that accepts the flag value and dispatches to the correct renderer — never scatter `if output == "json"` checks through command logic.
+- Use `github.com/jedib0t/go-pretty/v6/table` (or `text/tabwriter`) for table output; `encoding/json` for JSON.
+
+### Testability
+
+- Command functions must accept `io.Writer` arguments (or carry them on a struct) instead of writing directly to `os.Stdout`. This makes output capturable in tests.
+- Do **not** call `os.Exit` anywhere except in `main()` via `cobra.CheckErr`. Commands return errors; only the top-level entry point exits.
+- Test each command by constructing the `cobra.Command`, setting `SetOut`/`SetErr`, calling `Execute()`, and asserting the written output.
+
+```go
+func TestVersionCmd(t *testing.T) {
+    buf := &bytes.Buffer{}
+    rootCmd.SetOut(buf)
+    rootCmd.SetArgs([]string{"version"})
+    require.NoError(t, rootCmd.Execute())
+    assert.Contains(t, buf.String(), "v1.")
+}
+```
+
+### Error Handling
+
+- Return errors from `RunE`; never print them directly and return nil.
+- Use `fmt.Errorf("context: %w", err)` to wrap errors with context.
+- For user-input validation errors, return a descriptive error — Cobra will print it along with usage.
+- Suppress usage printing on runtime errors (not flag errors): `cmd.SilenceUsage = true` in `PersistentPreRunE` after validation passes.

--- a/agents/frameworks/nuxt.md
+++ b/agents/frameworks/nuxt.md
@@ -1,0 +1,64 @@
+## Nuxt 3
+
+### Auto-Imports
+
+- Nuxt auto-imports components from `components/`, composables from `composables/` and `utils/`, and Nuxt/Vue primitives everywhere.
+- Do **not** add manual `import` statements for auto-imported items — it creates duplicates and confuses tree-shaking.
+- If a composable or component is ambiguous, use `#imports` to make the source explicit.
+
+### File-Based Routing
+
+- Pages live in `pages/`. Every `.vue` file maps to a route automatically.
+- Dynamic segments: `pages/users/[id].vue` → `/users/:id`. Catch-all: `pages/[...slug].vue`.
+- Nested routes: create a `pages/users.vue` parent and a `pages/users/` directory for children.
+- Use `<NuxtLink>` (not `<a>`) for internal navigation to get prefetching.
+
+### Data Fetching
+
+- `useFetch(url)` — declarative, component-lifecycle-aware, SSR-safe, and automatically deduplicated. Preferred for most cases.
+- `useAsyncData(key, () => fetchFn())` — use when you need a custom key, multiple parallel fetches, or a non-URL data source (e.g., a database call in a server composable).
+- Never use `fetch` or `axios` directly inside `<script setup>` without wrapping in `useAsyncData` — it will run twice (server + client) and cause hydration mismatches.
+- Use `lazy: true` option for non-critical data to unblock navigation; show a loading skeleton while pending.
+
+### Server Routes
+
+- Server-side logic lives under `server/api/` (auto-prefixed at `/api/`) and `server/routes/` (mapped directly).
+- Handler files export `defineEventHandler(async (event) => { ... })`.
+- Read body: `await readBody(event)`. Read query params: `getQuery(event)`. Set status: `setResponseStatus(event, 201)`.
+- Never import Node.js-only modules (e.g., `fs`, `crypto`) in shared code — use them only inside `server/`.
+
+### SEO
+
+- Use `useSeoMeta({ title, description, ogImage, ... })` for all meta tag management — never manipulate `<head>` directly.
+- For page-level SEO that depends on async data, call `useSeoMeta` after `await useFetch(...)` resolves.
+- Use `defineOgImageComponent` or `og-image` Nuxt module for dynamic OG image generation when needed.
+
+### SSR Safety
+
+- Code inside `<script setup>` runs on both server and client. Guard browser-only APIs:
+  ```ts
+  if (import.meta.client) { window.analytics.track(...) }
+  // or
+  onMounted(() => { /* browser-only */ })
+  ```
+- Never access `localStorage`, `sessionStorage`, `document`, or `window` at the top level of a composable or setup script.
+- Use Nuxt's `useState` instead of `ref` for state that must be consistent across SSR/hydration boundaries.
+
+### Middleware
+
+- Route middleware lives in `middleware/`. Named middleware: `defineNuxtRouteMiddleware((to, from) => { ... })`.
+- Apply per-page: `definePageMeta({ middleware: ['auth'] })`.
+- Global middleware: prefix the file with `global` (e.g., `middleware/00.logging.global.ts`).
+- Use middleware for auth guards, redirect logic, and analytics page-views — not for data fetching.
+
+### Route Rules & Rendering Modes
+
+- Configure per-route rendering in `nuxt.config.ts` under `routeRules`:
+  ```ts
+  routeRules: {
+    '/':        { prerender: true },   // SSG
+    '/dashboard/**': { ssr: false },   // SPA
+    '/blog/**': { isr: 3600 },         // ISR — regenerate after 1 hour
+  }
+  ```
+- Default is SSR. Only opt out of SSR when the page is purely client-side (e.g., authenticated dashboard with real-time data).

--- a/agents/frameworks/typer.md
+++ b/agents/frameworks/typer.md
@@ -1,0 +1,68 @@
+## Typer CLI (Python)
+
+### Defining Commands
+
+- Type annotations are the CLI contract. Typer derives argument names, types, and help text from function signatures — never add manual argument parsing.
+- Use `@app.command()` for leaf commands. Compose sub-applications with `app.add_typer(sub_app, name="sub")`.
+- Each command lives in its own module under `src/<package>/cli/`. Register all commands in a top-level `cli/app.py` that creates the root `typer.Typer()` instance.
+
+```python
+import typer
+
+app = typer.Typer()
+
+@app.command()
+def deploy(
+    env: str = typer.Argument(..., help="Target environment"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview changes"),
+) -> None:
+    ...
+```
+
+### Options & Environment Variables
+
+- Back every important option with an environment variable using `typer.Option(envvar="APP_FOO")`.
+- Provide sensible defaults so the CLI is usable without memorising all env vars.
+- Group related options by creating a reusable `typer.Option` factory or shared callback.
+
+### Output & Formatting
+
+- Use `rich` for all structured output: tables (`rich.table.Table`), panels (`rich.panel.Panel`), progress bars (`rich.progress`), and syntax-highlighted code.
+- Use `typer.echo()` only for single-line, unformatted text (e.g., simple confirmations). Prefer `rich.print()` for anything styled.
+- Never mix `print()` with `rich` — it bypasses the rich console and breaks colour/width calculations.
+
+### Validation & Error Handling
+
+- Use `callback=` parameters on `typer.Option`/`typer.Argument` for inline validation:
+  ```python
+  def validate_port(value: int) -> int:
+      if not (1 <= value <= 65535):
+          raise typer.BadParameter(f"{value} is not a valid port number")
+      return value
+  ```
+- Raise `typer.BadParameter` for user-input errors (Typer formats and exits cleanly).
+- Raise `typer.Abort()` to cancel an interactive prompt or operation without an error message.
+- Raise `typer.Exit(code=1)` only for non-exception exits; prefer returning from `RunE`-equivalent patterns.
+
+### Testing
+
+- Always test via `typer.testing.CliRunner` — never `subprocess.run` or direct function calls.
+- `runner.invoke(app, ["cmd", "--flag", "value"])` returns a `Result` with `.output`, `.exit_code`, and `.exception`.
+- Assert `.exit_code == 0` for success paths; assert specific output strings; assert `.exit_code != 0` for error paths.
+
+```python
+from typer.testing import CliRunner
+from myapp.cli.app import app
+
+runner = CliRunner()
+
+def test_deploy_dry_run():
+    result = runner.invoke(app, ["deploy", "staging", "--dry-run"])
+    assert result.exit_code == 0
+    assert "Preview" in result.output
+```
+
+### Async Commands
+
+- Typer does not natively support `async def` commands. Wrap async logic with `asyncio.run()` inside a sync command function.
+- Extract the async core into a separate function in the application layer and call it from the CLI command.

--- a/agents/frameworks/vue.md
+++ b/agents/frameworks/vue.md
@@ -1,0 +1,43 @@
+## Vue 3
+
+### Syntax & Component Style
+
+- `<script setup>` is the only accepted syntax — never use the Options API or the classic `export default {}` form.
+- All components are single-file components (`.vue`). One component per file; file name matches the exported component name in PascalCase.
+- Extract reusable stateful logic into composables (`use*.ts`), not mixins. Mixins are banned.
+
+### Props & Emits
+
+- Declare props with `defineProps<Props>()` for full TypeScript type inference — no runtime-only definitions.
+- Declare emits with `defineEmits<{ (e: 'change', value: string): void }>()` (typed form).
+- Props are read-only inside the child. Never mutate a prop; emit an event instead.
+
+### State Management
+
+- **Local state**: `ref()` for primitives, `reactive()` for objects (prefer `ref` — it is more explicit).
+- **Computed values**: `computed()`. Never derive state in a method that runs on every render.
+- **Shared/global state**: Pinia. One store per domain concept (`useCartStore`, `useAuthStore`).
+  - Stores are defined with `defineStore`. Use the Setup Store form (function syntax) — not the Options Store form.
+  - Actions are plain functions inside the store; they may be async.
+  - Never access store internals from outside — always call actions and read state through the store ref.
+
+### Reactivity Pitfalls
+
+- Do **not** destructure reactive objects — reactivity is lost: `const { count } = reactive(state)` breaks.
+- Use `toRefs(state)` when you need to destructure and keep reactivity.
+- Avoid mutating arrays by index (`arr[0] = x`) inside reactive state; use `.splice()` or replace the ref value.
+- `watch` vs `watchEffect`: prefer `watchEffect` for side effects that depend on reactive data; use `watch` when you need the previous value or explicit source control.
+
+### Templates
+
+- Keep templates declarative and free of business logic. Move non-trivial expressions into `computed` properties.
+- Use `v-bind="$attrs"` intentionally on root element when building wrapper components (and set `inheritAttrs: false`).
+- Avoid `v-html` — XSS risk. Only use it with sanitized, trusted content.
+- Always provide a `key` attribute on `v-for` items (use a stable ID, not the array index).
+
+### Testing
+
+- Unit test composables and stores independently using Vitest.
+- Test components with `@vue/test-utils`. Prefer `mount` over `shallowMount` unless child component rendering is irrelevant to the test.
+- Use `flushPromises()` from `@vue/test-utils` after async operations before asserting DOM state.
+- Do not test implementation details (internal refs, private methods). Test observable behavior.

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-01T23:04:26Z",
+  "generated_at": "2026-03-02T11:38:38Z",
   "fragments": [
     {
       "name": "bff",
@@ -85,6 +85,34 @@
       "path": "agents/base/testing-philosophy.md",
       "heading": "Testing Philosophy",
       "words": 386
+    },
+    {
+      "name": "cobra",
+      "group": "frameworks",
+      "path": "agents/frameworks/cobra.md",
+      "heading": "Cobra CLI (Go)",
+      "words": 363
+    },
+    {
+      "name": "nuxt",
+      "group": "frameworks",
+      "path": "agents/frameworks/nuxt.md",
+      "heading": "Nuxt 3",
+      "words": 475
+    },
+    {
+      "name": "typer",
+      "group": "frameworks",
+      "path": "agents/frameworks/typer.md",
+      "heading": "Typer CLI (Python)",
+      "words": 380
+    },
+    {
+      "name": "vue",
+      "group": "frameworks",
+      "path": "agents/frameworks/vue.md",
+      "heading": "Vue 3",
+      "words": 394
     },
     {
       "name": "go",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,12 +1,12 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-01T23:04:26Z",
+  "generated_at": "2026-03-02T11:38:38Z",
   "skills": [
     {
       "name": "compose-agents-md",
       "group": "agentic",
       "path": "skills/agentic/compose-agents-md/SKILL.md",
-      "description": ">",
+      "description": "Meta-skill: helps create an AGENTS.md for a new project by guiding the user through selecting the right profile from the",
       "version": "1.0.0",
       "tags": [
         "agentic",
@@ -18,7 +18,7 @@
       "name": "configure-mcp",
       "group": "agentic",
       "path": "skills/agentic/configure-mcp/SKILL.md",
-      "description": ">",
+      "description": "Guides the user through selecting and configuring an MCP (Model Context Protocol) server for a project. Recommends serve",
       "version": "1.0.0",
       "tags": [
         "agentic",
@@ -30,7 +30,7 @@
       "name": "deploy-config",
       "group": "agentic",
       "path": "skills/agentic/deploy-config/SKILL.md",
-      "description": ">",
+      "description": "Meta-skill: deploys the full agentic configuration to a target project — AGENTS.md composition, vendor file generation, ",
       "version": "1.0.0",
       "tags": [
         "agentic",
@@ -42,7 +42,7 @@
       "name": "relational-database-design",
       "group": "data",
       "path": "skills/data/relational-database-design/SKILL.md",
-      "description": ">",
+      "description": "Designs or reviews a relational database schema for a given domain. Covers table structure, normalization, indexes, cons",
       "version": "1.0.0",
       "tags": [
         "data",
@@ -56,7 +56,7 @@
       "name": "add-tests",
       "group": "development",
       "path": "skills/development/add-tests/SKILL.md",
-      "description": ">",
+      "description": "Generates tests for existing code. Analyzes the target function, method, or class to identify the happy path, error case",
       "version": "1.0.0",
       "tags": [
         "testing",
@@ -68,20 +68,19 @@
       "name": "code-review",
       "group": "development",
       "path": "skills/development/code-review/SKILL.md",
-      "description": ">",
+      "description": "Performs a structured code review on the current diff or specified files. Checks for correctness, security vulnerabiliti",
       "version": "1.0.0",
       "tags": [
         "quality",
         "review",
-        "security",
-        "checklist.md"
+        "security"
       ]
     },
     {
       "name": "fix-bug",
       "group": "development",
       "path": "skills/development/fix-bug/SKILL.md",
-      "description": ">",
+      "description": "Investigates and fixes a reported bug. Reads relevant code, identifies the root cause, proposes a fix, and adds or updat",
       "version": "1.0.0",
       "tags": [
         "debugging",
@@ -93,7 +92,7 @@
       "name": "refactor",
       "group": "development",
       "path": "skills/development/refactor/SKILL.md",
-      "description": ">",
+      "description": "Refactors specified code to improve clarity, reduce duplication, or align with the project's architectural patterns — wi",
       "version": "1.0.0",
       "tags": [
         "refactoring",
@@ -105,7 +104,7 @@
       "name": "write-dockerfile",
       "group": "devops",
       "path": "skills/devops/write-dockerfile/SKILL.md",
-      "description": ">",
+      "description": "Creates an optimized, production-ready Dockerfile for the current project. Detects the language and framework, applies b",
       "version": "1.0.0",
       "tags": [
         "devops",
@@ -117,20 +116,19 @@
       "name": "write-adr",
       "group": "documentation",
       "path": "skills/documentation/write-adr/SKILL.md",
-      "description": ">",
+      "description": "Creates an Architecture Decision Record (ADR) documenting a significant technical decision. Follows the standard ADR for",
       "version": "1.0.0",
       "tags": [
         "documentation",
         "architecture",
-        "decision",
-        "adr-template.md"
+        "decision"
       ]
     },
     {
       "name": "write-changelog",
       "group": "documentation",
       "path": "skills/documentation/write-changelog/SKILL.md",
-      "description": ">",
+      "description": "Generates a CHANGELOG.md entry for a release by summarizing git commits since the last tag. Groups changes by type: Adde",
       "version": "1.0.0",
       "tags": [
         "documentation",
@@ -142,7 +140,7 @@
       "name": "write-readme",
       "group": "documentation",
       "path": "skills/documentation/write-readme/SKILL.md",
-      "description": ">",
+      "description": "Generates or updates a README.md for a project or package. Reads the source code to understand the project and produces ",
       "version": "1.0.0",
       "tags": [
         "documentation",

--- a/justfile
+++ b/justfile
@@ -89,7 +89,7 @@ deploy-skills target skills="all":
 
 # ─── Full Pipeline ────────────────────────────────────────────────────────────
 
-# Full deploy: compose + vendor-gen + deploy skills
+# Full deploy: compose + vendor-gen + deploy skills (use compose-full for inlined skill content)
 # Usage: just deploy typescript-hexagonal-microservice /path/to/project
 # Usage: just deploy typescript-hexagonal-microservice /path/to/project code-review,write-adr
 deploy profile target skills="all":
@@ -99,6 +99,15 @@ deploy profile target skills="all":
     @echo ""
     @echo "Deployed profile '{{profile}}' to {{target}}"
     @echo "Run 'just validate {{target}}' to verify the config."
+
+# Compose AGENTS.full.md with all skill content inlined (instead of a slim listing)
+# Usage: just compose-full typescript-hexagonal-microservice /path/to/project
+compose-full profile target:
+    @"{{LIBRARY_ROOT}}/tooling/lib/compose.sh" \
+        --library "{{LIBRARY_ROOT}}" \
+        --profile "{{profile}}" \
+        --target "{{target}}" \
+        --full
 
 # ─── Index ────────────────────────────────────────────────────────────────────
 

--- a/profiles/golang-hexagonal-cobra-cli.yaml
+++ b/profiles/golang-hexagonal-cobra-cli.yaml
@@ -1,0 +1,65 @@
+meta:
+  name: "Go Hexagonal Cobra CLI"
+  description: >
+    Go CLI tool following hexagonal architecture with DDD patterns.
+    Cobra + Viper for the command layer; domain and application layers have
+    zero CLI framework dependencies. Designed for testable, composable commands.
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+
+  languages:
+    - go
+
+  frameworks:
+    - cobra
+
+  architecture:
+    - hexagonal
+    - ddd
+
+  practices:
+    - tdd
+    - observability
+    - ci-cd
+
+  domains: []
+
+tech_stack:
+  language_runtime: "Go 1.23+"
+  package_manager: "Go modules"
+  cli_framework: "Cobra + Viper"
+  test_framework: "testify"
+  additional:
+    - "go-pretty/v6 (table output)"
+
+skills:
+  - code-review
+  - add-tests
+  - write-adr
+  - write-changelog
+
+output:
+  build_command: "go build ./..."
+  test_command: "go test ./... -race -cover"
+  lint_command: "golangci-lint run"
+  structure: flat
+  project_header: |
+    Go CLI tool built with Cobra and hexagonal architecture.
+    The domain package must have zero external dependencies — no Cobra, no Viper, no output libs.
+    Commands accept io.Writer arguments and never call os.Exit directly.
+    All dependencies are injected via interfaces defined in the domain or application layer.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/profiles/golang-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/golang-hexagonal-nuxt-vite-ui.yaml
@@ -1,0 +1,75 @@
+meta:
+  name: "Go Hexagonal + Nuxt/Vite UI"
+  description: >
+    Full-stack application with a Go hexagonal backend and a Nuxt 3 / Vue 3
+    frontend. Go handles all business logic and HTTP APIs; Nuxt delivers
+    SSR-capable pages with Vite for fast builds and Vitest for unit tests.
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+
+  languages:
+    - go
+    - typescript
+
+  frameworks:
+    - vue
+    - nuxt
+
+  architecture:
+    - hexagonal
+    - ddd
+    - microservices
+
+  practices:
+    - tdd
+    - api-design
+    - observability
+    - ci-cd
+
+  domains: []
+
+tech_stack:
+  language_runtime: "Go 1.23+ (backend) / Node 22+ (frontend)"
+  package_manager: "Go modules (backend) / pnpm (frontend)"
+  backend_framework: "gorilla/mux"
+  frontend_framework: "Nuxt 3"
+  ui_component_library: "shadcn/vue"
+  css_framework: "Tailwind CSS v4"
+  build_tool: "Vite 6"
+  test_framework: "Vitest (frontend) / testify (backend)"
+  additional:
+    - "Vue 3"
+    - "pinia"
+    - "VueRouter"
+
+skills:
+  - code-review
+  - add-tests
+  - write-adr
+  - write-readme
+
+output:
+  build_command: "go build ./... && pnpm build"
+  test_command: "go test ./... -race -cover && pnpm test"
+  lint_command: "golangci-lint run && pnpm lint"
+  structure: flat
+  project_header: |
+    Full-stack project: Go hexagonal backend + Nuxt 3 frontend.
+    Backend domain package must have zero external dependencies.
+    Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    All dependencies are injected via interfaces defined in the domain or application layer.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/profiles/golang-hexagonal-vue-vite-ui.yaml
+++ b/profiles/golang-hexagonal-vue-vite-ui.yaml
@@ -1,0 +1,74 @@
+meta:
+  name: "Go Hexagonal + Vue/Vite SPA"
+  description: >
+    Full-stack application with a Go hexagonal backend and a Vue 3 SPA
+    frontend. Go handles all business logic and HTTP APIs; Vue delivers a
+    client-side single-page application with Vite for fast builds and Vitest
+    for unit tests. No SSR.
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+
+  languages:
+    - go
+    - typescript
+
+  frameworks:
+    - vue
+
+  architecture:
+    - hexagonal
+    - ddd
+    - microservices
+
+  practices:
+    - tdd
+    - api-design
+    - observability
+    - ci-cd
+
+  domains: []
+
+tech_stack:
+  language_runtime: "Go 1.23+ (backend) / Node 22+ (frontend)"
+  package_manager: "Go modules (backend) / pnpm (frontend)"
+  backend_framework: "gorilla/mux"
+  frontend_framework: "Vue 3 (SPA)"
+  ui_component_library: "shadcn/vue"
+  css_framework: "Tailwind CSS v4"
+  build_tool: "Vite 6"
+  test_framework: "Vitest (frontend) / testify (backend)"
+  additional:
+    - "pinia"
+    - "VueRouter"
+
+skills:
+  - code-review
+  - add-tests
+  - write-adr
+  - write-readme
+
+output:
+  build_command: "go build ./... && pnpm build"
+  test_command: "go test ./... -race -cover && pnpm test"
+  lint_command: "golangci-lint run && pnpm lint"
+  structure: flat
+  project_header: |
+    Full-stack project: Go hexagonal backend + Vue 3 SPA frontend (no SSR).
+    Backend domain package must have zero external dependencies.
+    Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    All dependencies are injected via interfaces defined in the domain or application layer.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/profiles/python-hexagonal-typer-cli.yaml
+++ b/profiles/python-hexagonal-typer-cli.yaml
@@ -1,0 +1,68 @@
+meta:
+  name: "Python Hexagonal Typer CLI"
+  description: >
+    Python CLI tool following hexagonal architecture with DDD patterns.
+    Typer + Rich for the command layer; domain and application layers have
+    zero CLI framework dependencies. Fully type-annotated, tested with pytest,
+    linted with ruff, and type-checked with mypy.
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+
+  languages:
+    - python
+
+  frameworks:
+    - typer
+
+  architecture:
+    - hexagonal
+    - ddd
+
+  practices:
+    - tdd
+    - observability
+    - ci-cd
+
+  domains: []
+
+tech_stack:
+  language_runtime: "Python 3.12+"
+  package_manager: "uv"
+  cli_framework: "Typer"
+  test_framework: "pytest"
+  additional:
+    - "Rich"
+    - "ruff"
+    - "mypy"
+
+skills:
+  - code-review
+  - add-tests
+  - write-adr
+  - write-changelog
+
+output:
+  build_command: "uv build"
+  test_command: "uv run pytest"
+  lint_command: "uv run ruff check . && uv run mypy ."
+  structure: flat
+  project_header: |
+    Python CLI tool built with Typer and hexagonal architecture.
+    The domain package must have zero external dependencies — no Typer, no Rich, no CLI libs.
+    Type annotations are the CLI contract; never bypass them with manual argument parsing.
+    All dependencies are injected via interfaces defined in the domain or application layer.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
@@ -1,0 +1,75 @@
+meta:
+  name: "TypeScript Hexagonal + Nuxt/Vite UI"
+  description: >
+    Full-stack TypeScript application with a Hono hexagonal backend and a
+    Nuxt 3 / Vue 3 frontend. Hono handles all business logic and HTTP APIs;
+    Nuxt delivers SSR-capable pages with Vite for fast builds and Vitest for
+    unit tests. Monorepo or split-repo — same language end to end.
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+
+  languages:
+    - typescript
+
+  frameworks:
+    - vue
+    - nuxt
+
+  architecture:
+    - hexagonal
+    - ddd
+    - microservices
+
+  practices:
+    - tdd
+    - api-design
+    - observability
+    - ci-cd
+
+  domains: []
+
+tech_stack:
+  language_runtime: "Node 22+"
+  package_manager: "pnpm"
+  backend_framework: "Hono"
+  frontend_framework: "Nuxt 3"
+  ui_component_library: "shadcn/vue"
+  css_framework: "Tailwind CSS v4"
+  build_tool: "Vite 6"
+  test_framework: "Vitest"
+  additional:
+    - "Vue 3"
+    - "pinia"
+    - "VueRouter"
+
+skills:
+  - code-review
+  - add-tests
+  - write-adr
+  - write-readme
+
+output:
+  build_command: "pnpm build"
+  test_command: "pnpm test"
+  lint_command: "pnpm lint"
+  structure: flat
+  project_header: |
+    Full-stack TypeScript project: Hono hexagonal backend + Nuxt 3 frontend.
+    Backend domain layer must have zero framework dependencies.
+    Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    All dependencies are injected via interfaces defined in the domain or application layer.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/profiles/typescript-hexagonal-vue-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-vue-vite-ui.yaml
@@ -1,0 +1,73 @@
+meta:
+  name: "TypeScript Hexagonal + Vue/Vite SPA"
+  description: >
+    Full-stack TypeScript application with a Hono hexagonal backend and a Vue 3
+    SPA frontend. Hono handles all business logic and HTTP APIs; Vue delivers a
+    client-side single-page application with Vite for fast builds and Vitest
+    for unit tests. No SSR.
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+
+  languages:
+    - typescript
+
+  frameworks:
+    - vue
+
+  architecture:
+    - hexagonal
+    - ddd
+    - microservices
+
+  practices:
+    - tdd
+    - api-design
+    - observability
+    - ci-cd
+
+  domains: []
+
+tech_stack:
+  language_runtime: "Node 22+"
+  package_manager: "pnpm"
+  backend_framework: "Hono"
+  frontend_framework: "Vue 3 (SPA)"
+  ui_component_library: "shadcn/vue"
+  css_framework: "Tailwind CSS v4"
+  build_tool: "Vite 6"
+  test_framework: "Vitest"
+  additional:
+    - "pinia"
+    - "VueRouter"
+
+skills:
+  - code-review
+  - add-tests
+  - write-adr
+  - write-readme
+
+output:
+  build_command: "pnpm build"
+  test_command: "pnpm test"
+  lint_command: "pnpm lint"
+  structure: flat
+  project_header: |
+    Full-stack TypeScript project: Hono hexagonal backend + Vue 3 SPA frontend (no SSR).
+    Backend domain layer must have zero framework dependencies.
+    Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    All dependencies are injected via interfaces defined in the domain or application layer.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -69,6 +69,35 @@
         }
       }
     },
+    "tech_stack": {
+      "type": "object",
+      "description": "Optional tech stack metadata used to generate a Technical Stack section in AGENTS.md",
+      "additionalProperties": false,
+      "properties": {
+        "language_runtime": { "type": "string" },
+        "package_manager": { "type": "string" },
+        "backend_framework": { "type": "string" },
+        "frontend_framework": { "type": "string" },
+        "ui_component_library": { "type": "string" },
+        "css_framework": { "type": "string" },
+        "build_tool": { "type": "string" },
+        "test_framework": { "type": "string" },
+        "cli_framework": { "type": "string" },
+        "database": { "type": "string" },
+        "messaging": { "type": "string" },
+        "additional": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extra libraries or tools not covered by the named fields"
+        }
+      }
+    },
+    "skills": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Skill names to include in the generated Skills section (names must match index/skills.json)",
+      "default": []
+    },
     "output": {
       "type": "object",
       "additionalProperties": false,
@@ -88,6 +117,12 @@
         "project_header": {
           "type": "string",
           "description": "Optional text injected at the top of the assembled AGENTS.md"
+        },
+        "structure": {
+          "type": "string",
+          "enum": ["flat", "nested"],
+          "default": "flat",
+          "description": "Output structure: flat (single AGENTS.md) or nested (reserved for future use)"
         }
       }
     },

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -8,6 +8,7 @@ LIBRARY=""
 PROFILE=""
 TARGET=""
 DRY_RUN=false
+FULL_MODE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -15,6 +16,7 @@ while [[ $# -gt 0 ]]; do
     --profile)  PROFILE="$2";  shift 2 ;;
     --target)   TARGET="$2";   shift 2 ;;
     --dry-run)  DRY_RUN=true;  shift   ;;
+    --full)     FULL_MODE=true; shift  ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -63,6 +65,124 @@ load_fragments() {
   done
 }
 
+# ── Technical Stack section ───────────────────────────────────────────────────
+build_tech_stack_section() {
+  # Check if tech_stack key exists and is not null
+  local has_tech
+  has_tech=$(yq '.tech_stack // "null"' "$PROFILE_FILE")
+  [[ "$has_tech" == "null" ]] && return
+
+  local section=""
+  section+=$'\n## Technical Stack\n\n'
+  section+="| Layer | Technology |"$'\n'
+  section+="|-------|-----------|"$'\n'
+
+  # Ordered field definitions: "yq_key|display_label"
+  local -a field_defs=(
+    "language_runtime|Language"
+    "package_manager|Package Manager"
+    "backend_framework|Backend Framework"
+    "frontend_framework|Frontend Framework"
+    "ui_component_library|UI Components"
+    "css_framework|CSS"
+    "build_tool|Build Tool"
+    "test_framework|Test Framework"
+    "cli_framework|CLI Framework"
+    "database|Database"
+    "messaging|Messaging"
+  )
+
+  for field_def in "${field_defs[@]}"; do
+    local key="${field_def%%|*}"
+    local label="${field_def##*|}"
+    local value
+    value=$(yq ".tech_stack.${key} // \"null\"" "$PROFILE_FILE")
+    [[ -z "$value" || "$value" == "null" ]] && continue
+    section+="| ${label} | ${value} |"$'\n'
+  done
+
+  # Additional items (array)
+  local additional_raw
+  additional_raw=$(yq '.tech_stack.additional // []' "$PROFILE_FILE")
+  if [[ "$additional_raw" != "[]" && "$additional_raw" != "null" ]]; then
+    local additional_items=()
+    while IFS= read -r item; do
+      [[ -z "$item" || "$item" == "null" ]] && continue
+      additional_items+=("$item")
+    done < <(yq '.tech_stack.additional[]' "$PROFILE_FILE" 2>/dev/null || true)
+    if [[ ${#additional_items[@]} -gt 0 ]]; then
+      local joined
+      joined=$(IFS=", "; echo "${additional_items[*]}")
+      section+="| Additional | ${joined} |"$'\n'
+    fi
+  fi
+
+  printf '%s' "$section"
+}
+
+# ── Skills section ────────────────────────────────────────────────────────────
+build_skills_section() {
+  local full_mode="$1"  # "true" or "false"
+
+  local skills_list=()
+  while IFS= read -r _skill; do
+    skills_list+=("$_skill")
+  done < <(yq '.skills[]' "$PROFILE_FILE" 2>/dev/null || true)
+
+  # Nothing to do if no skills declared
+  [[ ${#skills_list[@]} -eq 0 ]] && return
+
+  local skills_index="$LIBRARY/index/skills.json"
+  [[ ! -f "$skills_index" ]] && {
+    echo "Warning: index/skills.json not found — skipping Skills section" >&2
+    return
+  }
+
+  if [[ "$full_mode" == "true" ]]; then
+    # Full mode: embed complete SKILL.md content
+    local section=""
+    section+=$'\n## Skills\n\n'
+    for skill_name in "${skills_list[@]+"${skills_list[@]}"}"; do
+      [[ -z "$skill_name" || "$skill_name" == "null" ]] && continue
+      local skill_path
+      skill_path=$(jq -r --arg n "$skill_name" '.skills[] | select(.name == $n) | .path' "$skills_index")
+      if [[ -z "$skill_path" || "$skill_path" == "null" ]]; then
+        echo "Warning: skill '$skill_name' not found in index — skipping" >&2
+        continue
+      fi
+      local skill_file="$LIBRARY/$skill_path"
+      if [[ ! -f "$skill_file" ]]; then
+        echo "Warning: skill file '$skill_file' not found — skipping" >&2
+        continue
+      fi
+      section+=$'\n<!-- skill: '"$skill_name"' -->\n\n'
+      section+=$(cat "$skill_file")
+      section+=$'\n'
+    done
+    printf '%s' "$section"
+  else
+    # Slim mode: listing table
+    local section=""
+    section+=$'\n## Skills\n\n'
+    section+="Load the relevant skill file before starting the task."$'\n\n'
+    section+="| Skill | Description | Path |"$'\n'
+    section+="|-------|-------------|------|"$'\n'
+
+    for skill_name in "${skills_list[@]+"${skills_list[@]}"}"; do
+      [[ -z "$skill_name" || "$skill_name" == "null" ]] && continue
+      local skill_path skill_desc
+      skill_path=$(jq -r --arg n "$skill_name" '.skills[] | select(.name == $n) | .path' "$skills_index")
+      skill_desc=$(jq -r --arg n "$skill_name" '.skills[] | select(.name == $n) | .description' "$skills_index")
+      if [[ -z "$skill_path" || "$skill_path" == "null" ]]; then
+        echo "Warning: skill '$skill_name' not found in index — skipping" >&2
+        continue
+      fi
+      section+="| ${skill_name} | ${skill_desc} | \`${skill_path}\` |"$'\n'
+    done
+    printf '%s' "$section"
+  fi
+}
+
 # ── Assemble ──────────────────────────────────────────────────────────────────
 OUTPUT=$(cat <<HEADER
 # Agent Instructions — ${PROJECT_NAME}
@@ -88,6 +208,9 @@ if [[ -n "$BUILD_CMD" || -n "$TEST_CMD" || -n "$LINT_CMD" ]]; then
   [[ -n "$LINT_CMD"  && "$LINT_CMD"  != "null" ]] && OUTPUT+="- **Lint**: \`${LINT_CMD}\`"$'\n'
 fi
 
+# Technical Stack section
+OUTPUT+=$(build_tech_stack_section)
+
 # Fragments in layer order
 OUTPUT+=$(load_fragments "base"         "agents/base")
 OUTPUT+=$(load_fragments "languages"    "agents/languages")
@@ -95,6 +218,9 @@ OUTPUT+=$(load_fragments "frameworks"   "agents/frameworks")
 OUTPUT+=$(load_fragments "architecture" "agents/architecture")
 OUTPUT+=$(load_fragments "practices"    "agents/practices")
 OUTPUT+=$(load_fragments "domains"      "agents/domains")
+
+# Skills section (slim listing or full embedded, depending on --full flag)
+OUTPUT+=$(build_skills_section "$FULL_MODE")
 
 # Local override (project-specific additions, if present)
 LOCAL_OVERRIDE="$TARGET/AGENTS.local.md"
@@ -105,16 +231,21 @@ if [[ -f "$LOCAL_OVERRIDE" ]]; then
 fi
 
 # ── Output ────────────────────────────────────────────────────────────────────
+# Determine output filename
+OUTPUT_FILENAME="AGENTS.md"
+[[ "$FULL_MODE" == "true" ]] && OUTPUT_FILENAME="AGENTS.full.md"
+
 if [[ "$DRY_RUN" == "true" ]]; then
   printf '%s\n' "$OUTPUT"
 else
   mkdir -p "$TARGET"
-  echo "$OUTPUT" > "$TARGET/AGENTS.md"
+  echo "$OUTPUT" > "$TARGET/$OUTPUT_FILENAME"
 
-  # Write lock file
-  LOCK_DIR="$TARGET/.agentic"
-  mkdir -p "$LOCK_DIR"
-  cat > "$LOCK_DIR/config.yaml" <<LOCK
+  # Write lock file (only for primary AGENTS.md, not full mode)
+  if [[ "$FULL_MODE" == "false" ]]; then
+    LOCK_DIR="$TARGET/.agentic"
+    mkdir -p "$LOCK_DIR"
+    cat > "$LOCK_DIR/config.yaml" <<LOCK
 # Managed by agentic library — do not edit manually
 # Regenerate with: just compose ${PROFILE} ${TARGET}
 library_commit: "$(cd "$LIBRARY" && git rev-parse HEAD 2>/dev/null || echo "unknown")"
@@ -122,6 +253,7 @@ profile: "${PROFILE}"
 profile_version: "${PROFILE_VER}"
 composed_at: "${GENERATED_AT}"
 LOCK
+  fi
 
-  echo "Composed AGENTS.md → $TARGET/AGENTS.md"
+  echo "Composed ${OUTPUT_FILENAME} → $TARGET/$OUTPUT_FILENAME"
 fi

--- a/tooling/lib/index.sh
+++ b/tooling/lib/index.sh
@@ -32,13 +32,15 @@ build_skills_index() {
     name=$(basename "$dir")
     local path="${skill_file#$LIBRARY/}"
 
-    # Extract frontmatter fields using yq (treating YAML frontmatter)
+    # Extract frontmatter fields using yq (parse YAML block between first two --- delimiters)
+    local frontmatter
+    frontmatter=$(awk '/^---$/{n++; if(n==1){p=1;next} if(n==2){exit}} p' "$skill_file")
     local description
-    description=$(sed -n '/^---$/,/^---$/p' "$skill_file" | grep '^description:' | sed 's/^description: *//' | tr -d '"' | head -1)
+    description=$(echo "$frontmatter" | yq '.description // ""' | tr -d '\n' | sed 's/  */ /g')
     local version
-    version=$(sed -n '/^---$/,/^---$/p' "$skill_file" | grep '^version:' | sed 's/^version: *//' | tr -d '"' | head -1)
+    version=$(echo "$frontmatter" | yq '.version // "0.0.0"')
     local tags
-    tags=$(sed -n '/^---$/,/^---$/p' "$skill_file" | grep -A20 '^tags:' | grep '^  - ' | sed 's/^  - //' | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null || echo '[]')
+    tags=$(echo "$frontmatter" | yq -o=json '.tags // []' 2>/dev/null || echo '[]')
 
     [[ "$first" == "false" ]] && skills_json+=","
     skills_json+=$(printf '{"name":"%s","group":"%s","path":"%s","description":"%s","version":"%s","tags":%s}' \

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -143,7 +143,7 @@ assert_file_not_contains "$TMP/t02/AGENTS.md" "## TypeScript" "T02"
 
 # T03 — compose: dry-run produces stdout, no files written
 run_test "T03 — compose: dry-run produces stdout, no files written"
-DRY_TMPFILE=$(mktemp)
+DRY_TMPFILE=$(mktemp "$TMP/dry-XXXXXX")
 T03_EXIT=0
 bash "$COMPOSE" \
   --library "$LIBRARY" \
@@ -154,7 +154,6 @@ bash "$COMPOSE" \
 assert_exit_code 0 "$T03_EXIT" "T03"
 assert_file_not_exists "$TMP/t03" "T03"
 assert_file_contains "$DRY_TMPFILE" "## Git Conventions" "T03"
-rm -f "$DRY_TMPFILE"
 
 # T04 — compose: unknown profile fails with exit code 1
 run_test "T04 — compose: unknown profile fails"
@@ -323,6 +322,68 @@ assert_json_valid "$LIBRARY/index/skills.json" "T15"
 assert_json_valid "$LIBRARY/index/fragments.json" "T15"
 assert_json_min_count "$LIBRARY/index/skills.json" '.skills | length' 10 "T15 skills"
 assert_json_min_count "$LIBRARY/index/fragments.json" '.fragments | length' 19 "T15 fragments"
+
+# T16 — compose: profile with tech_stack produces ## Technical Stack section
+run_test "T16 — compose: tech_stack profile produces ## Technical Stack"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-cobra-cli \
+  --target "$TMP/t16" \
+  > /dev/null 2>&1
+
+assert_file_contains "$TMP/t16/AGENTS.md" "## Technical Stack" "T16"
+assert_file_contains "$TMP/t16/AGENTS.md" "Go 1.23+" "T16"
+assert_file_contains "$TMP/t16/AGENTS.md" "Cobra + Viper" "T16"
+
+# T17 — compose: profile with skills produces slim ## Skills listing
+run_test "T17 — compose: skills profile produces ## Skills listing"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-cobra-cli \
+  --target "$TMP/t17" \
+  > /dev/null 2>&1
+
+assert_file_contains "$TMP/t17/AGENTS.md" "## Skills" "T17"
+assert_file_contains "$TMP/t17/AGENTS.md" "Load the relevant skill file before starting the task." "T17"
+assert_file_contains "$TMP/t17/AGENTS.md" "code-review" "T17"
+assert_file_contains "$TMP/t17/AGENTS.md" "write-adr" "T17"
+
+# T18 — compose: --full writes AGENTS.full.md, not AGENTS.md
+run_test "T18 — compose: --full writes AGENTS.full.md, not AGENTS.md"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-cobra-cli \
+  --target "$TMP/t18" \
+  --full \
+  > /dev/null 2>&1
+
+assert_file_exists "$TMP/t18/AGENTS.full.md" "T18"
+assert_file_not_exists "$TMP/t18/AGENTS.md" "T18"
+assert_file_not_exists "$TMP/t18/.agentic" "T18"
+
+# T19 — compose: --full embeds skill content inline (not just listing)
+run_test "T19 — compose: --full embeds full skill content"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-cobra-cli \
+  --target "$TMP/t19" \
+  --full \
+  > /dev/null 2>&1
+
+assert_file_contains "$TMP/t19/AGENTS.full.md" "## Skills" "T19"
+assert_file_contains "$TMP/t19/AGENTS.full.md" "## Code Review Skill" "T19"
+assert_file_not_contains "$TMP/t19/AGENTS.full.md" "Load the relevant skill file before starting the task." "T19"
+
+# T20 — compose: profile without tech_stack/skills has no ## Technical Stack or ## Skills
+run_test "T20 — compose: profile without tech_stack/skills omits those sections"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile go-hexagonal-microservice \
+  --target "$TMP/t20" \
+  > /dev/null 2>&1
+
+assert_file_not_contains "$TMP/t20/AGENTS.md" "## Technical Stack" "T20"
+assert_file_not_contains "$TMP/t20/AGENTS.md" "## Skills" "T20"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- **Schema** — three new optional profile fields: `tech_stack` (structured object), `skills` (string[]), `output.structure` (flat/nested enum)
- **`compose.sh`** — generates `## Technical Stack` table and `## Skills` slim listing from profile metadata; new `--full` flag embeds complete skill content and writes `AGENTS.full.md`
- **`justfile`** — new `compose-full PROFILE TARGET` recipe
- **`index.sh`** — fix skill description extraction (yq block scalar parsing; was returning literal `>`)
- **4 new framework fragments** — `vue.md`, `nuxt.md`, `cobra.md`, `typer.md`
- **6 new profiles** — Go + Nuxt UI, Go + Vue SPA, TS + Nuxt UI, TS + Vue SPA, Go + Cobra CLI, Python + Typer CLI; all with `tech_stack` and `skills`
- **Test suite** — 44 assertions (up from 29): T16–T20 cover new compose behaviours; T03 dry-run temp file moved inside `$TMP` so `EXIT` trap covers it unconditionally
- **`AGENTS.md`** — contributor Testing & Quality rules: run `just test` before committing tooling changes, add assertions for every new behaviour, run `just lint` + `just index` after content changes

## Test plan

- [x] `just lint` — PASSED (25 fragments, 11 profiles, 5 adapters, 12 skills)
- [x] `just test` — 44/44 PASSED
- [x] `just index` — rebuilt; 4 framework fragments indexed, 11 profiles listed
- [x] Dry-run smoke test: `just dry-run golang-hexagonal-cobra-cli` produces `## Technical Stack` and `## Skills` sections
- [x] Full mode smoke test: `AGENTS.full.md` contains embedded skill content, no slim listing instruction line, no `.agentic/` lock dir
- [x] Negative: `go-hexagonal-microservice` (no `tech_stack`/`skills`) produces neither section