### PR TITLE
chore(oss): add OSS license and community files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to agentic
+
+Thank you for your interest in contributing to agentic! This library serves as a vendor-agnostic foundation for AI agent configurations, and we welcome contributions that improve its quality, coverage, and usability.
+
+## Prerequisites
+
+Before contributing, ensure you have the following tools installed:
+
+- **just** — command runner (install via `brew install just` or your package manager)
+- **yq** — YAML processor (install via `brew install yq` or your package manager)
+- **jq** — JSON processor (install via `brew install jq` or your package manager)
+- **bash** — shell (version 4.0 or higher)
+
+Run `just setup` to verify all dependencies are installed (macOS can auto-install them).
+
+## Fork & Local Setup
+
+1. **Fork the repository** on GitHub
+2. **Clone your fork locally:**
+   ```bash
+   git clone https://github.com/your-username/agentic.git
+   cd agentic
+   ```
+3. **Create a feature branch:**
+   ```bash
+   git checkout -b feat/your-feature-name
+   # or
+   git checkout -b fix/your-fix-description
+   ```
+
+## Quality Checks
+
+**Before opening a pull request, you must run:**
+
+```bash
+just lint && just test
+```
+
+- `just lint` — validates all fragments, profiles, and adapter files against schemas
+- `just test` — runs 29+ assertions to ensure tooling works correctly
+
+All tests must pass before your PR can be merged.
+
+## Fragment Authoring Rules
+
+Fragments are composable building blocks in `agents/`. Each fragment must be:
+
+- **Self-contained** — no cross-references to other fragments, no project-specific paths, no hardcoded credentials
+- **Properly structured** — starts with a single H2 heading (`## Section Name`) matching its purpose
+- **Concise** — must not exceed 300 lines; split larger content into focused fragments
+- **Tokenized** — use `{TOKEN_NAME}` syntax for project-specific values substituted at compose time (e.g., `{BUILD_CMD}`, `{PROJECT_NAME}`)
+
+## Skill Authoring Rules
+
+Skills are reusable agent skill definitions in `skills/`. Each skill directory must have:
+
+- **SKILL.md** with valid YAML frontmatter containing:
+  - `name` — skill identifier
+  - `description` — what the skill does
+  - `version` — SemVer format (MAJOR.MINOR.PATCH)
+  - `tags` — searchable tags
+  - `vendor_support` — supported vendors
+- **resources:** declaration in frontmatter listing all supporting files
+- All referenced files must exist in the skill directory
+
+## Commit Conventions
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+```
+
+**Types:**
+- `feat` — new feature (fragment, profile, skill, vendor adapter)
+- `fix` — bug fix in existing content
+- `chore` — maintenance tasks (CI, tooling, index updates)
+- `docs` — documentation changes
+- `refactor` — code restructuring without behavior change
+
+**Scopes:**
+- `fragments` — changes to agent fragments
+- `skills` — changes to skills
+- `profiles` — changes to profile definitions
+- `vendors` — changes to vendor adapters
+- `tooling` — changes to scripts or CLI
+- `index` — changes to index files
+- `ci` — changes to CI/CD configuration
+
+**Examples:**
+```
+feat(fragments): add new code review fragment
+feat(profiles): add python-fastapi-async profile
+fix(skills): correct skill description in SKILL.md
+chore(index): rebuild index after fragment addition
+chore(ci): add validate workflow for PRs
+```
+
+## Index Updates
+
+After adding or modifying any fragment or skill, **you must regenerate the index**:
+
+```bash
+just index
+```
+
+This updates `index/skills.json` and `index/fragments.json`. Commit these changes alongside your source modifications in the same commit.
+
+## Pull Request Checklist
+
+Before submitting your PR, verify:
+
+- [ ] `just lint` passes with no errors
+- [ ] `just test` passes (all assertions green)
+- [ ] `just index` was run if you added/modified fragments or skills
+- [ ] Commit message follows Conventional Commits format
+- [ ] Documentation updated if adding new features
+- [ ] New fragments/skills follow authoring rules (self-contained, H2 heading, <300 lines, proper frontmatter)
+
+## Getting Help
+
+- Open an issue for bugs or feature requests
+- Use discussions for questions
+- Check existing issues and discussions before posting
+
+We appreciate every contribution, no matter how small!

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+---
+name: Bug Report
+description: Report something that isn't working correctly
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the issue
+      placeholder: Describe what's broken or not working
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How to reproduce the issue
+      placeholder: |
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should happen
+      placeholder: Describe what you expected to happen
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happens
+      placeholder: Describe what actually happened
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      description: Your operating system (e.g., macOS 14.0, Ubuntu 22.04, Windows 11)
+      placeholder: macOS 14.0
+  - type: input
+    id: just-version
+    attributes:
+      label: just version
+      description: Run `just --version` to get this
+      placeholder: 1.x.x
+  - type: input
+    id: yq-version
+    attributes:
+      label: yq version
+      description: Run `yq --version` to get this
+      placeholder: 4.x.x
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem (error messages, screenshots, etc.)
+      placeholder: Add any other relevant information here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/soulcodex/agentic/tree/main/docs
+    about: Read the docs before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+---
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: Describe the feature you'd like to see
+      placeholder: What feature do you want?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / Use Case
+      description: Why do you need this feature? What problem does it solve?
+      placeholder: Describe the motivation or use case
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Proposed Implementation
+      description: How do you think this should be implemented?
+      placeholder: Describe your proposed implementation approach
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions you've considered?
+      placeholder: Describe any alternatives you've considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary of Changes
+
+<!-- Briefly describe what this PR does -->
+
+
+## Type of Change
+
+- [ ] feat - New feature (fragment, profile, skill, vendor adapter)
+- [ ] fix - Bug fix
+- [ ] chore - Maintenance task (tooling, CI, index)
+- [ ] docs - Documentation changes
+- [ ] refactor - Code restructuring
+
+## Checklist
+
+- [ ] `just lint` passes without errors
+- [ ] `just test` passes (all assertions pass)
+- [ ] `just index` was run (if fragments or skills were added/modified)
+- [ ] Documentation updated (if adding new features)
+- [ ] Commit message follows Conventional Commits format
+
+## Additional Notes
+
+<!-- Any other context about this PR -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+## Supported Versions
+
+Only the `main` branch is actively supported with security updates. We recommend always using the latest version from main.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| main    | :white_check_mark: |
+| other   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Private disclosure** — Do not open a public GitHub issue
+2. **GitHub Security Advisories** — Use [GitHub's private vulnerability reporting](https://github.com/soulcodex/agentic/security/advisories/new)
+3. **Email** — Alternatively, email security concerns to `security@example.com` (placeholder)
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact assessment
+- Any suggested fixes (optional)
+
+We aim to acknowledge reports within 48 hours and provide a timeline for fixes.
+
+## Security Warnings
+
+### No Code Execution from Untrusted Sources
+
+This library generates and outputs shell scripts, configuration files, and executable code that may be run by AI agents in your projects.
+
+**Do not:**
+- Use fragments or profiles from untrusted sources
+- Deploy this library to projects without reviewing the generated output
+- Trust AI-generated code without human review
+
+**Always:**
+- Review generated `AGENTS.md` and vendor files before committing
+- Run `just lint` and `just test` locally before deploying
+- Audit the output in your project's `.agentic/` directory
+
+## Best Practices
+
+- Fork this library and review all fragments before deploying to production projects
+- Use the `just compose --dry-run` option to preview generated content
+- Keep your fork updated with the latest changes from upstream

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 soulcodex
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -149,4 +149,12 @@ Run `just setup` to check (and install on macOS) all required tools: `just`, `ba
 
 Contributions welcome — new fragments, profiles, vendor adapters, and skills. Run `just lint && just test` before opening a PR.
 
-MIT
+## Contributing
+
+Contributions are welcome! Please see our [Contributing Guide](.github/CONTRIBUTING.md) for details on how to set up the development environment, run quality checks, and submit pull requests.
+
+---
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- **OSS Community Files**: Add `LICENSE` (MIT), `CONTRIBUTING.md`, `SECURITY.md`, GitHub issue templates (bug report, feature request), and a PR template to standardise contributions and community interactions.
- **Architecture Fragments**: Enrich existing fragments with richer guardrails:
  - `ddd.md`: Pre-Modeling Checklist, Authorization Boundary, Shared Module Discipline
  - `hexagonal.md`: Wiring-at-composition-root rule, acyclicity verification, package-naming-by-purpose, infra-error-isolation
  - `cqrs.md`: Contract & Schema Parity section (versioned schemas, drift-as-breaking-change)
  - `eda.md`: Dependency & Local Parity, Intentional Planning checklist, Document Flows guardrail
  - `event-sourcing.md`: Concurrency Safety section, Event Schema as Public Contract with versioning policy
- **New Skill — `persist-plan`**: Adds `skills/agentic/persist-plan/` with `SKILL.md` and `plan-template.md`; persists agent plans to `.agentic/plans/` using datestamped slugged filenames and an `INDEX.md` registry for multi-agent discoverability.
- **Index rebuild**: Updates `index/skills.json` (28 skills) and `index/fragments.json` (26 fragments).

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation update