### PR TITLE
fix(docs): unify duplicate Contributing sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,7 @@ Add a fragment, profile, skill, or vendor adapter — all in plain Markdown and 
 
 Run `just setup` to check (and install on macOS) all required tools: `just`, `bash`, `yq`, `jq`.
 
-Contributions welcome — new fragments, profiles, vendor adapters, and skills. Run `just lint && just test` before opening a PR.
-
-## Contributing
-
-Contributions are welcome! Please see our [Contributing Guide](.github/CONTRIBUTING.md) for details on how to set up the development environment, run quality checks, and submit pull requests.
+Contributions are welcome — new fragments, profiles, vendor adapters, and skills. Please see our [Contributing Guide](.github/CONTRIBUTING.md) for details on how to set up the development environment, run quality checks, and submit pull requests. Run `just lint && just test` before opening a PR.
 
 ---
 


### PR DESCRIPTION
## Summary

The README had two separate Contributing sections that were introduced independently:

- `## Prerequisites & Contributing` — mentioned setup requirements and a one-liner about contributions
- `## Contributing` — pointed to the full `CONTRIBUTING.md` guide added in a later PR

These have been merged into a single `## Prerequisites & Contributing` section that combines both the setup prerequisite info, the link to the full Contributing Guide, and the quality-check reminder (`just lint && just test`), avoiding redundancy.

## Changes

- `README.md`: removed the standalone `## Contributing` section and folded its content into the existing `## Prerequisites & Contributing` section.