### PR TITLE
docs: document new profiles, link mode commands, and skill groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Writes `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.gemini/sys
 | `python-fastapi-microservice` | FastAPI service with uv + Pydantic | Python |
 | `python-hexagonal-typer-cli` | Python CLI tool with Typer + Rich | Python |
 | `php-hexagonal-ddd` | PHP 8.3+ Symfony application | PHP |
+| `go-library` | Go reusable library/package with stable public API | Go |
+| `typescript-library` | TypeScript reusable library for npm/private registry | TypeScript |
 
 [Full profile details, nested mode, and tier config →](docs/profiles.md)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -65,6 +65,7 @@ agentic deploy <profile> [target] <vendors> [options]
 
 **Options:**
 - `--full` — Inline all fragment content (monolithic AGENTS.md)
+- `--link` — Use symlinks instead of file copies (POSIX only; see Link Mode section below)
 - `--skills LIST` — Deploy specific skills (default: all from profile)
 
 **Examples:**
@@ -84,6 +85,7 @@ agentic compose <profile> [target] [options]
 
 **Options:**
 - `--full` — Inline all fragment content
+- `--link` — Use symlinks instead of file copies (POSIX only)
 
 **Examples:**
 ```bash
@@ -168,6 +170,20 @@ just compose-full PROFILE TARGET      # Compose AGENTS.md (full mode)
 just dry-run PROFILE                  # Preview without writing files
 just validate TARGET                  # Validate AGENTS.md in a project
 just sync-check TARGET                # Check for config drift
+just sync TARGET                      # Re-sync configuration
+```
+
+### Link Mode (POSIX only)
+
+> **Not supported on Windows** (without WSL). These commands create POSIX symlinks
+> instead of copying files. The target repo stays minimal — only `config.yaml`,
+> `profile.yaml`, and `project-skills/` are committed; fragments, skills, and
+> vendor-files are live symlinks back to the library.
+
+```bash
+just compose-linked PROFILE TARGET          # Compose using symlinks
+just deploy-linked PROFILE TARGET VENDORS   # Full pipeline using symlinks
+just sync-links TARGET                      # Re-create broken symlinks from config
 ```
 
 ### Deployment

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -77,6 +77,7 @@ Skills are reusable agent task definitions in `skills/{group}/{name}/SKILL.md`.
 
 ```bash
 mkdir -p skills/development/my-skill
+# Groups: development, agentic, data, quality, architecture, or any custom name
 # Write skills/development/my-skill/SKILL.md with frontmatter + steps
 just index
 just lint

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -17,6 +17,8 @@ A profile is a named YAML preset that selects which fragments, tech stack detail
 | `python-fastapi-microservice` | FastAPI service with uv + Pydantic, hexagonal | Python |
 | `python-hexagonal-typer-cli` | Python CLI tool with Typer + Rich, hexagonal | Python |
 | `php-hexagonal-ddd` | PHP 8.3+ Symfony application, hexagonal + DDD + CQRS | PHP |
+| `go-library` | Go reusable library/package with stable public API and minimal transitive dependencies | Go |
+| `typescript-library` | TypeScript reusable library for npm/private registry, ESM-first, zero framework dependencies | TypeScript |
 
 ## Nested Output Mode
 


### PR DESCRIPTION
## Summary

- Add `go-library` and `typescript-library` profiles to the `README.md` and `docs/profiles.md` tables
- Document the three new link-mode `just` recipes (`compose-linked`, `deploy-linked`, `sync-links`) and the `--link` flag in `docs/commands.md`, including a POSIX-only warning
- Update the skill group list in `docs/extending.md` to include the `agentic` and `data` groups introduced by the `write-plan` and `json-to-toon` skills