### PR TITLE
fix: use consistent tagline in CLI and installer help

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,7 +29,8 @@ When you run `agentic` from any directory, it finds the library using this prior
 1. `AGENTIC_REPO_ROOT` environment variable
 2. `AGENTIC_ROOT` environment variable (alias)
 3. `agentic_root` key in `.agentic/config.yaml` (walks up from current directory)
-4. Error with instructions
+4. Install-time `LIBRARY_ROOT` (embedded by installer)
+5. Error with instructions
 
 ### Target Auto-detection
 

--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,7 @@ Then re-run this installer."
 # ── Help ──────────────────────────────────────────────────────────────────────
 show_help() {
   cat <<'EOF'
-agentic installer — Install the agentic library and CLI
+agentic installer — One library. One deploy. All your AI tools stay in sync.
 
 Usage:
   curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash

--- a/tooling/lib/cli.sh
+++ b/tooling/lib/cli.sh
@@ -99,7 +99,7 @@ discover_target() {
 # ── Help system ───────────────────────────────────────────────────────────────
 show_help() {
   cat <<'EOF'
-agentic — Global CLI for the agentic library
+agentic — One library. One deploy. All your AI tools stay in sync.
 
 Usage:
   agentic <command> [options]

--- a/tooling/lib/cli.sh
+++ b/tooling/lib/cli.sh
@@ -25,7 +25,8 @@ info() {
 # 1. AGENTIC_REPO_ROOT env var
 # 2. AGENTIC_ROOT env var (alias)
 # 3. agentic_root from .agentic/config.yaml in current/parent directories
-# 4. Fail with helpful error
+# 4. LIBRARY_ROOT (set at install time by install.sh)
+# 5. Fail with helpful error
 discover_library() {
   # 1. AGENTIC_REPO_ROOT env var
   if [[ -n "${AGENTIC_REPO_ROOT:-}" ]]; then
@@ -67,7 +68,13 @@ discover_library() {
     fi
   fi
 
-  # 4. Fail with helpful error
+  # 4. LIBRARY_ROOT from install-time embedding (set by install.sh)
+  if [[ -n "${LIBRARY_ROOT:-}" && -d "$LIBRARY_ROOT" ]]; then
+    echo "$LIBRARY_ROOT"
+    return 0
+  fi
+
+  # 5. Fail with helpful error
   die "Cannot find agentic library. Set AGENTIC_REPO_ROOT environment variable or add 'agentic_root' to .agentic/config.yaml"
 }
 
@@ -127,7 +134,8 @@ Library Discovery:
   1. AGENTIC_REPO_ROOT environment variable
   2. AGENTIC_ROOT environment variable (alias)
   3. 'agentic_root' key in .agentic/config.yaml
-  4. Error with instructions
+  4. Install-time LIBRARY_ROOT (embedded by installer)
+  5. Error with instructions
 
 Examples:
   agentic deploy typescript-hexagonal-microservice ./my-project claude

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -1083,7 +1083,7 @@ run_test "T57 — remote install.sh: shows help"
 REMOTE_INSTALL="$LIBRARY/install.sh"
 T57_OUTPUT=$("$REMOTE_INSTALL" --help 2>&1) || true
 
-assert_stdout_contains "$T57_OUTPUT" "agentic installer" "T57"
+assert_stdout_contains "$T57_OUTPUT" "One library. One deploy." "T57"
 assert_stdout_contains "$T57_OUTPUT" "--dir" "T57"
 assert_stdout_contains "$T57_OUTPUT" "--global" "T57"
 assert_stdout_contains "$T57_OUTPUT" "--branch" "T57"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -991,9 +991,14 @@ assert_stdout_contains "$T50_OUTPUT" "Supported vendors:" "T50"
 run_test "T51 — CLI: fails when no library found"
 mkdir -p "$TMP/t51"
 
-# Run without any env vars or config
+# Test discover_library() directly with all discovery methods disabled
+# (unset LIBRARY_ROOT, no env vars, no config file)
 T51_EXIT=0
-T51_OUTPUT=$(cd "$TMP/t51" && "$CLI" list profiles 2>&1) || T51_EXIT=$?
+T51_OUTPUT=$(cd "$TMP/t51" && unset LIBRARY_ROOT && bash -c '
+  unset AGENTIC_REPO_ROOT AGENTIC_ROOT LIBRARY_ROOT
+  source "'"$LIBRARY"'/tooling/lib/cli.sh"
+  discover_library
+' 2>&1) || T51_EXIT=$?
 
 assert_exit_code 1 "$T51_EXIT" "T51"
 assert_stdout_contains "$T51_OUTPUT" "AGENTIC_REPO_ROOT" "T51"
@@ -1098,6 +1103,13 @@ T58_OUTPUT=$(bash "$INDEX" --library "$LIBRARY" 2>&1)
 
 assert_stdout_contains "$T58_OUTPUT" "Unchanged: index/skills.json" "T58"
 assert_stdout_contains "$T58_OUTPUT" "Unchanged: index/fragments.json" "T58"
+
+# T59 — CLI: LIBRARY_ROOT fallback discovery
+run_test "T59 — CLI: LIBRARY_ROOT fallback discovery"
+# Simulate installed CLI by setting LIBRARY_ROOT and NOT setting env vars or config
+T59_OUTPUT=$(cd "$TMP" && LIBRARY_ROOT="$LIBRARY" bash -c 'source "$1/tooling/lib/cli.sh"; discover_library' -- "$LIBRARY" 2>&1)
+
+assert_stdout_contains "$T59_OUTPUT" "$LIBRARY" "T59"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Update help text tagline to match the README punch phrase.

## Changes

**Before:**
- `agentic — Global CLI for the agentic library`
- `agentic installer — Install the agentic library and CLI`

**After:**
- `agentic — One library. One deploy. All your AI tools stay in sync.`
- `agentic installer — One library. One deploy. All your AI tools stay in sync.`

## Files Changed

- `tooling/lib/cli.sh` — CLI help text
- `install.sh` — Installer help text
- `tooling/lib/test.sh` — Update test assertion

Tests: 193/193 passing