### PR TITLE
feat: commands in tier files, proprietary_libraries, separator, relational-database-design skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ agentic/  (this repo — fork it, make it yours)
 │   └── my-profile.yaml
 │       ├── fragments:            which building blocks to include
 │       ├── tech_stack:           runtime, frameworks, tools  (optional)
+│       │   └── proprietary_libraries: internal packages with doc links (optional)
 │       ├── skills:               on-demand agent tasks       (optional)
 │       └── output:               build / test / lint commands
 │
@@ -218,6 +219,33 @@ mkdir -p skills/development/my-skill
 touch skills/development/my-skill/SKILL.md
 just index
 ```
+
+### Declare proprietary libraries
+
+List internal packages that agents need to be aware of — their name, what they provide, and where to find the docs. Agents are told to load the relevant documentation before making changes.
+
+**Project-wide** (rendered in root `AGENTS.md`, under `tech_stack`):
+
+```yaml
+tech_stack:
+  proprietary_libraries:
+    - name: "@acme/core"
+      description: "Core domain primitives shared across all services"
+      url_doc: "https://docs.acme.internal/core"   # optional
+```
+
+**Tier-specific** (nested profiles only — rendered in that tier's `AGENTS.md`):
+
+```yaml
+tiers:
+  backend:
+    proprietary_libraries:
+      - name: "@acme/domain-kit"
+        description: "Backend domain helpers"
+        url_doc: "https://docs.acme.internal/domain-kit"
+```
+
+`url_doc` is optional. When omitted the Docs column shows `—`.
 
 ---
 

--- a/profiles/go-hexagonal-microservice.yaml
+++ b/profiles/go-hexagonal-microservice.yaml
@@ -31,6 +31,9 @@ fragments:
 
   domains: []
 
+skills:
+  - relational-database-design
+
 output:
   build_command: "go build ./..."
   test_command: "go test ./... -race -cover"

--- a/profiles/golang-hexagonal-cobra-cli.yaml
+++ b/profiles/golang-hexagonal-cobra-cli.yaml
@@ -44,6 +44,7 @@ skills:
   - add-tests
   - write-adr
   - write-changelog
+  - relational-database-design
 
 output:
   build_command: "go build ./..."

--- a/profiles/golang-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/golang-hexagonal-nuxt-vite-ui.yaml
@@ -37,6 +37,10 @@ tiers:
       - hexagonal
       - ddd
       - microservices
+    commands:
+      build_command: "go build ./..."
+      test_command:  "go test ./... -race -cover"
+      lint_command:  "golangci-lint run"
   ui:
     languages:
       - typescript
@@ -44,6 +48,10 @@ tiers:
       - vue
       - nuxt
     architecture: []
+    commands:
+      build_command: "pnpm build"
+      test_command:  "pnpm test"
+      lint_command:  "pnpm lint"
 
 tech_stack:
   language_runtime: "Go 1.23+ (backend) / Node 22+ (frontend)"
@@ -64,6 +72,7 @@ skills:
   - add-tests
   - write-adr
   - write-readme
+  - relational-database-design
 
 output:
   build_command: "go build ./... && pnpm build"

--- a/profiles/golang-hexagonal-vue-vite-ui.yaml
+++ b/profiles/golang-hexagonal-vue-vite-ui.yaml
@@ -38,12 +38,20 @@ tiers:
       - hexagonal
       - ddd
       - microservices
+    commands:
+      build_command: "go build ./..."
+      test_command:  "go test ./... -race -cover"
+      lint_command:  "golangci-lint run"
   ui:
     languages:
       - typescript
     frameworks:
       - vue
     architecture: []
+    commands:
+      build_command: "pnpm build"
+      test_command:  "pnpm test"
+      lint_command:  "pnpm lint"
 
 tech_stack:
   language_runtime: "Go 1.23+ (backend) / Node 22+ (frontend)"
@@ -63,6 +71,7 @@ skills:
   - add-tests
   - write-adr
   - write-readme
+  - relational-database-design
 
 output:
   build_command: "go build ./... && pnpm build"

--- a/profiles/php-hexagonal-ddd.yaml
+++ b/profiles/php-hexagonal-ddd.yaml
@@ -31,6 +31,9 @@ fragments:
 
   domains: []
 
+skills:
+  - relational-database-design
+
 output:
   build_command: "composer install --no-dev --optimize-autoloader"
   test_command: "vendor/bin/phpunit"

--- a/profiles/python-fastapi-microservice.yaml
+++ b/profiles/python-fastapi-microservice.yaml
@@ -30,6 +30,9 @@ fragments:
 
   domains: []
 
+skills:
+  - relational-database-design
+
 output:
   build_command: "uv build"
   test_command: "uv run pytest"

--- a/profiles/python-hexagonal-typer-cli.yaml
+++ b/profiles/python-hexagonal-typer-cli.yaml
@@ -47,6 +47,7 @@ skills:
   - add-tests
   - write-adr
   - write-changelog
+  - relational-database-design
 
 output:
   build_command: "uv build"

--- a/profiles/typescript-hexagonal-microservice.yaml
+++ b/profiles/typescript-hexagonal-microservice.yaml
@@ -32,6 +32,9 @@ fragments:
 
   domains: []
 
+skills:
+  - relational-database-design
+
 output:
   build_command: "pnpm build"
   test_command: "pnpm test --run"

--- a/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
@@ -38,6 +38,14 @@ tiers:
       - hexagonal
       - ddd
       - microservices
+    commands:
+      build_command: "pnpm --filter backend build"
+      test_command:  "pnpm --filter backend test"
+      lint_command:  "pnpm --filter backend lint"
+    proprietary_libraries:
+      - name: "@acme/domain-kit"
+        description: "Backend domain kit"
+        url_doc: "https://docs.acme.internal/domain-kit"
   ui:
     languages:
       - typescript
@@ -45,6 +53,13 @@ tiers:
       - vue
       - nuxt
     architecture: []
+    commands:
+      build_command: "pnpm --filter ui build"
+      test_command:  "pnpm --filter ui test"
+      lint_command:  "pnpm --filter ui lint"
+    proprietary_libraries:
+      - name: "@acme/ui-tokens"
+        description: "Design system tokens"
 
 tech_stack:
   language_runtime: "Node 22+"
@@ -59,12 +74,16 @@ tech_stack:
     - "Vue 3"
     - "pinia"
     - "VueRouter"
+  proprietary_libraries:
+    - name: "@acme/core"
+      description: "Core domain primitives shared across all services"
 
 skills:
   - code-review
   - add-tests
   - write-adr
   - write-readme
+  - relational-database-design
 
 output:
   build_command: "pnpm build"

--- a/profiles/typescript-hexagonal-vue-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-vue-vite-ui.yaml
@@ -38,12 +38,20 @@ tiers:
       - hexagonal
       - ddd
       - microservices
+    commands:
+      build_command: "pnpm --filter backend build"
+      test_command:  "pnpm --filter backend test"
+      lint_command:  "pnpm --filter backend lint"
   ui:
     languages:
       - typescript
     frameworks:
       - vue
     architecture: []
+    commands:
+      build_command: "pnpm --filter ui build"
+      test_command:  "pnpm --filter ui test"
+      lint_command:  "pnpm --filter ui lint"
 
 tech_stack:
   language_runtime: "Node 22+"
@@ -63,6 +71,7 @@ skills:
   - add-tests
   - write-adr
   - write-readme
+  - relational-database-design
 
 output:
   build_command: "pnpm build"

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -89,6 +89,20 @@
           "type": "array",
           "items": { "type": "string" },
           "description": "Extra libraries or tools not covered by the named fields"
+        },
+        "proprietary_libraries": {
+          "type": "array",
+          "description": "Internal/private packages — listed with context in the Proprietary Libraries section",
+          "items": {
+            "type": "object",
+            "required": ["name", "description"],
+            "additionalProperties": false,
+            "properties": {
+              "name":        { "type": "string", "description": "Package identifier (e.g. @acme/core)" },
+              "description": { "type": "string", "description": "What this package provides" },
+              "url_doc":     { "type": "string", "description": "URL to the package documentation (optional)" }
+            }
+          }
         }
       }
     },
@@ -107,7 +121,31 @@
         "properties": {
           "languages":    { "type": "array", "items": { "type": "string" }, "default": [] },
           "frameworks":   { "type": "array", "items": { "type": "string" }, "default": [] },
-          "architecture": { "type": "array", "items": { "type": "string" }, "default": [] }
+          "architecture": { "type": "array", "items": { "type": "string" }, "default": [] },
+          "commands": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Per-tier build/test/lint commands emitted into this tier's AGENTS.md",
+            "properties": {
+              "build_command": { "type": "string" },
+              "test_command":  { "type": "string" },
+              "lint_command":  { "type": "string" }
+            }
+          },
+          "proprietary_libraries": {
+            "type": "array",
+            "description": "Tier-specific private packages",
+            "items": {
+              "type": "object",
+              "required": ["name", "description"],
+              "additionalProperties": false,
+              "properties": {
+                "name":        { "type": "string" },
+                "description": { "type": "string" },
+                "url_doc":     { "type": "string" }
+              }
+            }
+          }
         }
       }
     },

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -172,6 +172,50 @@ build_tech_stack_section() {
   printf '%s' "$section"
 }
 
+# ── Commands section builder ───────────────────────────────────────────────────
+build_commands_block() {
+  local build_cmd="$1" test_cmd="$2" lint_cmd="$3"
+  local section=""
+  [[ -z "$build_cmd" && -z "$test_cmd" && -z "$lint_cmd" ]] && return
+  [[ "$build_cmd" == "null" && "$test_cmd" == "null" && "$lint_cmd" == "null" ]] && return
+
+  section+=$'\n## Commands\n\n'
+  [[ -n "$build_cmd" && "$build_cmd" != "null" ]] && section+="- **Build**: \`${build_cmd}\`"$'\n'
+  [[ -n "$test_cmd"  && "$test_cmd"  != "null" ]] && section+="- **Test**: \`${test_cmd}\`"$'\n'
+  [[ -n "$lint_cmd"  && "$lint_cmd"  != "null" ]] && section+="- **Lint**: \`${lint_cmd}\`"$'\n'
+  printf '%s' "$section"
+}
+
+# ── Proprietary Libraries section builder ─────────────────────────────────────
+build_proprietary_libraries_section() {
+  local profile_file="$1"
+  local yq_path="$2"
+
+  local count
+  count=$(yq "${yq_path} | length" "$profile_file" 2>/dev/null || echo "0")
+  [[ "$count" == "0" || "$count" == "null" ]] && return
+
+  local section=""
+  section+=$'\n## Proprietary Libraries\n\n'
+  section+="> Internal packages not available on public registries. Load the relevant docs before making changes."$'\n\n'
+  section+="| Package | Description | Docs |"$'\n'
+  section+="|---------|-------------|------|"$'\n'
+
+  local i=0
+  while [[ $i -lt $count ]]; do
+    local name desc url_doc
+    name=$(yq    "${yq_path}[$i].name"            "$profile_file")
+    desc=$(yq    "${yq_path}[$i].description"     "$profile_file")
+    url_doc=$(yq "${yq_path}[$i].url_doc // \"\"" "$profile_file")
+    local docs_cell="—"
+    [[ -n "$url_doc" && "$url_doc" != "null" ]] && docs_cell="[docs](${url_doc})"
+    section+="| \`${name}\` | ${desc} | ${docs_cell} |"$'\n'
+    i=$(( i + 1 ))
+  done
+
+  printf '%s' "$section"
+}
+
 # ── Skills section ────────────────────────────────────────────────────────────
 build_skills_section() {
   local full_mode="$1"  # "true" or "false"
@@ -249,22 +293,17 @@ HEADER
 
 # Project-specific header (from profile output.project_header)
 if [[ -n "$PROJECT_HEADER" && "$PROJECT_HEADER" != "null" ]]; then
-  OUTPUT+=$'\n'"## Project Context"$'\n\n'"${PROJECT_HEADER}"$'\n'
-fi
-
-# Commands section
-if [[ -n "$BUILD_CMD" || -n "$TEST_CMD" || -n "$LINT_CMD" ]]; then
-  OUTPUT+=$'\n'"## Commands"$'\n\n'
-  [[ -n "$BUILD_CMD" && "$BUILD_CMD" != "null" ]] && OUTPUT+="- **Build**: \`${BUILD_CMD}\`"$'\n'
-  [[ -n "$TEST_CMD"  && "$TEST_CMD"  != "null" ]] && OUTPUT+="- **Test**: \`${TEST_CMD}\`"$'\n'
-  [[ -n "$LINT_CMD"  && "$LINT_CMD"  != "null" ]] && OUTPUT+="- **Lint**: \`${LINT_CMD}\`"$'\n'
+  OUTPUT+=$'\n\n---\n\n'"## Project Context"$'\n\n'"${PROJECT_HEADER}"$'\n'
 fi
 
 # Technical Stack section
 OUTPUT+=$(build_tech_stack_section)
+OUTPUT+=$(build_proprietary_libraries_section "$PROFILE_FILE" ".tech_stack.proprietary_libraries")
 
 # ── Flat mode (single AGENTS.md) ─────────────────────────────────────────────
 compose_flat() {
+  OUTPUT+=$(build_commands_block "$BUILD_CMD" "$TEST_CMD" "$LINT_CMD")
+
   if [[ "$FULL_MODE" == "true" ]]; then
     OUTPUT+=$(inline_fragments)
   else
@@ -447,6 +486,12 @@ compose_nested() {
     tier_out+="<!-- Generated: ${GENERATED_AT} -->"$'\n'
     tier_out+="<!-- DO NOT EDIT — run \`just compose ${PROFILE} <target>\` to regenerate -->"$'\n\n'
 
+    local tier_build tier_test tier_lint
+    tier_build=$(yq ".tiers.${tier}.commands.build_command // \"\"" "$PROFILE_FILE")
+    tier_test=$(yq  ".tiers.${tier}.commands.test_command  // \"\""  "$PROFILE_FILE")
+    tier_lint=$(yq  ".tiers.${tier}.commands.lint_command  // \"\""  "$PROFILE_FILE")
+    tier_out+=$(build_commands_block "$tier_build" "$tier_test" "$tier_lint")
+
     if [[ ${#tier_frags[@]} -gt 0 ]]; then
       if [[ "$FULL_MODE" == "true" ]]; then
         for f in "${tier_frags[@]}"; do
@@ -468,6 +513,8 @@ compose_nested() {
         done
       fi
     fi
+
+    tier_out+=$(build_proprietary_libraries_section "$PROFILE_FILE" ".tiers.${tier}.proprietary_libraries")
 
     tier_out+=$'\n## Cross-tier Conventions\n\n'
     tier_out+="> Base conventions and practices are in the root \`AGENTS.md\`."$'\n'

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -378,16 +378,17 @@ assert_file_contains "$TMP/t19/AGENTS.md" "## Skills" "T19"
 assert_file_contains "$TMP/t19/AGENTS.md" "## Code Review Skill" "T19"
 assert_file_not_contains "$TMP/t19/AGENTS.md" "Load the relevant skill file before starting the task." "T19"
 
-# T20 — compose: profile without tech_stack/skills has no ## Technical Stack or ## Skills
-run_test "T20 — compose: profile without tech_stack/skills omits those sections"
+# T20 — compose: profile without tech_stack has no ## Technical Stack; has ## Skills with relational-database-design
+run_test "T20 — compose: profile without tech_stack omits that section; skills section present"
 bash "$COMPOSE" \
   --library "$LIBRARY" \
   --profile go-hexagonal-microservice \
   --target "$TMP/t20" \
   > /dev/null 2>&1
 
-assert_file_not_contains "$TMP/t20/AGENTS.md" "## Technical Stack" "T20"
-assert_file_not_contains "$TMP/t20/AGENTS.md" "## Skills" "T20"
+assert_file_not_contains "$TMP/t20/AGENTS.md" "## Technical Stack"        "T20"
+assert_file_contains     "$TMP/t20/AGENTS.md" "## Skills"                  "T20"
+assert_file_contains     "$TMP/t20/AGENTS.md" "relational-database-design" "T20"
 
 # T21 — compose: --full produces monolithic AGENTS.md with mode: full in lock file
 run_test "T21 — compose: --full flag produces monolithic AGENTS.md"
@@ -452,6 +453,7 @@ assert_file_not_contains  "$TMP/t24/AGENTS.md" ".agentic/fragments/hexagonal.md"
 assert_file_not_contains  "$TMP/t24/AGENTS.md" ".agentic/fragments/vue.md"              "T24"
 assert_file_contains      "$TMP/t24/.agentic/config.yaml" "structure: nested"           "T24"
 assert_file_contains      "$TMP/t24/.agentic/config.yaml" "mode: lean"                  "T24"
+assert_file_not_contains  "$TMP/t24/AGENTS.md"            "## Commands"                 "T24"
 
 # T25 — compose: nested lean mode writes correct tier AGENTS.md files
 run_test "T25 — compose: nested lean mode tier AGENTS.md content"
@@ -473,6 +475,8 @@ assert_file_not_contains  "$TMP/t25/backend/AGENTS.md" ".agentic/fragments/tdd.m
 assert_file_not_contains  "$TMP/t25/ui/AGENTS.md"      ".agentic/fragments/tdd.md"         "T25"
 assert_file_exists        "$TMP/t25/.agentic/fragments/hexagonal.md"                    "T25"
 assert_file_exists        "$TMP/t25/.agentic/fragments/vue.md"                          "T25"
+assert_file_contains      "$TMP/t25/backend/AGENTS.md" "## Commands"                    "T25"
+assert_file_contains      "$TMP/t25/ui/AGENTS.md"      "## Commands"                    "T25"
 
 # T26 — compose: nested --full inlines content into tier AGENTS.md files
 run_test "T26 — compose: nested --full inlines fragment content in tier files"
@@ -491,6 +495,21 @@ assert_file_not_contains  "$TMP/t26/backend/AGENTS.md" "## Vue 3"               
 assert_file_contains      "$TMP/t26/ui/AGENTS.md"      "## Vue 3"                       "T26"
 assert_file_not_contains  "$TMP/t26/ui/AGENTS.md"      "## Hexagonal Architecture"      "T26"
 assert_file_contains      "$TMP/t26/.agentic/config.yaml" "structure: nested"           "T26"
+
+# T27 — compose: proprietary_libraries appear in correct locations
+run_test "T27 — compose: proprietary_libraries sections in correct locations"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-nuxt-vite-ui \
+  --target "$TMP/t27" > /dev/null 2>&1
+
+assert_file_contains      "$TMP/t27/AGENTS.md"         "@acme/core"              "T27"
+assert_file_contains      "$TMP/t27/AGENTS.md"         "Core domain primitives"  "T27"
+assert_file_contains      "$TMP/t27/backend/AGENTS.md" "@acme/domain-kit"        "T27"
+assert_file_contains      "$TMP/t27/backend/AGENTS.md" "docs.acme.internal"      "T27"
+assert_file_contains      "$TMP/t27/ui/AGENTS.md"      "@acme/ui-tokens"         "T27"
+assert_file_not_contains  "$TMP/t27/AGENTS.md"         "@acme/domain-kit"        "T27"
+assert_file_not_contains  "$TMP/t27/AGENTS.md"         "@acme/ui-tokens"         "T27"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Four independent quality improvements on top of the nested output structure:

- **Commands → tier files**: `## Commands` no longer appears in the nested root `AGENTS.md`. A new `build_commands_block()` helper is called from `compose_flat()` (unchanged behaviour) and from the `compose_nested()` tier loop using per-tier `tiers.<name>.commands.*` keys. Schema updated; four full-stack profiles split their commands by tier.
- **`proprietary_libraries` field**: new `build_proprietary_libraries_section()` helper renders a `Package / Description / Docs` table. Available at `tech_stack.proprietary_libraries` (root AGENTS.md) and `tiers.<name>.proprietary_libraries` (tier AGENTS.md). Schema updated for both locations.
- **Project context separator**: `\n\n---\n\n` before `## Project Context` creates a clear visual break from the auto-generated metadata annotation block.
- **`relational-database-design` skill**: added to all backend profiles with DB concerns (go/php/python/typescript microservices, cobra/typer CLIs, all four full-stack nested profiles). `typescript-bff` excluded (stateless).

## Test plan

- [x] `just lint` — all 11 profiles validate against updated schema ✅
- [x] `just test` — 103 assertions (was 92), all pass ✅
- [x] Nested commands: `## Commands` absent from root, present in `backend/` and `ui/` tier files ✅
- [x] Flat commands: `## Commands` still present in flat root AGENTS.md ✅
- [x] Separator: `---` line appears between metadata annotation and `## Project Context` ✅
- [x] Proprietary libraries: root libs in root AGENTS.md, tier libs only in their respective tier file ✅
- [x] `relational-database-design` present in microservice and full-stack profiles, absent from `typescript-bff` ✅