### PR TITLE
feat(profiles): migrate full-stack profiles to nested output structure

### DIFF
--- a/profiles/golang-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/golang-hexagonal-nuxt-vite-ui.yaml
@@ -14,18 +14,11 @@ fragments:
     - testing-philosophy
     - documentation
 
-  languages:
-    - go
-    - typescript
+  languages: []       # ignored in nested mode — declared in tiers below
 
-  frameworks:
-    - vue
-    - nuxt
+  frameworks: []      # ignored in nested mode — declared in tiers below
 
-  architecture:
-    - hexagonal
-    - ddd
-    - microservices
+  architecture: []    # ignored in nested mode — each tier defines its own
 
   practices:
     - tdd
@@ -34,6 +27,23 @@ fragments:
     - ci-cd
 
   domains: []
+
+tiers:
+  backend:
+    languages:
+      - go
+    frameworks: []
+    architecture:
+      - hexagonal
+      - ddd
+      - microservices
+  ui:
+    languages:
+      - typescript
+    frameworks:
+      - vue
+      - nuxt
+    architecture: []
 
 tech_stack:
   language_runtime: "Go 1.23+ (backend) / Node 22+ (frontend)"
@@ -59,7 +69,7 @@ output:
   build_command: "go build ./... && pnpm build"
   test_command: "go test ./... -race -cover && pnpm test"
   lint_command: "golangci-lint run && pnpm lint"
-  structure: flat
+  structure: nested
   project_header: |
     Full-stack project: Go hexagonal backend + Nuxt 3 frontend.
     Backend domain package must have zero external dependencies.

--- a/profiles/golang-hexagonal-vue-vite-ui.yaml
+++ b/profiles/golang-hexagonal-vue-vite-ui.yaml
@@ -15,17 +15,11 @@ fragments:
     - testing-philosophy
     - documentation
 
-  languages:
-    - go
-    - typescript
+  languages: []       # ignored in nested mode — declared in tiers below
 
-  frameworks:
-    - vue
+  frameworks: []      # ignored in nested mode — declared in tiers below
 
-  architecture:
-    - hexagonal
-    - ddd
-    - microservices
+  architecture: []    # ignored in nested mode — each tier defines its own
 
   practices:
     - tdd
@@ -34,6 +28,22 @@ fragments:
     - ci-cd
 
   domains: []
+
+tiers:
+  backend:
+    languages:
+      - go
+    frameworks: []
+    architecture:
+      - hexagonal
+      - ddd
+      - microservices
+  ui:
+    languages:
+      - typescript
+    frameworks:
+      - vue
+    architecture: []
 
 tech_stack:
   language_runtime: "Go 1.23+ (backend) / Node 22+ (frontend)"
@@ -58,7 +68,7 @@ output:
   build_command: "go build ./... && pnpm build"
   test_command: "go test ./... -race -cover && pnpm test"
   lint_command: "golangci-lint run && pnpm lint"
-  structure: flat
+  structure: nested
   project_header: |
     Full-stack project: Go hexagonal backend + Vue 3 SPA frontend (no SSR).
     Backend domain package must have zero external dependencies.

--- a/profiles/typescript-hexagonal-vue-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-vue-vite-ui.yaml
@@ -15,16 +15,11 @@ fragments:
     - testing-philosophy
     - documentation
 
-  languages:
-    - typescript
+  languages: []       # ignored in nested mode — declared in tiers below
 
-  frameworks:
-    - vue
+  frameworks: []      # ignored in nested mode — declared in tiers below
 
-  architecture:
-    - hexagonal
-    - ddd
-    - microservices
+  architecture: []    # ignored in nested mode — each tier defines its own
 
   practices:
     - tdd
@@ -33,6 +28,22 @@ fragments:
     - ci-cd
 
   domains: []
+
+tiers:
+  backend:
+    languages:
+      - typescript
+    frameworks: []
+    architecture:
+      - hexagonal
+      - ddd
+      - microservices
+  ui:
+    languages:
+      - typescript
+    frameworks:
+      - vue
+    architecture: []
 
 tech_stack:
   language_runtime: "Node 22+"
@@ -57,7 +68,7 @@ output:
   build_command: "pnpm build"
   test_command: "pnpm test"
   lint_command: "pnpm lint"
-  structure: flat
+  structure: nested
   project_header: |
     Full-stack TypeScript project: Hono hexagonal backend + Vue 3 SPA frontend (no SSR).
     Backend domain layer must have zero framework dependencies.


### PR DESCRIPTION
## Summary

- Migrates `golang-hexagonal-nuxt-vite-ui`, `golang-hexagonal-vue-vite-ui`, and `typescript-hexagonal-vue-vite-ui` from `output.structure: flat` to `output.structure: nested`
- Adds `tiers` block to each profile with the correct backend/UI split
- `typescript-hexagonal-nuxt-vite-ui` was already migrated in #8

## Tier breakdown

| Profile | backend tier | ui tier |
|---------|-------------|---------|
| `golang-hexagonal-nuxt-vite-ui` | go + hexagonal/ddd/microservices | typescript + vue + nuxt |
| `golang-hexagonal-vue-vite-ui` | go + hexagonal/ddd/microservices | typescript + vue |
| `typescript-hexagonal-vue-vite-ui` | typescript + hexagonal/ddd/microservices | typescript + vue |

## Test plan

- [x] `just lint` passes (all profiles validate against schema)
- [x] `just test` passes (92/92 assertions)
- [x] `just compose golang-hexagonal-vue-vite-ui <target>` produces `AGENTS.md` + `backend/AGENTS.md` + `ui/AGENTS.md`