### PR TITLE
feat(tooling): add curl-based installer and fix index timestamp noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Customize per-project with local profiles and project-specific skills → [docs/
 
 ## Quickstart
 
+### One-line Install
+
+```bash
+curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash
+```
+
+This clones the library to `~/.local/share/agentic` and installs the `agentic` CLI to `~/.local/bin`.
+
+### Manual Install (for forking)
+
 ```bash
 # 1. Fork this repo — it becomes your team's instruction library
 git clone https://github.com/your-org/agentic ~/agentic-library
@@ -48,11 +58,15 @@ git clone https://github.com/your-org/agentic ~/agentic-library
 cd ~/agentic-library
 just install
 # (installs to ~/.local/bin — add to PATH if needed)
+```
 
-# 3. Pick a profile
+### Deploy to a Project
+
+```bash
+# List available profiles
 agentic list profiles
 
-# 4. Deploy to your project
+# Deploy to your project
 agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# install.sh — Remote installer for the agentic library
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash
+#   curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash -s -- --dir ~/my-agentic
+#   curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash -s -- --global
+#
+# Options:
+#   --dir PATH    Install library to PATH (default: ~/.agentic)
+#   --global      Install CLI to /usr/local/bin instead of ~/.local/bin
+#   --branch REF  Clone specific branch/tag (default: main)
+#   --help        Show this help
+#
+set -euo pipefail
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+DEFAULT_INSTALL_DIR="$HOME/.local/share/agentic"
+DEFAULT_BRANCH="main"
+REPO_URL="https://github.com/soulcodex/agentic.git"
+
+# ── Output helpers ────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+die() {
+  echo -e "${RED}Error:${NC} $*" >&2
+  exit 1
+}
+
+info() {
+  echo -e "${BLUE}==>${NC} $*"
+}
+
+success() {
+  echo -e "${GREEN}==>${NC} $*"
+}
+
+warn() {
+  echo -e "${YELLOW}Warning:${NC} $*"
+}
+
+# ── Dependency checks ─────────────────────────────────────────────────────────
+check_dependencies() {
+  local missing=()
+
+  command -v git >/dev/null 2>&1 || missing+=("git")
+  command -v bash >/dev/null 2>&1 || missing+=("bash")
+
+  # Check for just (required for install)
+  if ! command -v just >/dev/null 2>&1; then
+    missing+=("just")
+  fi
+
+  # Check for yq (required by agentic)
+  if ! command -v yq >/dev/null 2>&1; then
+    missing+=("yq")
+  fi
+
+  # Check for jq (required by agentic)
+  if ! command -v jq >/dev/null 2>&1; then
+    missing+=("jq")
+  fi
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo ""
+    die "Missing required tools: ${missing[*]}
+
+Install them first:
+  macOS:   brew install ${missing[*]}
+  Ubuntu:  sudo apt install ${missing[*]}
+  Arch:    sudo pacman -S ${missing[*]}
+
+Then re-run this installer."
+  fi
+}
+
+# ── Help ──────────────────────────────────────────────────────────────────────
+show_help() {
+  cat <<'EOF'
+agentic installer — Install the agentic library and CLI
+
+Usage:
+  curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash
+  curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash -s -- [options]
+
+Options:
+  --dir PATH    Install library to PATH (default: ~/.local/share/agentic)
+  --global      Install CLI to /usr/local/bin instead of ~/.local/bin
+  --branch REF  Clone specific branch/tag (default: main)
+  --help        Show this help
+
+Examples:
+  # Default install (library to ~/.local/share/agentic, CLI to ~/.local/bin)
+  curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash
+
+  # Install to custom directory
+  curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash -s -- --dir ~/code/agentic
+
+  # Install CLI globally (requires sudo)
+  curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash -s -- --global
+
+What this does:
+  1. Clones the agentic repository to the specified directory
+  2. Installs the 'agentic' CLI to your PATH
+  3. Verifies the installation
+
+After installation:
+  agentic list profiles    # See available profiles
+  agentic --help           # Full command reference
+EOF
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+main() {
+  local install_dir="$DEFAULT_INSTALL_DIR"
+  local cli_target="local"
+  local branch="$DEFAULT_BRANCH"
+
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dir)
+        install_dir="$2"
+        shift 2
+        ;;
+      --global)
+        cli_target="global"
+        shift
+        ;;
+      --branch)
+        branch="$2"
+        shift 2
+        ;;
+      --help|-h)
+        show_help
+        exit 0
+        ;;
+      *)
+        die "Unknown option: $1. Use --help for usage."
+        ;;
+    esac
+  done
+
+  # Expand ~ in install_dir
+  install_dir="${install_dir/#\~/$HOME}"
+
+  echo ""
+  echo "  ╭─────────────────────────────────────╮"
+  echo "  │     agentic library installer       │"
+  echo "  ╰─────────────────────────────────────╯"
+  echo ""
+
+  # Check dependencies
+  info "Checking dependencies..."
+  check_dependencies
+  success "All dependencies found"
+
+  # Clone or update repository
+  if [[ -d "$install_dir/.git" ]]; then
+    info "Updating existing installation at $install_dir..."
+    cd "$install_dir"
+    git fetch origin
+    git checkout "$branch"
+    git pull origin "$branch"
+    success "Updated to latest $branch"
+  else
+    if [[ -d "$install_dir" ]]; then
+      die "Directory exists but is not a git repo: $install_dir
+Remove it first or choose a different --dir"
+    fi
+
+    info "Cloning agentic library to $install_dir..."
+    git clone --branch "$branch" "$REPO_URL" "$install_dir"
+    success "Cloned successfully"
+  fi
+
+  cd "$install_dir"
+
+  # Install CLI
+  info "Installing agentic CLI..."
+  if [[ "$cli_target" == "global" ]]; then
+    just install global
+  else
+    just install
+  fi
+
+  # Verify installation
+  echo ""
+  if command -v agentic >/dev/null 2>&1; then
+    success "Installation complete!"
+    echo ""
+    echo "  Library: $install_dir"
+    echo "  CLI:     $(command -v agentic)"
+    echo ""
+    echo "  Get started:"
+    echo "    agentic list profiles"
+    echo "    agentic deploy <profile> <target> <vendors>"
+    echo ""
+  else
+    warn "CLI installed but not found in PATH"
+    echo ""
+    echo "  Add this to your shell profile (~/.bashrc, ~/.zshrc):"
+    if [[ "$cli_target" == "global" ]]; then
+      echo "    export PATH=\"/usr/local/bin:\$PATH\""
+    else
+      echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+    fi
+    echo ""
+    echo "  Then restart your shell or run:"
+    echo "    source ~/.bashrc  # or ~/.zshrc"
+    echo ""
+  fi
+}
+
+main "$@"

--- a/tooling/lib/index.sh
+++ b/tooling/lib/index.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # index.sh — Rebuilds index/skills.json and index/fragments.json
 # Called by: just index
+#
+# Only updates files when content actually changes (ignoring generated_at timestamp)
+# to avoid noise in git diffs.
 set -euo pipefail
 
 LIBRARY=""
@@ -16,11 +19,39 @@ done
 
 INDEX_DIR="$LIBRARY/index"
 mkdir -p "$INDEX_DIR"
-GENERATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Writes JSON to file only if content (excluding generated_at) has changed.
+# If content changed, updates generated_at to current time.
+# If content unchanged, leaves file untouched.
+write_if_changed() {
+  local file="$1"
+  local new_json="$2"
+
+  if [[ -f "$file" ]]; then
+    # Extract existing content without generated_at for comparison
+    local existing_content
+    existing_content=$(jq 'del(.generated_at)' "$file" 2>/dev/null || echo "{}")
+    local new_content
+    new_content=$(echo "$new_json" | jq 'del(.generated_at)')
+
+    if [[ "$existing_content" == "$new_content" ]]; then
+      # Content unchanged, don't update file
+      return 1
+    fi
+  fi
+
+  # Content changed (or new file), write with current timestamp
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  echo "$new_json" | jq --arg ts "$timestamp" '.generated_at = $ts' > "$file"
+  return 0
+}
 
 # ── Skills index ──────────────────────────────────────────────────────────────
 build_skills_index() {
-  local skills_json='{"version":"1.0.0","generated_at":"'"$GENERATED_AT"'","skills":['
+  local skills_json='{"version":"1.0.0","generated_at":"","skills":['
   local first=true
 
   while IFS= read -r skill_file; do
@@ -49,13 +80,20 @@ build_skills_index() {
   done < <(find "$LIBRARY/skills" -name "SKILL.md" | sort)
 
   skills_json+="]}"
-  echo "$skills_json" | jq . > "$INDEX_DIR/skills.json"
-  echo "  Built: index/skills.json ($(find "$LIBRARY/skills" -name "SKILL.md" | wc -l | tr -d ' ') skills)"
+
+  local count
+  count=$(find "$LIBRARY/skills" -name "SKILL.md" | wc -l | tr -d ' ')
+
+  if write_if_changed "$INDEX_DIR/skills.json" "$skills_json"; then
+    echo "  Updated: index/skills.json ($count skills)"
+  else
+    echo "  Unchanged: index/skills.json ($count skills)"
+  fi
 }
 
 # ── Fragments index ───────────────────────────────────────────────────────────
 build_fragments_index() {
-  local frags_json='{"version":"1.0.0","generated_at":"'"$GENERATED_AT"'","fragments":['
+  local frags_json='{"version":"1.0.0","generated_at":"","fragments":['
   local first=true
 
   while IFS= read -r frag_file; do
@@ -76,8 +114,15 @@ build_fragments_index() {
   done < <(find "$LIBRARY/agents" -name "*.md" | sort)
 
   frags_json+="]}"
-  echo "$frags_json" | jq . > "$INDEX_DIR/fragments.json"
-  echo "  Built: index/fragments.json ($(find "$LIBRARY/agents" -name "*.md" | wc -l | tr -d ' ') fragments)"
+
+  local count
+  count=$(find "$LIBRARY/agents" -name "*.md" | wc -l | tr -d ' ')
+
+  if write_if_changed "$INDEX_DIR/fragments.json" "$frags_json"; then
+    echo "  Updated: index/fragments.json ($count fragments)"
+  else
+    echo "  Unchanged: index/fragments.json ($count fragments)"
+  fi
 }
 
 echo "Rebuilding indexes..."

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -81,7 +81,7 @@ assert_exit_code() {
 
 assert_stdout_contains() {
   local output="$1" pattern="$2" label="$3"
-  if echo "$output" | grep -qF "$pattern"; then
+  if echo "$output" | grep -qF -- "$pattern"; then
     pass "$label — stdout contains: $pattern"
   else
     fail "$label — stdout missing: $pattern"
@@ -1077,6 +1077,27 @@ T56_OUTPUT=$("$INSTALL" 2>&1) || true
 assert_stdout_contains "$T56_OUTPUT" "Usage:" "T56"
 assert_stdout_contains "$T56_OUTPUT" "install" "T56"
 assert_stdout_contains "$T56_OUTPUT" "uninstall" "T56"
+
+# T57 — remote install.sh: shows help
+run_test "T57 — remote install.sh: shows help"
+REMOTE_INSTALL="$LIBRARY/install.sh"
+T57_OUTPUT=$("$REMOTE_INSTALL" --help 2>&1) || true
+
+assert_stdout_contains "$T57_OUTPUT" "agentic installer" "T57"
+assert_stdout_contains "$T57_OUTPUT" "--dir" "T57"
+assert_stdout_contains "$T57_OUTPUT" "--global" "T57"
+assert_stdout_contains "$T57_OUTPUT" "--branch" "T57"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# INDEX STABILITY TESTS
+# ══════════════════════════════════════════════════════════════════════════════
+
+# T58 — index.sh: does not update unchanged content
+run_test "T58 — index.sh: does not update unchanged content"
+T58_OUTPUT=$(bash "$INDEX" --library "$LIBRARY" 2>&1)
+
+assert_stdout_contains "$T58_OUTPUT" "Unchanged: index/skills.json" "T58"
+assert_stdout_contains "$T58_OUTPUT" "Unchanged: index/fragments.json" "T58"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

- Add curl-based remote installation script
- Fix index generation to avoid constant `generated_at` timestamp changes
- Add new tests (193 total)

## Changes

### Remote Installer (`install.sh`)

New users can install with a single command:

```bash
curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash
```

Options:
- `--dir PATH` — Install library to custom path (default: `~/.agentic`)
- `--global` — Install CLI to `/usr/local/bin` instead of `~/.local/bin`
- `--branch REF` — Clone specific branch/tag

The script:
1. Checks dependencies (git, bash, just, yq, jq)
2. Clones or updates the repository
3. Runs `just install` to install the CLI
4. Verifies installation

### Index Timestamp Fix (`tooling/lib/index.sh`)

Previously, every `just index` run updated `generated_at`, causing git diff noise even with no content changes.

Now the index files only update when actual content changes:
- `Unchanged: index/skills.json (27 skills)` — no git diff
- `Updated: index/fragments.json (26 fragments)` — content changed, new timestamp

### Test Improvements

- Add T57: remote install.sh help output
- Add T58: index stability (unchanged detection)
- Fix `assert_stdout_contains()` to handle `--` prefixed patterns

## Chained From

This PR is based on #17 (global CLI) and should be merged after it.

## Testing

```bash
just test  # 193/193 passing
./install.sh --help  # verify help output
just index && git status  # should show no changes
```