### PR TITLE
chore: add CODEOWNERS for automatic PR review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — automatically request reviews from maintainers
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo
+* @soulcodex


### PR DESCRIPTION
## Summary

Add CODEOWNERS file to automatically request reviews from maintainer on all PRs.

## Changes

- **New `.github/CODEOWNERS`**: Sets `@soulcodex` as default owner for all files

## Why

Ensures all PRs are automatically assigned for review, streamlining the merge process.