### PR TITLE
feat(fragments+skills): enrich architecture guardrails and add persist-plan skill

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to agentic
+
+Thank you for your interest in contributing to agentic! This library serves as a vendor-agnostic foundation for AI agent configurations, and we welcome contributions that improve its quality, coverage, and usability.
+
+## Prerequisites
+
+Before contributing, ensure you have the following tools installed:
+
+- **just** — command runner (install via `brew install just` or your package manager)
+- **yq** — YAML processor (install via `brew install yq` or your package manager)
+- **jq** — JSON processor (install via `brew install jq` or your package manager)
+- **bash** — shell (version 4.0 or higher)
+
+Run `just setup` to verify all dependencies are installed (macOS can auto-install them).
+
+## Fork & Local Setup
+
+1. **Fork the repository** on GitHub
+2. **Clone your fork locally:**
+   ```bash
+   git clone https://github.com/your-username/agentic.git
+   cd agentic
+   ```
+3. **Create a feature branch:**
+   ```bash
+   git checkout -b feat/your-feature-name
+   # or
+   git checkout -b fix/your-fix-description
+   ```
+
+## Quality Checks
+
+**Before opening a pull request, you must run:**
+
+```bash
+just lint && just test
+```
+
+- `just lint` — validates all fragments, profiles, and adapter files against schemas
+- `just test` — runs 29+ assertions to ensure tooling works correctly
+
+All tests must pass before your PR can be merged.
+
+## Fragment Authoring Rules
+
+Fragments are composable building blocks in `agents/`. Each fragment must be:
+
+- **Self-contained** — no cross-references to other fragments, no project-specific paths, no hardcoded credentials
+- **Properly structured** — starts with a single H2 heading (`## Section Name`) matching its purpose
+- **Concise** — must not exceed 300 lines; split larger content into focused fragments
+- **Tokenized** — use `{TOKEN_NAME}` syntax for project-specific values substituted at compose time (e.g., `{BUILD_CMD}`, `{PROJECT_NAME}`)
+
+## Skill Authoring Rules
+
+Skills are reusable agent skill definitions in `skills/`. Each skill directory must have:
+
+- **SKILL.md** with valid YAML frontmatter containing:
+  - `name` — skill identifier
+  - `description` — what the skill does
+  - `version` — SemVer format (MAJOR.MINOR.PATCH)
+  - `tags` — searchable tags
+  - `vendor_support` — supported vendors
+- **resources:** declaration in frontmatter listing all supporting files
+- All referenced files must exist in the skill directory
+
+## Commit Conventions
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+```
+
+**Types:**
+- `feat` — new feature (fragment, profile, skill, vendor adapter)
+- `fix` — bug fix in existing content
+- `chore` — maintenance tasks (CI, tooling, index updates)
+- `docs` — documentation changes
+- `refactor` — code restructuring without behavior change
+
+**Scopes:**
+- `fragments` — changes to agent fragments
+- `skills` — changes to skills
+- `profiles` — changes to profile definitions
+- `vendors` — changes to vendor adapters
+- `tooling` — changes to scripts or CLI
+- `index` — changes to index files
+- `ci` — changes to CI/CD configuration
+
+**Examples:**
+```
+feat(fragments): add new code review fragment
+feat(profiles): add python-fastapi-async profile
+fix(skills): correct skill description in SKILL.md
+chore(index): rebuild index after fragment addition
+chore(ci): add validate workflow for PRs
+```
+
+## Index Updates
+
+After adding or modifying any fragment or skill, **you must regenerate the index**:
+
+```bash
+just index
+```
+
+This updates `index/skills.json` and `index/fragments.json`. Commit these changes alongside your source modifications in the same commit.
+
+## Pull Request Checklist
+
+Before submitting your PR, verify:
+
+- [ ] `just lint` passes with no errors
+- [ ] `just test` passes (all assertions green)
+- [ ] `just index` was run if you added/modified fragments or skills
+- [ ] Commit message follows Conventional Commits format
+- [ ] Documentation updated if adding new features
+- [ ] New fragments/skills follow authoring rules (self-contained, H2 heading, <300 lines, proper frontmatter)
+
+## Getting Help
+
+- Open an issue for bugs or feature requests
+- Use discussions for questions
+- Check existing issues and discussions before posting
+
+We appreciate every contribution, no matter how small!

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+---
+name: Bug Report
+description: Report something that isn't working correctly
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the issue
+      placeholder: Describe what's broken or not working
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How to reproduce the issue
+      placeholder: |
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should happen
+      placeholder: Describe what you expected to happen
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happens
+      placeholder: Describe what actually happened
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      description: Your operating system (e.g., macOS 14.0, Ubuntu 22.04, Windows 11)
+      placeholder: macOS 14.0
+  - type: input
+    id: just-version
+    attributes:
+      label: just version
+      description: Run `just --version` to get this
+      placeholder: 1.x.x
+  - type: input
+    id: yq-version
+    attributes:
+      label: yq version
+      description: Run `yq --version` to get this
+      placeholder: 4.x.x
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem (error messages, screenshots, etc.)
+      placeholder: Add any other relevant information here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/soulcodex/agentic/tree/main/docs
+    about: Read the docs before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+---
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: Describe the feature you'd like to see
+      placeholder: What feature do you want?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / Use Case
+      description: Why do you need this feature? What problem does it solve?
+      placeholder: Describe the motivation or use case
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Proposed Implementation
+      description: How do you think this should be implemented?
+      placeholder: Describe your proposed implementation approach
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions you've considered?
+      placeholder: Describe any alternatives you've considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary of Changes
+
+<!-- Briefly describe what this PR does -->
+
+
+## Type of Change
+
+- [ ] feat - New feature (fragment, profile, skill, vendor adapter)
+- [ ] fix - Bug fix
+- [ ] chore - Maintenance task (tooling, CI, index)
+- [ ] docs - Documentation changes
+- [ ] refactor - Code restructuring
+
+## Checklist
+
+- [ ] `just lint` passes without errors
+- [ ] `just test` passes (all assertions pass)
+- [ ] `just index` was run (if fragments or skills were added/modified)
+- [ ] Documentation updated (if adding new features)
+- [ ] Commit message follows Conventional Commits format
+
+## Additional Notes
+
+<!-- Any other context about this PR -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported Versions
+
+Only the `main` branch is actively supported with security updates. We recommend always using the latest version from main.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| main    | :white_check_mark: |
+| other   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Private disclosure** — Do not open a public GitHub issue
+2. **GitHub Security Advisories** — Use [GitHub's private vulnerability reporting](https://github.com/soulcodex/agentic/security/advisories/new)
+3. **Email** — Alternatively, email security concerns to `security@example.com` (placeholder)
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact assessment
+- Any suggested fixes (optional)
+
+We aim to acknowledge reports within 48 hours and provide a timeline for fixes.
+
+## Security Warnings
+
+### No Code Execution from Untrusted Sources
+
+This library generates and outputs shell scripts, configuration files, and executable code that may be run by AI agents in your projects.
+
+**Do not:**
+- Use fragments or profiles from untrusted sources
+- Deploy this library to projects without reviewing the generated output
+- Trust AI-generated code without human review
+
+**Always:**
+- Review generated `AGENTS.md` and vendor files before committing
+- Run `just lint` and `just test` locally before deploying
+- Audit the output in your project's `.agentic/` directory
+
+## Best Practices
+
+- Fork this library and review all fragments before deploying to production projects
+- Use the `just compose --dry-run` option to preview generated content
+- Keep your fork updated with the latest changes from upstream

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 soulcodex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -149,4 +149,12 @@ Run `just setup` to check (and install on macOS) all required tools: `just`, `ba
 
 Contributions welcome — new fragments, profiles, vendor adapters, and skills. Run `just lint && just test` before opening a PR.
 
-MIT
+## Contributing
+
+Contributions are welcome! Please see our [Contributing Guide](.github/CONTRIBUTING.md) for details on how to set up the development environment, run quality checks, and submit pull requests.
+
+---
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/agents/architecture/cqrs.md
+++ b/agents/architecture/cqrs.md
@@ -79,6 +79,25 @@ The bus also provides a hook point for middleware: logging, validation, transact
   the write model's schema.
 - A stale read model is acceptable. The write model is the source of truth.
 
+### Contract & Schema Parity
+
+Every command or query that crosses a service boundary must have a versioned,
+machine-readable contract:
+
+- **Commands that enter via HTTP/gRPC/message queue** must have a corresponding request schema
+  (OpenAPI, Protobuf, JSON Schema). The schema is the single source of truth — generated code
+  is derived from it, not the reverse.
+- **Query responses that cross service boundaries** must have a versioned response schema.
+  Query handlers return DTOs whose shape is governed by the contract.
+- Validate generated artifacts (e.g., `oapi-codegen`, `protoc`, `spectral lint`) before
+  shipping. Document the generation command in the project's README or `Makefile`/`justfile`
+  so any contributor can reproduce it.
+- **Schema drift is a breaking change**: removing or renaming a field in a command or query
+  DTO that is part of a published contract requires a migration plan (version the route or
+  message type, run old and new in parallel, retire old after consumers migrate).
+- Stale contracts are worse than no contracts. Update the schema in the same commit as the
+  handler change — never after.
+
 ### File Layout
 
 ```

--- a/agents/architecture/ddd.md
+++ b/agents/architecture/ddd.md
@@ -58,6 +58,49 @@ A bounded context defines the boundary within which a domain model applies.
 - Input validation (format, required fields) happens at the boundary (controller/handler),
   not in the domain.
 
+### Pre-Modeling Checklist
+
+Answer these questions **before** writing any model, aggregate, or handler. Capture the
+answers in the PR description or a short design note so the reasoning stays discoverable.
+
+1. **Context ownership** — which bounded context owns this change? Where do the invariants
+   naturally live?
+2. **Business capabilities** — which capabilities are affected? Sketch a one-paragraph
+   use-case narrative referencing existing application services.
+3. **Aggregate boundaries** — what are the aggregates, their invariants, and their consistency
+   boundaries? Does the change require a new aggregate root or extend an existing one?
+4. **Cross-context interactions** — are there cross-context collaborations? If so, can they be
+   expressed via domain events or read models instead of synchronous imports? Prefer async
+   event hand-offs over direct cross-context calls.
+5. **Policy placement** — which policies belong to the domain layer (pure business rules) vs.
+   the application layer (orchestration, authorization, validation)? Document the decision.
+
+### Authorization Boundary
+
+Authorization is a cross-cutting concern — keep it entirely out of the domain:
+
+- Domain models must stay **ignorant of permissions and roles** so business invariants remain
+  pure and independently testable.
+- Define authorization interfaces and errors in an **infrastructure-agnostic shared package**
+  (e.g., `pkg/authorization`) — never inside domain packages.
+- Module-specific permissions and authorizers belong in the **application layer**; the domain
+  layer never calls them.
+- Concrete authorization adapters (e.g., OpenFGA, OPA, Casbin) live in infrastructure and
+  implement the interfaces — never imported directly by application services.
+- Permission-to-relation mappings are registered once at the **composition root** (wiring), not
+  scattered across handlers.
+
+### Shared Module Discipline
+
+A shared/common module must stay lean:
+
+- Limit it to truly cross-cutting primitives: base value objects, shared DTOs, error types, and
+  cross-context interface definitions.
+- If accepting a dependency would force the shared module to know about a specific bounded
+  context, push the abstraction down to that context instead.
+- Never place bounded-context business logic in a shared module to avoid duplication — duplication
+  is preferable to the wrong coupling.
+
 ### Anti-Patterns to Avoid
 
 - **Anemic Domain Model**: entities with only getters/setters and no behavior. Behavior belongs
@@ -66,3 +109,7 @@ A bounded context defines the boundary within which a domain model applies.
   the whole domain. Breaks transactional boundaries.
 - **Repository for every entity**: only aggregate roots have repositories. Child entities are
   accessed through the root.
+- **Authorization in domain**: checking permissions inside aggregate methods or domain services
+  couples business rules to infrastructure concerns and breaks testability.
+- **Cross-context direct imports**: importing another bounded context's domain or infrastructure
+  package directly. Use well-defined ports, shared DTOs, or domain events instead.

--- a/agents/architecture/eda.md
+++ b/agents/architecture/eda.md
@@ -124,3 +124,35 @@ Event schemas are public contracts; breaking changes break consumers without war
 - Emit a metric for **processing duration** per event type and **error rate** per consumer.
 - Log the event `id`, `type`, and `correlation_id` at the start and end of every consumer
   handler — never lose the ability to trace an event through the system.
+
+### Dependency & Local Parity
+
+- Only adopt a message broker or external event store if it **publishes a Docker image**
+  (official or community). This ensures integration tests can spin up the dependency
+  deterministically without mocks and without relying on shared/remote environments.
+- For SaaS brokers that lack a Docker image, build a lightweight stub/mock container and
+  treat it as the canonical local and CI target.
+- Document broker startup, teardown, and any required seeding in the project's compose file
+  and README so any contributor can reproduce a full local environment with a single command.
+
+### Intentional Planning Before Implementation
+
+Before writing any producer or consumer, capture and communicate:
+
+1. **Which events are produced and consumed** — name them explicitly in past tense.
+2. **Which bounded contexts or services are affected** — map ownership of each event type.
+3. **Correlation and tracing strategy** — how will `correlation_id` flow from the originating
+   request through every downstream handler?
+4. **Failure and retry contract** — what is the retry policy, DLQ owner, and replay mechanism?
+
+Skipping this step leads to undocumented event flows that are expensive to debug and nearly
+impossible to hand off to other agents or team members.
+
+### Document Flows When They Change
+
+When event flows, choreography boundaries, consumer ownership, or schema contracts change:
+
+- Update the relevant architecture diagrams or flow documentation in the same PR.
+- Update the schema registry or contract files alongside the code change.
+- Stale EDA documentation is the most dangerous kind of drift: a consumer reading an outdated
+  flow diagram may silently process events incorrectly.

--- a/agents/architecture/event-sourcing.md
+++ b/agents/architecture/event-sourcing.md
@@ -74,6 +74,33 @@ Event handlers and projection updates must be idempotent:
 - Track processed event IDs to prevent double-processing.
 - Use database transactions to atomically update the projection and mark the event as processed.
 
+### Concurrency Safety
+
+Optimistic concurrency in the event store (version checks) is necessary but not sufficient:
+
+- **Test under race conditions**: append and projection-update paths must be exercised with
+  a race-condition detector (e.g., Go's `-race` flag, ThreadSanitizer, or equivalent). A
+  passing test suite without race detection does not qualify as validation for event-sourced
+  aggregates.
+- Use atomic database transactions to update a projection and mark its checkpoint in a single
+  operation — never two separate writes. A crash between them causes double-processing or
+  silent data loss.
+- Competing consumers reading the same stream partition must use optimistic locking or
+  upsert semantics; assume concurrent execution is the default, not the exception.
+
+### Event Schema as a Public Contract
+
+Events that cross service boundaries (published to a broker or event store consumed by
+external systems) are public contracts — treat them with the same discipline as API schemas:
+
+- **Define a versioned schema** (JSON Schema, Protobuf, Avro) for every published event type.
+  The schema is the source of truth; generated serialization code is derived from it.
+- **Breaking changes require a migration plan**: add a `v2` event type, run both versions in
+  parallel until all consumers have migrated, then retire `v1`. Never silently change the
+  shape of an existing event type.
+- **Internal events** (never leaving the service boundary) are lower risk, but still benefit
+  from schema definitions — they become external the moment a second consumer appears.
+
 ### When to Use Event Sourcing
 
 Good fit:

--- a/agents/architecture/hexagonal.md
+++ b/agents/architecture/hexagonal.md
@@ -77,3 +77,18 @@ src/
    with pure unit tests — no database, no HTTP, no time.
 4. **One adapter per port per deployment**: a port may have multiple adapters (real + test stub),
    but a running application wires exactly one adapter per port.
+5. **Wiring happens in exactly one place**: infrastructure components are only instantiated at
+   the composition root (e.g., `main`, `cmd/wire`, `AppModule`). No other layer creates concrete
+   adapters. This makes the dependency graph explicit and replaceable.
+6. **No circular dependencies**: before introducing a new import, verify the dependency graph
+   stays acyclic (tools: `madge`, `go mod graph`, `deptrac`, `import-cycles`). When the
+   direction is unclear, prefer events or DTO hand-offs over direct calls.
+7. **Package names express purpose, not implementation**: name packages by what they do
+   (`authorization`, `messaging`, `storage`), not by the technology behind them (`openfga`,
+   `kafka`, `postgres`). Place concrete implementations in subpackages named after the
+   technology (`authorization/openfga`, `storage/postgres`). This keeps the application layer
+   decoupled from infrastructure choices.
+8. **Application-layer errors are infrastructure-agnostic**: define meaningful error types at
+   the application boundary (e.g., `ErrNotFound`, `ErrPermissionDenied`). Never let
+   infrastructure-specific errors (SQL errors, HTTP status codes, driver errors) leak upward
+   through the port interface.

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-04T13:02:20Z",
+  "generated_at": "2026-03-06T18:21:19Z",
   "fragments": [
     {
       "name": "bff",
@@ -14,35 +14,35 @@
       "group": "architecture",
       "path": "agents/architecture/cqrs.md",
       "heading": "CQRS (Command Query Responsibility Segregation)",
-      "words": 420
+      "words": 594
     },
     {
       "name": "ddd",
       "group": "architecture",
       "path": "agents/architecture/ddd.md",
       "heading": "Domain-Driven Design (DDD)",
-      "words": 484
+      "words": 852
     },
     {
       "name": "eda",
       "group": "architecture",
       "path": "agents/architecture/eda.md",
       "heading": "Event-Driven Architecture",
-      "words": 901
+      "words": 1163
     },
     {
       "name": "event-sourcing",
       "group": "architecture",
       "path": "agents/architecture/event-sourcing.md",
       "heading": "Event Sourcing",
-      "words": 411
+      "words": 647
     },
     {
       "name": "hexagonal",
       "group": "architecture",
       "path": "agents/architecture/hexagonal.md",
       "heading": "Hexagonal Architecture",
-      "words": 421
+      "words": 568
     },
     {
       "name": "microservices",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-04T13:02:20Z",
+  "generated_at": "2026-03-06T18:21:18Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -36,6 +36,19 @@
         "agentic",
         "meta",
         "deployment"
+      ]
+    },
+    {
+      "name": "persist-plan",
+      "group": "agentic",
+      "path": "skills/agentic/persist-plan/SKILL.md",
+      "description": "Persists the current or completed plan as a structured Markdown file under .agentic/plans/ with a datestamped, slugged f",
+      "version": "1.0.0",
+      "tags": [
+        "agentic",
+        "planning",
+        "architecture",
+        "multi-agent"
       ]
     },
     {

--- a/skills/agentic/persist-plan/SKILL.md
+++ b/skills/agentic/persist-plan/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: persist-plan
+description: >
+  Persists the current or completed plan as a structured Markdown file under
+  .agentic/plans/ with a datestamped, slugged filename and registers it in the
+  plans index. Enables multi-agent setups to discover past architectural decisions
+  and plans without re-deriving context.
+  Invoked when the user says "save this plan", "persist the plan", "record this decision",
+  or at the end of any planning session that produced actionable architectural decisions.
+version: 1.0.0
+tags:
+  - agentic
+  - planning
+  - architecture
+  - multi-agent
+resources:
+  - plan-template.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Persist Plan Skill
+
+Capture a plan or architectural decision as a discoverable, structured file so that
+any agent or team member can find it later without re-deriving the context.
+
+### Step 1 — Gather Plan Metadata
+
+Collect (or confirm) the following before writing:
+
+1. **Title** — a short, descriptive phrase (e.g., "Introduce CQRS in order service",
+   "Migrate auth to hexagonal ports"). Used for the filename and H1 heading.
+2. **Type** — one of: `feature`, `refactor`, `architecture`, `investigation`, `decision`.
+3. **Status** — one of: `draft`, `in-progress`, `completed`, `superseded`.
+4. **Affected areas** — which modules, bounded contexts, or services does this plan touch?
+5. **Author** — the agent name or human handle that produced the plan.
+
+### Step 2 — Derive the Filename
+
+Build the filename as:
+
+```
+YYYY-MM-DD-{kebab-case-title}.md
+```
+
+Examples:
+```
+2026-03-06-introduce-cqrs-in-order-service.md
+2026-03-06-migrate-auth-to-hexagonal-ports.md
+```
+
+- Use today's date in `YYYY-MM-DD` format.
+- Slugify the title: lowercase, replace spaces and special characters with hyphens,
+  strip leading/trailing hyphens.
+- If a file with the same slug already exists for today, append `-2`, `-3`, etc.
+
+### Step 3 — Write the Plan File
+
+Save to `.agentic/plans/{filename}` using the template from `plan-template.md`.
+
+Mandatory sections:
+
+```markdown
+# {Title}
+
+**Date**: YYYY-MM-DD
+**Type**: feature | refactor | architecture | investigation | decision
+**Status**: draft | in-progress | completed | superseded
+**Affected**: [list of modules / bounded contexts / services]
+**Author**: {agent-name or handle}
+
+## Context
+
+What situation, problem, or question prompted this plan?
+Be specific — a reader unfamiliar with the moment must understand the trigger.
+
+## Goals
+
+What does this plan aim to achieve?
+Use bullet points. Each goal must be verifiable (done / not done).
+
+## Approach
+
+How will the goals be achieved?
+Include the key decisions made, alternatives considered, and the rationale for
+the chosen direction. Reference relevant fragments, ADRs, or tickets where applicable.
+
+## Steps
+
+Ordered list of concrete tasks derived from this plan.
+
+1. ...
+2. ...
+
+## Risks & Open Questions
+
+- Any unknowns, blockers, or decisions that still need to be made.
+
+## Outcome
+
+(Fill in when status moves to `completed` or `superseded`.)
+What was the actual result? Did the plan change during execution? Why?
+```
+
+### Step 4 — Update the Plans Index
+
+After writing the file, append a one-line entry to `.agentic/plans/INDEX.md`.
+Create the file if it does not exist, with this header:
+
+```markdown
+# Plans Index
+
+| Date | Title | Type | Status | File |
+|------|-------|------|--------|------|
+```
+
+Append the new row:
+
+```markdown
+| YYYY-MM-DD | {Title} | {Type} | {Status} | [{filename}]({filename}) |
+```
+
+The index allows any agent to list all past plans with a single file read, without
+scanning every individual plan file.
+
+### Step 5 — Confirm
+
+Report back:
+- The full path of the written plan file.
+- Whether the INDEX.md was created or updated.
+- The plan's current status so the user knows whether to mark it `completed`.

--- a/skills/agentic/persist-plan/plan-template.md
+++ b/skills/agentic/persist-plan/plan-template.md
@@ -1,0 +1,38 @@
+# {Title}
+
+**Date**: {YYYY-MM-DD}
+**Type**: feature | refactor | architecture | investigation | decision
+**Status**: draft | in-progress | completed | superseded
+**Affected**: {modules / bounded contexts / services}
+**Author**: {agent-name or handle}
+
+## Context
+
+What situation, problem, or question prompted this plan?
+Be specific — a reader unfamiliar with the moment must understand the trigger.
+
+## Goals
+
+- Goal 1 (verifiable: done / not done)
+- Goal 2
+
+## Approach
+
+How will the goals be achieved? Include key decisions, alternatives considered,
+and rationale. Reference relevant fragments, ADRs, or tickets.
+
+## Steps
+
+1. Step one
+2. Step two
+3. Step three
+
+## Risks & Open Questions
+
+- Unknown or blocker 1
+- Decision still pending: ...
+
+## Outcome
+
+(Fill in when status moves to `completed` or `superseded`.)
+What was the actual result? Did the plan change during execution? Why?


### PR DESCRIPTION
## Summary

Extracts vendor-agnostic guardrails from a real production AGENTS.md and backports
them as additive, self-contained improvements to the five architecture fragments.
Adds a new `persist-plan` agentic skill that enables multi-agent setups to discover
past plans and architectural decisions without re-deriving context.

## Fragment changes

### `agents/architecture/ddd.md`
- **Pre-Modeling Checklist** — 5-question workflow (context ownership, business capabilities, aggregate boundaries, cross-context interactions, policy placement) that agents must answer *before* writing any model or handler. Answers are captured in the PR or a design note.
- **Authorization Boundary** — domain models stay ignorant of permissions/roles; auth interfaces live in an infra-agnostic shared package; application layer consumes them; composition root registers mappings.
- **Shared Module Discipline** — limits shared/common to truly cross-cutting primitives; pushes bounded-context-specific abstractions down to the owning context.
- **Two new anti-patterns** — "Authorization in domain" and "Cross-context direct imports".

### `agents/architecture/hexagonal.md`
- **Rule 5 — Wiring at composition root** — infra components instantiated only in `main`/`cmd`/`wire`; no other layer creates concrete adapters.
- **Rule 6 — No circular dependencies** — verify graph before merging; prefer events or DTO hand-offs when direction is unclear.
- **Rule 7 — Package names express purpose** — packages named by capability (`authorization`, `storage`); concrete impls in technology-named subpackages (`authorization/openfga`).
- **Rule 8 — Application-layer errors are infra-agnostic** — meaningful error types at the port boundary; infrastructure errors never leak upward.

### `agents/architecture/cqrs.md`
- **Contract & Schema Parity** — versioned machine-readable schemas for every boundary-crossing command/query; schema drift treated as a breaking change; contract updated in the same commit as the handler.

### `agents/architecture/eda.md`
- **Dependency & Local Parity** — brokers/event stores must have a Docker image for deterministic local and CI testing; SaaS-only services require a stub container.
- **Intentional Planning Before Implementation** — four-point checklist (event names, ownership, tracing strategy, failure contract) before writing any producer or consumer.
- **Document Flows When They Change** — flow diagrams and schema contracts updated in the same PR as code changes; stale EDA docs called out as the most dangerous drift.

### `agents/architecture/event-sourcing.md`
- **Concurrency Safety** — race-condition testing mandatory for append and projection paths; atomic DB transactions for projection + checkpoint; optimistic locking assumed concurrent by default.
- **Event Schema as Public Contract** — versioned schemas for published events; `v2` migration pattern; internal events treated as pre-public.

## New skill

### `skills/agentic/persist-plan/`
- `SKILL.md` — five-step skill: gather metadata → derive datestamped slug filename → write structured plan to `.agentic/plans/` → update `INDEX.md` registry → confirm.
- `plan-template.md` — canonical template with mandatory sections: Context, Goals, Approach, Steps, Risks & Open Questions, Outcome.
- Grouped under `skills/agentic/` alongside `compose-agents-md`, `configure-mcp`, `deploy-config`.

## Quality gates

```
just lint   → Lint PASSED — no issues found (26 fragments, 28 skills, all profiles and adapters)
just index  → index/skills.json (28 skills), index/fragments.json (26 fragments)
```