### PR TITLE
docs: move platform notes on link mode from README to commands.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,6 @@ Writes `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.gemini/sys
 
 ## Key Commands
 
-### Platform Notes
-
-The `--link` / `compose-linked` / `deploy-linked` commands use POSIX symlinks and are
-**not supported on Windows** (without WSL). On non-POSIX systems these commands will
-fail with a clear error. Use the standard `compose` / `deploy` commands instead, which
-copy files and work on all platforms.
-
 ```bash
 # Global CLI (install with: just install)
 agentic deploy PROFILE TARGET VENDORS    # compose + vendor-gen + deploy skills
@@ -136,7 +129,7 @@ just lint && just test                   # validate the library
 <details>
 <summary>Full command reference</summary>
 
-See [docs/commands.md](docs/commands.md) for the complete reference including discovery, composition, deployment, maintenance, and MCP server commands.
+See [docs/commands.md](docs/commands.md) for the complete reference including discovery, composition, deployment, maintenance, MCP server commands, and platform notes on link mode.
 
 </details>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -175,10 +175,14 @@ just sync TARGET                      # Re-sync configuration
 
 ### Link Mode (POSIX only)
 
-> **Not supported on Windows** (without WSL). These commands create POSIX symlinks
-> instead of copying files. The target repo stays minimal — only `config.yaml`,
-> `profile.yaml`, and `project-skills/` are committed; fragments, skills, and
-> vendor-files are live symlinks back to the library.
+> **Platform note:** The `--link` / `compose-linked` / `deploy-linked` commands use
+> POSIX symlinks and are **not supported on Windows** (without WSL). On non-POSIX
+> systems these commands will fail with a clear error. Use the standard `compose` /
+> `deploy` commands instead, which copy files and work on all platforms.
+>
+> These commands create POSIX symlinks instead of copying files. The target repo stays
+> minimal — only `config.yaml`, `profile.yaml`, and `project-skills/` are committed;
+> fragments, skills, and vendor-files are live symlinks back to the library.
 
 ```bash
 just compose-linked PROFILE TARGET          # Compose using symlinks


### PR DESCRIPTION
## Summary

- Removes the **Platform Notes** sub-section from `README.md` to keep the Key Commands section concise
- Moves the note into `docs/commands.md` under the existing `### Link Mode (POSIX only)` block, where it naturally belongs alongside the link-mode command reference
- Updates the `details` link description in `README.md` to mention platform notes so readers know where to find it