### PR TITLE
fix(docs): update outdated ./agentic references to agentic switch

### DIFF
--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -362,7 +362,7 @@ profile: "${PROFILE}"
 profile_version: "${PROFILE_VER}"
 composed_at: "${GENERATED_AT}"
 mode: lean
-library_path: "${LIBRARY}"
+agentic_root: "${LIBRARY}"
 active_vendors: []
 LOCK
     else
@@ -375,7 +375,7 @@ profile: "${PROFILE}"
 profile_version: "${PROFILE_VER}"
 composed_at: "${GENERATED_AT}"
 mode: full
-library_path: "${LIBRARY}"
+agentic_root: "${LIBRARY}"
 active_vendors: []
 LOCK
     fi
@@ -579,7 +579,7 @@ compose_nested() {
     echo "profile_version: \"${PROFILE_VER}\""
     echo "composed_at: \"${GENERATED_AT}\""
     echo "mode: ${compose_mode}"
-    echo "library_path: \"${LIBRARY}\""
+    echo "agentic_root: \"${LIBRARY}\""
     echo "active_vendors: []"
     echo "structure: nested"
     echo "tiers:"

--- a/tooling/lib/deploy-skills.sh
+++ b/tooling/lib/deploy-skills.sh
@@ -100,7 +100,7 @@ symlinks are created when you switch vendors:
 .agents/skills   → ../.agentic/skills   (Codex)
 ```
 
-Run `./agentic <vendor>` to switch vendors and update symlinks.
+Run `agentic switch <vendor>` to switch vendors and update symlinks.
 
 ## Available Skills
 

--- a/tooling/lib/sync.sh
+++ b/tooling/lib/sync.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # sync.sh — Regenerates target project from local profile
-# Called by: ./agentic sync
+# Called by: agentic sync
 # Uses: .agentic/profile.yaml (local customizable profile)
-#       .agentic/config.yaml (library_path, active_vendors)
+#       .agentic/config.yaml (agentic_root, active_vendors)
 set -euo pipefail
 
 # ── Argument parsing ──────────────────────────────────────────────────────────

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -269,4 +269,4 @@ if [[ -n "$CURRENT_VENDORS" && "$CURRENT_VENDORS" != "${VENDORS[*]}" ]]; then
   echo "Previous vendors: $CURRENT_VENDORS"
 fi
 echo ""
-echo "Note: Symlinks are gitignored. After cloning, run './agentic ${VENDORS[*]}' to recreate them."
+echo "Note: Symlinks are gitignored. After cloning, run 'agentic switch ${VENDORS[*]}' to recreate them."

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # vendor-switch.sh — Switches the active AI vendor(s) in a target project
 # Called by: just vendor-switch <target> <vendors>
-#            TARGET/agentic <vendor[,vendor...]|list|sync>
-# Supports multiple vendors: ./agentic claude,copilot or ./agentic claude copilot
+#            agentic switch <vendor[,vendor...]|list|sync>
+# Supports multiple vendors: agentic switch claude,copilot or agentic switch claude copilot
 set -euo pipefail
 
 # ── Argument parsing ──────────────────────────────────────────────────────────

--- a/vendors/_schema/capability-matrix.md
+++ b/vendors/_schema/capability-matrix.md
@@ -74,7 +74,7 @@ The agentic library uses a symlink-based vendor switching system:
 2. **Skills**: Deployed once to `.agentic/skills/`, symlinked to vendor-specific paths
 3. **Entrypoints**: Vendor config files (CLAUDE.md, opencode.json, etc.) are symlinks
 4. **Switching**: Only symlinks change — no file movement or copying
-5. **Git**: Symlinks are gitignored; recreate locally via `./agentic <vendor>`
+5. **Git**: Symlinks are gitignored; recreate locally via `agentic switch <vendor>`
 
 ## Update Log
 


### PR DESCRIPTION
## Summary

Updates all remaining references to the legacy `./agentic` wrapper script and `library_path` config key to use the new global CLI conventions.

## Changes

### Script comments & generated output
- `tooling/lib/vendor-switch.sh`: Update header comment from `TARGET/agentic` to `agentic switch`
- `tooling/lib/vendor-switch.sh`: Update post-switch message from `./agentic ${VENDORS}` → `agentic switch ${VENDORS}`
- `tooling/lib/sync.sh`: Update comment to reference `agentic_root` not `library_path`
- `tooling/lib/deploy-skills.sh`: Update generated README from `./agentic <vendor>` → `agentic switch <vendor>`
- `vendors/_schema/capability-matrix.md`: Update documentation from `./agentic <vendor>` → `agentic switch <vendor>`

### Config generation (important fix)
- `tooling/lib/compose.sh`: Generate `agentic_root` instead of `library_path` in `.agentic/config.yaml`

This last change is critical: the global CLI's `discover_library()` function looks for `agentic_root` in config.yaml. Previously, `compose.sh` was still generating `library_path`, which meant newly composed projects wouldn't work correctly with the global CLI until the user manually renamed the key.

Legacy `library_path` config files are still supported via fallback in `sync.sh`.

## Testing

All 194 tests pass.