### PR TITLE
feat(skills): add json-to-toon skill for token-optimised LLM input

### DIFF
--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-03T22:46:22Z",
+  "generated_at": "2026-04-03T23:19:35Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -181,6 +181,20 @@
         "webhook",
         "reliability",
         "integration"
+      ]
+    },
+    {
+      "name": "json-to-toon",
+      "group": "data",
+      "path": "skills/data/json-to-toon/SKILL.md",
+      "description": "Transforms JSON input into Token-Oriented Object Notation (TOON) to reduce token consumption in LLM prompts and context ",
+      "version": "1.0.0",
+      "tags": [
+        "data",
+        "token-optimization",
+        "toon",
+        "json",
+        "llm"
       ]
     },
     {

--- a/skills/data/json-to-toon/SKILL.md
+++ b/skills/data/json-to-toon/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: json-to-toon
+description: >
+  Transforms JSON input into Token-Oriented Object Notation (TOON) to reduce
+  token consumption in LLM prompts and context windows. Applies the full TOON
+  spec: inline primitive arrays, tabular format for uniform object arrays, and
+  list format for heterogeneous or nested structures. Invoked when the user asks
+  to compress, optimize, or convert JSON for LLM use, or to reduce token count
+  on structured input data.
+version: 1.0.0
+tags:
+  - data
+  - token-optimization
+  - toon
+  - json
+  - llm
+resources:
+  - toon-spec-reference.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## JSON to TOON Transformation Skill
+
+Convert JSON input into TOON (Token-Oriented Object Notation) to achieve 30–70%
+token reduction, making it ideal for use in LLM prompts, RAG pipelines, and any
+context-window-sensitive application.
+
+---
+
+### Step 1 — Load the Specification
+
+Read `toon-spec-reference.md` (in this skill's directory). It contains the
+complete encoding rules you must apply throughout this skill.
+
+---
+
+### Step 2 — Assess the Input
+
+Inspect the JSON the user has provided:
+
+1. **Identify the root type**: is it an object, array of uniform objects, array
+   of mixed objects, or a primitive array?
+2. **Scan for high-repetition patterns**: arrays of objects with identical keys
+   are prime candidates for tabular format (biggest token savings).
+3. **Flag any values that require quoting**: strings containing `,`, `:`, `[`,
+   `{`, `-` at start, leading/trailing spaces, or values that look like
+   booleans/numbers/null.
+4. **Note depth**: deeply nested structures may benefit most from TOON's
+   indentation-based nesting (no closing braces).
+
+Output a brief one-line assessment: e.g.
+`"Root object with 3 tabular arrays and 2 nested objects — expect ~55% token reduction."`
+
+---
+
+### Step 3 — Choose Array Format for Each Array
+
+For every array in the input, apply this decision tree:
+
+```
+Is every element a primitive (string, number, boolean, null)?
+  YES → Inline format:  key[N]: v1,v2,v3
+
+Are ALL elements objects AND do they share identical top-level keys AND
+are all their values primitives (no nested objects or arrays)?
+  YES → Tabular format: key[N]{f1,f2,f3}:
+                          v1,v2,v3
+                          v4,v5,v6
+
+Otherwise (different keys, nested values, mixed types)
+       → List format:   key[N]:
+                          - field: value
+                            field2: value2
+```
+
+Use the **field order of the first object** for all tabular rows. Never
+re-order fields.
+
+---
+
+### Step 4 — Encode the Full Structure
+
+Walk the JSON top-down and apply the rules from `toon-spec-reference.md`:
+
+- **Objects**: `key: value` pairs, one per line. Nested objects indent 2 spaces.
+- **Primitive values**: unquoted alphanumeric strings/numbers/booleans. Quote
+  only when required (see spec quoting rules).
+- **Empty structures**: `key:` for empty objects, `key[0]:` for empty arrays,
+  `""` for empty strings.
+- **Nulls**: `null` (unquoted).
+- **Booleans**: `true` / `false` (lowercase, unquoted).
+- **Dates/times**: ISO 8601 quoted string (`"2025-01-01T00:00:00.000Z"`).
+- **Non-serialisable values** (functions, symbols, Infinity, NaN): `null`.
+
+Formatting invariants — never violate these:
+- No trailing whitespace on any line.
+- No trailing newline at end of output.
+- Consistent 2-space indentation throughout.
+- Array length markers must match actual element counts.
+
+---
+
+### Step 5 — Wrap Output and Report Savings
+
+Output the TOON-encoded data inside a fenced code block:
+
+~~~
+```toon
+<encoded output here>
+```
+~~~
+
+Then append a short savings summary:
+
+```
+Token estimate: JSON ~{N} tokens → TOON ~{M} tokens ({P}% reduction)
+Format choices: {brief justification — e.g. "3 tabular arrays, 1 list array, inline primitives"}
+```
+
+Use the `cl100k_base` tokenizer heuristic (≈ 1 token per 4 characters of JSON,
+≈ 1 token per 5 characters of TOON) for the estimate if an exact count is not
+available. Always clarify it is an estimate.
+
+---
+
+### Step 6 — Offer Round-Trip Guidance (Optional)
+
+If the user will need to reconstruct the original JSON from TOON, proactively
+mention the known lossy edge cases:
+
+- **Empty string vs. empty object**: both encode as `key:` — decoder must infer
+  from schema context.
+- **Quoted vs. unquoted type coercion**: `"true"` stays a string; `true` becomes
+  a boolean.
+- **Key order**: TOON preserves insertion order but round-trip tools may vary.
+- **Recommendation**: for APIs requiring exact lossless JSON, keep the original
+  JSON. Use TOON for LLM prompt payloads and discard after the LLM call.
+
+Only include this section if the user asks about round-tripping or if the
+payload contains edge-case values (empty strings, ambiguous-looking strings,
+datetime objects).
+
+---
+
+### Quick Reference — Format Decision Table
+
+| Input pattern | Format | Example |
+|---|---|---|
+| Primitive array | Inline | `tags[3]: a,b,c` |
+| Uniform objects, flat values | Tabular | `rows[2]{id,name}: 1,Alice\n 2,Bob` |
+| Non-uniform objects | List | `items[2]:\n  - id: 1\n  - id: 2\n    extra: true` |
+| Nested objects | Indented key-value | `user:\n  id: 1\n  name: Alice` |
+| Mixed array | List | `data[3]:\n  - 1\n  - a: 1\n  - text` |

--- a/skills/data/json-to-toon/toon-spec-reference.md
+++ b/skills/data/json-to-toon/toon-spec-reference.md
@@ -1,0 +1,163 @@
+# TOON Spec Reference
+
+Token-Oriented Object Notation (TOON) v0.9-beta1 — compact encoding rules for LLM-optimised data.
+
+---
+
+## Primitives
+
+| Type | Rule | JSON → TOON |
+|---|---|---|
+| Safe string | Alphanumeric + underscore: unquoted | `"Alice"` → `Alice` |
+| Empty string | Always quoted | `""` → `""` |
+| Ambiguous string | Looks like bool/null/number: quoted | `"true"` → `"true"`, `"42"` → `"42"` |
+| Special chars string | Contains `,` `:` `[` `{` `-`(leading) space: quoted | `"a,b"` → `"a,b"` |
+| Control chars | Escape inside quotes | `"a\nb"` → `"a\\nb"` |
+| Integer / float | Unquoted | `42` → `42`, `3.14` → `3.14` |
+| Boolean | Lowercase, unquoted | `true` → `true`, `false` → `false` |
+| Null / undefined | Unquoted keyword | `null` → `null` |
+| Date / time | ISO 8601, quoted | `"2025-01-01T00:00:00.000Z"` |
+| Non-serialisable | Functions, symbols, Infinity, NaN | → `null` |
+
+---
+
+## Objects
+
+```
+key: value          ← simple pair
+nested:             ← object value on next line, indented 2 spaces
+  inner: value
+empty_obj:          ← empty object (colon, no value)
+```
+
+Key quoting rules: quote keys that contain `,` `:` `[` `{` spaces, leading `-`,
+numeric-only keys, or empty key.
+
+---
+
+## Arrays — Three Formats
+
+### 1. Inline (primitive elements)
+
+```
+tags[3]: reading,gaming,coding
+nums[4]: 1,2,3,4
+empty[0]:
+```
+
+Syntax: `key[N]: v1,v2,...`  
+Quote elements containing `,` or other special chars.
+
+### 2. Tabular (uniform objects — all same keys, all flat values)
+
+```
+products[3]{id,name,price}:
+  1,Widget,9.99
+  2,Gadget,14.50
+  3,Tool,7.25
+```
+
+Syntax: `key[N]{field1,field2,...}:\n  row1\n  row2`  
+Field order comes from the **first object**. Quote cells containing `,`.
+
+### 3. List (non-uniform objects, nested values, or mixed types)
+
+```
+items[2]:
+  - id: 1
+    name: First
+  - id: 2
+    name: Second
+    extra: true
+    tags[2]: a,b
+```
+
+Syntax: `key[N]:` then each item starts with `- ` at indent+2; subsequent
+fields align with first field (indent+4 for 2-space indent).
+
+---
+
+## Decision Tree
+
+```
+All elements are primitives?
+  YES → Inline
+
+All elements are objects AND identical top-level keys AND all values are flat?
+  YES → Tabular
+
+Otherwise (mixed, nested, heterogeneous)?
+  → List
+```
+
+---
+
+## Nesting
+
+Objects in objects → 2-space indent per level, no closing braces:
+
+```
+user:
+  id: 123
+  address:
+    city: London
+    zip: W1A1AA
+```
+
+Arrays inside list items → apply same rules recursively:
+
+```
+orders[1]:
+  - id: 42
+    lines[2]{sku,qty}:
+      A1,3
+      B2,1
+    tags[2]: urgent,new
+```
+
+---
+
+## Root-Level Arrays
+
+```
+[3]: a,b,c                          ← root primitive array
+[2]{id,name}:                       ← root tabular array
+  1,Alice
+  2,Bob
+[2]:                                ← root list array
+  - id: 1
+  - id: 2
+    name: Ada
+[0]:                                ← root empty array
+```
+
+---
+
+## Invariants — Never Violate
+
+- No trailing whitespace on any line.
+- No trailing newline at end of output.
+- Consistent 2-space indentation (or chosen level, but must be uniform).
+- Array `[N]` length must equal actual element count.
+- Tabular column order must match header throughout all rows.
+
+---
+
+## Token Savings Reference (cl100k_base)
+
+| Data pattern | Typical reduction vs JSON |
+|---|---|
+| Tabular arrays (10+ rows) | 50–70% |
+| Nested objects | 30–50% |
+| Primitive arrays | 20–40% |
+| Small flat objects (< 5 fields) | 5–15% |
+
+---
+
+## Caveats
+
+- **Lossy edge cases**: `key:` is ambiguous between empty string and empty
+  object. Decoder infers from context — do not rely on lossless round-trips.
+- **Type coercion**: `"true"` (quoted) → string; `true` (unquoted) → boolean.
+- **Purpose**: TOON is a forward-transformation format for LLM consumption, not
+  a lossless interchange format. Keep original JSON for strict APIs.


### PR DESCRIPTION
## Summary

- Adds a new `data/json-to-toon` skill that transforms JSON payloads into **Token-Oriented Object Notation (TOON)**, targeting 30–70% input token reduction for LLM prompts and context windows.
- Ships a companion `toon-spec-reference.md` resource (loaded at Step 1) containing the full TOON v0.9-beta1 encoding rules — primitives, quoting, inline/tabular/list array formats, nesting, invariants, and token-savings reference — keeping the main `SKILL.md` lean.
- Index rebuilt: 31 skills total (`just index` + `just lint` both pass clean).

## What TOON Is

TOON (Token-Oriented Object Notation) is a compact, human-readable data serialisation format designed for LLM consumption. Key encoding patterns:

| Input pattern | Format | Token saving |
|---|---|---|
| Primitive arrays | `tags[3]: a,b,c` | 20–40% |
| Uniform object arrays | `rows[2]{id,name}:` tabular | 50–70% |
| Nested / heterogeneous | `items[2]:` list with `- ` prefix | 30–50% |

## Skill Workflow (6 steps)

1. Load spec from `toon-spec-reference.md`
2. Assess input (root type, repetition patterns, quoting needs)
3. Choose array format per array (inline → tabular → list decision tree)
4. Encode the full structure following all spec rules
5. Wrap output in ` ```toon ``` ` block + report estimated token savings
6. Offer round-trip caveats when relevant (lossy edge cases)

## Files Changed

- `skills/data/json-to-toon/SKILL.md` — skill definition
- `skills/data/json-to-toon/toon-spec-reference.md` — spec resource
- `index/skills.json` — rebuilt index (31 skills)