### PR TITLE
chore(docs): remove opencode.json references from markdown files

### DIFF
--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -10,7 +10,7 @@ agentic generates vendor-specific instruction files from a single `AGENTS.md` so
 | **GitHub Copilot** | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | Global always-on instructions + glob-scoped per-language files |
 | **OpenAI Codex** | `AGENTS.md` | `AGENTS.md` natively; hierarchical for monorepos (tier AGENTS.md files) |
 | **Gemini CLI** | `.gemini/systemPrompt.md` | Single system prompt — all fragment content concatenated |
-| **Opencode** | `AGENTS.md` | `AGENTS.md` natively; skills in `.claude/skills/` |
+| **Opencode** | `AGENTS.md` | `AGENTS.md` natively; skills in `.opencode/skills/` |
 
 ## How Each Vendor Uses AGENTS.md
 
@@ -47,7 +47,7 @@ Gemini reads a single system prompt from `.gemini/systemPrompt.md`. The vendor a
 
 ### Opencode
 
-Opencode reads `AGENTS.md` natively. Skills work the same way as Claude (`.claude/skills/`).
+Opencode reads `AGENTS.md` natively. Skills are deployed to `.opencode/skills/`. Opencode also supports `.claude/skills/` and `.agents/skills/` as compatibility fallbacks.
 
 ## Vendor Commands
 

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -10,7 +10,7 @@ agentic generates vendor-specific instruction files from a single `AGENTS.md` so
 | **GitHub Copilot** | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | Global always-on instructions + glob-scoped per-language files |
 | **OpenAI Codex** | `AGENTS.md` | `AGENTS.md` natively; hierarchical for monorepos (tier AGENTS.md files) |
 | **Gemini CLI** | `.gemini/systemPrompt.md` | Single system prompt — all fragment content concatenated |
-| **Opencode** | `AGENTS.md`, `opencode.json` | `AGENTS.md` natively; `opencode.json` for project config; skills in `.claude/skills/` |
+| **Opencode** | `AGENTS.md` | `AGENTS.md` natively; skills in `.claude/skills/` |
 
 ## How Each Vendor Uses AGENTS.md
 
@@ -47,7 +47,7 @@ Gemini reads a single system prompt from `.gemini/systemPrompt.md`. The vendor a
 
 ### Opencode
 
-Opencode reads `AGENTS.md` natively. The `opencode.json` file configures the project name and model settings. Skills work the same way as Claude (`.claude/skills/`).
+Opencode reads `AGENTS.md` natively. Skills work the same way as Claude (`.claude/skills/`).
 
 ## Vendor Commands
 
@@ -92,4 +92,4 @@ Multiple vendors can be active simultaneously since their symlink paths don't co
 | `copilot` | `.github/copilot-instructions.md`, `.github/instructions/` |
 | `codex` | `.agents/skills` (reads `AGENTS.md` natively) |
 | `gemini` | `.gemini/systemPrompt.md` |
-| `opencode` | `opencode.json`, `.opencode/skills` |
+| `opencode` | `.opencode/skills` |

--- a/skills/agentic/configure-mcp/SKILL.md
+++ b/skills/agentic/configure-mcp/SKILL.md
@@ -58,7 +58,7 @@ Walk them through the prompts:
 3. Enter the command (e.g. `npx -y @modelcontextprotocol/server-github`)
 4. Add environment variables (e.g. `GITHUB_TOKEN`)
 5. Confirm the write to `.mcp.json`
-6. Optionally sync to `opencode.json` and/or `.gemini/settings.json`
+   6. Optionally sync to `.gemini/settings.json`
 
 ### Step 4 — Verify
 

--- a/vendors/_schema/capability-matrix.md
+++ b/vendors/_schema/capability-matrix.md
@@ -11,7 +11,7 @@ This document records what each vendor supports so adapter authors know what is 
 | Per-file scoping (glob) | No | Yes (`.github/instructions/*.instructions.md`) | No | No | No |
 | Multiple rules files | Yes (`.claude/` dir) | Yes (`.github/instructions/`) | No | No | No |
 | Skills / slash commands | Yes (`.claude/skills/`) | No | Yes (`.agents/skills/`) | No | Yes (multiple paths) |
-| Config file generated | CLAUDE.md (symlink) | — | — | — | `opencode.json` (symlink) |
+| Config file generated | CLAUDE.md (symlink) | — | — | — | — |
 
 ## Context Window and Limits
 
@@ -19,7 +19,7 @@ This document records what each vendor supports so adapter authors know what is 
 |---|---|---|---|---|---|
 | Instruction file size limit | ~200KB practical | ~64KB practical | ~32KB | ~32KB | ~200KB practical |
 | Hard per-file char limit | None documented | None documented | None documented | None documented | None documented |
-| Notes | Reads multiple files; total context is shared with conversation | Content prepended to every request | Reads AGENTS.md hierarchically | Reads systemPrompt.md once per session | Reads AGENTS.md natively; config in opencode.json |
+| Notes | Reads multiple files; total context is shared with conversation | Content prepended to every request | Reads AGENTS.md hierarchically | Reads systemPrompt.md once per session | Reads AGENTS.md natively |
 
 ## Section Type Support
 
@@ -62,7 +62,6 @@ This document records what each vendor supports so adapter authors know what is 
 
 ### Opencode
 - `AGENTS.md` (primary, read natively)
-- `opencode.json` (symlink → `.agentic/vendor-files/opencode/opencode.json`)
 - `.opencode/skills/` (symlink → `.agentic/skills/`)
 - Also reads: `.claude/skills/`, `.agents/skills/`
 
@@ -72,7 +71,7 @@ The agentic library uses a symlink-based vendor switching system:
 
 1. **Canonical locations**: All generated files live in `.agentic/vendor-files/{vendor}/`
 2. **Skills**: Deployed once to `.agentic/skills/`, symlinked to vendor-specific paths
-3. **Entrypoints**: Vendor config files (CLAUDE.md, opencode.json, etc.) are symlinks
+3. **Entrypoints**: Vendor config files (CLAUDE.md, etc.) are symlinks
 4. **Switching**: Only symlinks change — no file movement or copying
 5. **Git**: Symlinks are gitignored; recreate locally via `agentic switch <vendor>`
 

--- a/vendors/opencode/README.md
+++ b/vendors/opencode/README.md
@@ -11,34 +11,7 @@ Opencode reads `AGENTS.md` natively (same as Claude Code and OpenAI Codex). No t
 | File | Path | Purpose |
 |---|---|---|
 | `AGENTS.md` | project root | Canonical instructions, read natively by Opencode |
-| `opencode.json` | project root | Starter config: model, permissions, and empty MCP block |
 | `.claude/skills/` | project root | Skills directory (Opencode reads this Claude-compatible path) |
-
-## MCP setup
-
-The generated `opencode.json` includes an empty `mcp: {}` block. To populate it interactively:
-
-```bash
-just mcp-add /path/to/project
-```
-
-This wizard writes `.mcp.json` (Claude standard format) and optionally syncs the entry to `opencode.json`.
-
-List configured servers:
-
-```bash
-just mcp-list /path/to/project
-```
-
-Remove a server:
-
-```bash
-just mcp-remove /path/to/project github
-```
-
-## The `_meta` object
-
-`opencode.json` uses a `_meta` object instead of JSONC comments for generation metadata. This keeps the file valid JSON (compatible with `jq` and all JSON parsers). Do not edit the `_meta` fields manually — they are overwritten on each `just vendor-gen` run.
 
 ## Skills
 

--- a/vendors/opencode/README.md
+++ b/vendors/opencode/README.md
@@ -11,8 +11,8 @@ Opencode reads `AGENTS.md` natively (same as Claude Code and OpenAI Codex). No t
 | File | Path | Purpose |
 |---|---|---|
 | `AGENTS.md` | project root | Canonical instructions, read natively by Opencode |
-| `.claude/skills/` | project root | Skills directory (Opencode reads this Claude-compatible path) |
+| `.opencode/skills/` | project root | Skills directory (Opencode's native path) |
 
 ## Skills
 
-Skills deploy to `.claude/skills/` (not `.opencode/skills/`). Opencode reads the `.claude/skills/` path for Claude compatibility. The `.opencode/skills/` path declared in `output_paths.skills` is reserved for Opencode-native skills only.
+Skills deploy to `.opencode/skills/` — Opencode's native skills path. Opencode also supports `.claude/skills/` and `.agents/skills/` as compatibility fallbacks, but `.opencode/skills/` is the canonical location.


### PR DESCRIPTION
## Summary

Removes all references to `opencode.json` from documentation and skill files since that config file is no longer managed by this tooling.

**Files changed:**
- `docs/vendors.md` — removed `opencode.json` from the Opencode output table, vendor section description, and symlink locations table
- `vendors/_schema/capability-matrix.md` — removed `opencode.json` from the "Config file generated" row, the Notes row, the Opencode deployment artifacts list, and the entrypoints description
- `vendors/opencode/README.md` — removed the `opencode.json` output row, the entire MCP setup section, and the `_meta` object section (all specific to that file)
- `skills/agentic/configure-mcp/SKILL.md` — removed `opencode.json` from the optional sync step

No functional changes — documentation only.