### PR TITLE
fix(docs): correct malformed side-by-side directory diagram in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,41 @@ One library. One deploy. All your AI tools stay in sync.
 
 ## The Problem
 
+**Without agentic**
+
 ```
-Without agentic              With agentic
- ─────────────────────────    ────────────────────────────────────
- my-project/                  my-project/
- ├── CLAUDE.md                ├── AGENTS.md               ← source of truth
- ├── .github/                 ├── CLAUDE.md               ← symlink
- │   └── copilot-instr.md     ├── .github/
- ├── .cursor/rules/           │   └── copilot-instructions.md ← symlink
- │   └── *.mdc                ├── .gemini/
- └── .gemini/                 │   ├── GEMINI.md           ← auto-discovered
-     └── systemPrompt.md      │   ├── system.md           ← symlink
-                              └── .agentic/              └── skills/          ← symlink
-                                   ├── config.yaml         ← locked config
-                                   ├── profile.yaml        ← customize per-project
-                                   ├── project-skills/     ← your custom skills
-                                   ├── fragments/          ← on-demand context
-                                   ├── skills/             ← deployed skills
-                                   └── vendor-files/       ← generated once
-                                       ├── claude/
-                                       ├── copilot/
-                                       └── gemini/
+my-project/
+├── CLAUDE.md
+├── .github/
+│   └── copilot-instr.md
+├── .cursor/rules/
+│   └── *.mdc
+└── .gemini/
+    └── systemPrompt.md
+```
+
+**With agentic**
+
+```
+my-project/
+├── AGENTS.md                        ← source of truth
+├── CLAUDE.md                        ← symlink
+├── .github/
+│   └── copilot-instructions.md      ← symlink
+├── .gemini/
+│   ├── GEMINI.md                    ← auto-discovered
+│   ├── system.md                    ← symlink
+│   └── skills/                      ← symlink
+└── .agentic/
+    ├── config.yaml                  ← locked config
+    ├── profile.yaml                 ← customize per-project
+    ├── project-skills/              ← your custom skills
+    ├── fragments/                   ← on-demand context
+    ├── skills/                      ← deployed skills
+    └── vendor-files/                ← generated once
+        ├── claude/
+        ├── copilot/
+        └── gemini/
 ```
 
 Instructions drift and contradict each other. Every new project starts from scratch. Adding a new AI tool means updating N files manually.


### PR DESCRIPTION
## Problem

The two-column ASCII layout in the \"The Problem\" section was overflowing horizontally. On line 24 of the original README, two separate tree branches were collapsed onto the same line:

\`\`\`
└── .agentic/              └── skills/          ← symlink
\`\`\`

This made \`.gemini/skills/\` appear to be a child of \`.agentic/\` and orphaned it from \`.gemini/\`, producing a structurally incorrect tree on the right-hand side.

## Fix

Split the single side-by-side block into two clearly labelled separate blocks (**Without agentic** / **With agentic**). Each tree now renders correctly at any terminal or browser width, with no ambiguity about parent-child relationships.