### PR TITLE
docs: fix outdated Gemini references, add doc-maintenance rule, and git-flow-pr skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,18 @@ project repositories via the tooling provided here.
 - The canonical source of truth is always `AGENTS.md` (assembled from fragments).
 - `adapter.json` files must validate against `vendors/_schema/adapter.schema.json`.
 
+### Documentation
+
+- **Any change that introduces, renames, or removes a vendor output file, symlink path,
+  tooling flag, or `just` recipe must include a corresponding update to the affected
+  docs in the same commit.** Relevant files: `README.md`, `docs/vendors.md`,
+  `docs/commands.md`, `docs/extending.md`, and any `vendors/*/README.md`.
+- When adding a new vendor adapter, add it to the Supported Vendors table in
+  `README.md` and `docs/vendors.md`, and document its output files and symlink paths.
+- When adding a new `just` recipe or CLI command, add it to `docs/commands.md`.
+- When adding or updating a skill that references tooling paths or output filenames,
+  verify those paths are still accurate before committing.
+
 ### Profiles
 
 - Profile YAML files must validate against `schemas/profile.schema.json`.
@@ -74,7 +86,7 @@ Rules:
 
 ### Testing & Quality
 
-- **Always run `just test` before committing any change to `tooling/`.** All 29 (or more) assertions must pass.
+- **Always run `just test` before committing any change to `tooling/`.** All assertions must pass (currently 279+).
 - **When adding or changing behaviour in `compose.sh`, `vendor-gen.sh`, `deploy-skills.sh`, or any other script, add corresponding assertions to `tooling/lib/test.sh`.**
   - New compose feature (e.g. a new generated section)? Add a `T##` test that composes a suitable profile and asserts the section is present.
   - New flag or mode? Add a test that exercises the flag, checks the output file(s) exist (or don't), and verifies the content.

--- a/README.md
+++ b/README.md
@@ -12,24 +12,25 @@ One library. One deploy. All your AI tools stay in sync.
 
 ```
 Without agentic              With agentic
-─────────────────────────    ────────────────────────────────────
-my-project/                  my-project/
-├── CLAUDE.md                ├── AGENTS.md               ← source of truth
-├── .github/                 ├── CLAUDE.md               ← symlink
-│   └── copilot-instr.md     ├── .github/
-├── .cursor/rules/           │   └── copilot-instr.md    ← symlink
-│   └── *.mdc                ├── .gemini/
-└── .gemini/                 │   └── systemPrompt.md     ← symlink
-    └── systemPrompt.md      └── .agentic/
-                                 ├── config.yaml         ← locked config
-                                 ├── profile.yaml        ← customize per-project
-                                 ├── project-skills/     ← your custom skills
-                                 ├── fragments/          ← on-demand context
-                                 ├── skills/             ← deployed skills
-                                 └── vendor-files/       ← generated once
-                                     ├── claude/
-                                     ├── copilot/
-                                     └── gemini/
+ ─────────────────────────    ────────────────────────────────────
+ my-project/                  my-project/
+ ├── CLAUDE.md                ├── AGENTS.md               ← source of truth
+ ├── .github/                 ├── CLAUDE.md               ← symlink
+ │   └── copilot-instr.md     ├── .github/
+ ├── .cursor/rules/           │   └── copilot-instructions.md ← symlink
+ │   └── *.mdc                ├── .gemini/
+ └── .gemini/                 │   ├── GEMINI.md           ← auto-discovered
+     └── systemPrompt.md      │   ├── system.md           ← symlink
+                              └── .agentic/              └── skills/          ← symlink
+                                   ├── config.yaml         ← locked config
+                                   ├── profile.yaml        ← customize per-project
+                                   ├── project-skills/     ← your custom skills
+                                   ├── fragments/          ← on-demand context
+                                   ├── skills/             ← deployed skills
+                                   └── vendor-files/       ← generated once
+                                       ├── claude/
+                                       ├── copilot/
+                                       └── gemini/
 ```
 
 Instructions drift and contradict each other. Every new project starts from scratch. Adding a new AI tool means updating N files manually.
@@ -70,7 +71,7 @@ agentic list profiles
 agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
 ```
 
-Writes `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.gemini/systemPrompt.md`, and `.agentic/config.yaml` into `~/code/my-api`. Run `agentic sync` from within any project to regenerate from local profile.
+Writes `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `GEMINI.md`, `.gemini/system.md`, and `.agentic/config.yaml` into `~/code/my-api`. Run `agentic sync` from within any project to regenerate from local profile.
 
 ---
 
@@ -103,7 +104,7 @@ Writes `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `.gemini/sys
 | **Claude** (Claude Code) | `AGENTS.md`, `CLAUDE.md`, `.claude/skills/` |
 | **GitHub Copilot** | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` |
 | **OpenAI Codex** | `AGENTS.md` |
-| **Gemini CLI** | `.gemini/systemPrompt.md` |
+| **Gemini CLI** | `GEMINI.md`, `.gemini/system.md`, `.gemini/skills/` |
 | **Opencode** | `AGENTS.md` (native), `.opencode/skills/` |
 
 [Vendor details, glob mechanism, and vendor-switch →](docs/vendors.md)

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -203,7 +203,8 @@ into the format expected by a specific AI tool.
 
 1. Create `vendors/my-tool/` directory.
 2. Add a template file (e.g., `template.my-tool.md`).
-3. Add the generation logic to `tooling/lib/vendor-gen.sh` as a `gen_mytool()` function.
-4. Add `my-tool` to the `resolve_vendors` function.
-5. Add `my-tool` to the `vendors.enabled` list in any profiles that should use it.
-6. Run `just lint && just test`.
+3. Create `tooling/lib/vendors/my-tool.sh` with a `gen_mytool()` function (see existing vendor scripts for the pattern).
+4. Add a `# shellcheck source=tooling/lib/vendors/my-tool.sh` directive and `source` call to `tooling/lib/vendor-gen.sh`'s vendor-loading block.
+5. Add `my-tool` to the `AGENTIC_VENDORS` array in `tooling/lib/common.sh`.
+6. Add `my-tool` to the `vendors.enabled` list in any profiles that should use it.
+7. Run `just lint && just test`.

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -9,7 +9,7 @@ agentic generates vendor-specific instruction files from a single `AGENTS.md` so
 | **Claude** (Claude Code) | `AGENTS.md`, `CLAUDE.md` | `AGENTS.md` natively; `CLAUDE.md` is a thin wrapper pointing to it; skills in `.claude/skills/` |
 | **GitHub Copilot** | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | Global always-on instructions + glob-scoped per-language files |
 | **OpenAI Codex** | `AGENTS.md` | `AGENTS.md` natively; hierarchical for monorepos (tier AGENTS.md files) |
-| **Gemini CLI** | `.gemini/systemPrompt.md` | Single system prompt — all fragment content concatenated |
+| **Gemini CLI** | `GEMINI.md`, `.gemini/system.md` | Root context file (auto-discovered) + system-prompt override |
 | **Opencode** | `AGENTS.md` | `AGENTS.md` natively; skills in `.opencode/skills/` |
 
 ## How Each Vendor Uses AGENTS.md
@@ -43,7 +43,11 @@ This means the Go conventions are injected only when Copilot is working on `.go`
 
 ### Gemini CLI
 
-Gemini reads a single system prompt from `.gemini/systemPrompt.md`. The vendor adapter concatenates all fragment content (in lean mode, reads from `.agentic/fragments/`) and appends it after the prompt header.
+Gemini CLI auto-discovers `GEMINI.md` at the project root — no environment variables
+required. The vendor adapter also generates `.gemini/system.md` as a full
+system-prompt override; set `GEMINI_SYSTEM_MD=1` to activate it.
+Skills are deployed natively to `.gemini/skills/` and activated lazily via the
+`activate_skill` tool, keeping the initial context lean.
 
 ### Opencode
 
@@ -91,5 +95,5 @@ Multiple vendors can be active simultaneously since their symlink paths don't co
 | `claude` | `CLAUDE.md`, `.claude/skills` |
 | `copilot` | `.github/copilot-instructions.md`, `.github/instructions/` |
 | `codex` | `.agents/skills` (reads `AGENTS.md` natively) |
-| `gemini` | `.gemini/systemPrompt.md` |
+| `gemini` | `GEMINI.md`, `.gemini/system.md`, `.gemini/skills` |
 | `opencode` | `.opencode/skills` |

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-04T11:17:24Z",
+  "generated_at": "2026-04-18T19:27:03Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -245,6 +245,19 @@
         "debugging",
         "fix",
         "quality"
+      ]
+    },
+    {
+      "name": "git-flow-pr",
+      "group": "development",
+      "path": "skills/development/git-flow-pr/SKILL.md",
+      "description": "Executes the full PR-driven development workflow: create an isolated feature branch from the current work, commit all st",
+      "version": "1.0.0",
+      "tags": [
+        "git",
+        "github",
+        "pull-request",
+        "workflow"
       ]
     },
     {

--- a/skills/agentic/deploy-config/SKILL.md
+++ b/skills/agentic/deploy-config/SKILL.md
@@ -54,7 +54,9 @@ After deploying, list the files created in the target project:
 - `AGENTS.md` — primary agent instructions
 - `CLAUDE.md` — Claude adapter (if claude vendor enabled)
 - `.github/copilot-instructions.md` — Copilot adapter (if copilot enabled)
-- `.gemini/systemPrompt.md` — Gemini adapter (if gemini enabled)
+- `GEMINI.md` — Gemini primary context file (auto-discovered, if gemini enabled)
+- `.gemini/system.md` — Gemini system-prompt override (requires `GEMINI_SYSTEM_MD=1`, if gemini enabled)
+- `.gemini/skills/` — Gemini skills directory (symlinked, if gemini enabled)
 - `.claude/skills/*/` — deployed skill directories (if claude enabled)
 - `.agentic/config.yaml` — lock file recording what was deployed
 

--- a/skills/development/git-flow-pr/SKILL.md
+++ b/skills/development/git-flow-pr/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: git-flow-pr
+description: >
+  Executes the full PR-driven development workflow: create an isolated feature
+  branch from the current work, commit all staged changes, rebase cleanly onto
+  origin/main (skipping any ancestor commits already merged), push the branch,
+  and open a GitHub pull request linked to a related issue. Invoked when the
+  user says "open a PR", "create a pull request", "push and PR", or "branch,
+  rebase and PR".
+version: 1.0.0
+tags:
+  - git
+  - github
+  - pull-request
+  - workflow
+resources: []
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: native
+---
+
+## Git Flow PR Skill
+
+Complete workflow for creating a clean, rebased pull request from in-progress work.
+
+### Step 1 — Confirm Current State
+
+Before doing anything, understand what exists:
+
+```bash
+git status --short          # Are there uncommitted changes?
+git log --oneline -10       # What commits exist on this branch?
+git branch --show-current   # Which branch are we on?
+git fetch origin main       # Get latest state of main
+git log --oneline origin/main..HEAD   # Commits unique to this branch
+```
+
+Identify:
+- The **base branch** (usually `main`)
+- Any **uncommitted changes** that need to be staged
+- Whether the current branch's ancestor commits are **already merged into main**
+  (this determines which `--onto` strategy to use in Step 4)
+
+### Step 2 — Stage and Commit (if uncommitted changes exist)
+
+If there are uncommitted changes, stage and commit them now:
+
+```bash
+git add <files>     # Stage relevant files; be specific — don't `git add .` blindly
+git commit -m "<type>(<scope>): <summary>
+
+<body explaining why, not just what>
+
+Closes #<issue-number>"
+```
+
+Commit message rules:
+- Follow Conventional Commits: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
+- Scope should reflect the area changed: `(gemini)`, `(tooling)`, `(docs)`, `(skills)`, etc.
+- Reference the issue with `Closes #N` or `Fixes #N` in the commit body
+- Keep the subject line ≤ 72 characters
+
+### Step 3 — Create the Feature Branch
+
+Create a new branch from the tip of the current work and give it a descriptive name:
+
+```bash
+COMMIT=$(git rev-parse HEAD)
+git checkout -b feat/<short-description> "$COMMIT"
+```
+
+Branch naming convention:
+- `feat/<description>` — new feature or enhancement
+- `fix/<description>` — bug fix
+- `docs/<description>` — documentation only
+- `chore/<description>` — maintenance, tooling, dependencies
+
+Use kebab-case. Keep it short but descriptive (3–5 words max).
+
+### Step 4 — Rebase onto origin/main
+
+**Critical:** determine the correct rebase strategy before running.
+
+#### Case A — No ancestor commits already in main (simple case)
+
+The branch was created fresh and diverged directly from main:
+
+```bash
+git rebase origin/main
+```
+
+#### Case B — Ancestor commits are already merged into main (squash-merge or similar)
+
+This happens when:
+- The branch was created on top of another branch that was already merged
+- The repo uses squash-merge PRs, so commit SHAs on the branch differ from main
+
+Identify the last commit **not** in main:
+
+```bash
+# Find the oldest commit on this branch not present in main
+git log --oneline origin/main..HEAD
+# The last line shows the oldest unique commit — its *parent* is the rebase base
+ANCESTOR=$(git log --oneline origin/main..HEAD | tail -1 | awk '{print $1}')
+PARENT=$(git rev-parse "$ANCESTOR"^)
+```
+
+Then rebase only the unique commits onto main:
+
+```bash
+git rebase --onto origin/main "$PARENT" HEAD
+```
+
+This replays only the commits that are genuinely new, dropping the already-merged ones.
+
+#### After rebase — verify
+
+```bash
+git log --oneline -5          # Should show: new commit(s) on top of origin/main HEAD
+git status                    # Should be clean
+```
+
+If there are conflicts, resolve them file by file, then `git add <file> && git rebase --continue`. Never use `git rebase --skip` unless you are certain the commit is truly redundant.
+
+### Step 5 — Run Quality Gates
+
+Before pushing, run the project's verification suite. For this repo:
+
+```bash
+just test    # All assertions must pass
+just lint    # Zero findings
+```
+
+For other projects, run whatever the project defines as its quality gate (CI commands, test suite, type-check, etc.). Do not push a branch that fails its own quality gates.
+
+### Step 6 — Push the Branch
+
+```bash
+git push origin <branch-name> -u
+```
+
+The `-u` flag sets the upstream, making future `git push` / `git pull` work without arguments.
+
+If the push is rejected because the remote already has a version of this branch (e.g., you rebased), use force-push **only on feature branches** (never on `main`):
+
+```bash
+git push origin <branch-name> --force-with-lease
+```
+
+`--force-with-lease` is safer than `--force`: it fails if someone else pushed to the branch since your last fetch.
+
+### Step 7 — Open the Pull Request
+
+```bash
+gh pr create \
+  --title "<type>(<scope>): <concise summary>" \
+  --base main \
+  --head <branch-name> \
+  --body "$(cat <<'EOF'
+## Summary
+
+- <bullet 1: what changed and why>
+- <bullet 2>
+- <bullet 3>
+
+## Changes
+
+| Area | Files |
+|------|-------|
+| <area> | <files> |
+
+Closes #<issue-number>
+EOF
+)"
+```
+
+PR title rules:
+- Same format as the commit message subject
+- Must match the branch's purpose exactly
+- ≤ 72 characters
+
+Body rules:
+- 2–4 bullet summary (what + why, not just what)
+- Changes table for non-trivial diffs
+- `Closes #N` links the PR to the issue and auto-closes it on merge
+
+### Step 8 — Verify
+
+After opening:
+
+```bash
+gh pr view        # Confirm PR is open with correct title, base branch, and issue link
+```
+
+Check:
+- [ ] PR title follows Conventional Commits format
+- [ ] Base branch is `main` (not another feature branch)
+- [ ] Issue is linked via `Closes #N` in the body
+- [ ] CI checks are triggered and passing (check `gh pr checks`)
+- [ ] Branch is up to date with `main` (no "behind by N commits" warning)


### PR DESCRIPTION
## Summary

- Fix all stale `.gemini/systemPrompt.md` references across docs and skills — updated to reflect the dual-file Gemini output introduced in #61 (`GEMINI.md` + `.gemini/system.md`)
- Update `docs/extending.md` vendor adapter authoring steps to match the new per-vendor script isolation (`tooling/lib/vendors/<vendor>.sh`)
- Add a `### Documentation` rule to `AGENTS.md` requiring doc updates whenever output files, symlink paths, tooling flags, or `just` recipes change
- Add `git-flow-pr` skill encoding the full PR-driven workflow: branch → commit → smart rebase (handles already-merged ancestors) → push → `gh pr create` linked to issue

## Changes

| Area | Files |
|------|-------|
| Doc fixes (Gemini paths) | `README.md`, `docs/vendors.md`, `docs/extending.md`, `skills/agentic/deploy-config/SKILL.md` |
| AGENTS.md rule | `AGENTS.md` |
| New skill | `skills/development/git-flow-pr/SKILL.md` |
| Index | `index/skills.json` |