### PR TITLE
feat(fragments,skills,profiles): add Vue/Nuxt component design, testing and styling guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Writes `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `GEMINI.md`,
 
 | Profile | What it's for | Language(s) |
 |---|---|---|
+| `typescript-vue-spa` | Standalone Vue 3 SPA — Vite, Pinia, Vue Router, no SSR | TypeScript |
+| `typescript-nuxt-app` | Standalone Nuxt 3 app — SSR, file-based routing, Nitro | TypeScript |
 | `typescript-hexagonal-microservice` | TypeScript backend service with Hono | TypeScript |
 | `typescript-bff` | Backend-for-Frontend aggregation layer | TypeScript |
 | `typescript-hexagonal-nuxt-vite-ui` | Hono backend + Nuxt 3 / Vue 3 (SSR) | TypeScript |

--- a/agents/frameworks/nuxt-patterns.md
+++ b/agents/frameworks/nuxt-patterns.md
@@ -1,0 +1,99 @@
+## Nuxt 3 Patterns
+
+### `definePageMeta` Full Options
+
+All options available on every page component:
+
+- **`layout`** — choose a named layout from `layouts/`
+- **`middleware`** — array of named middleware to run before the page renders
+- **`keepalive`** — preserve component state between route changes (wrap pages in `<KeepAlive>`)
+- **`transition`** — named Vue transition applied on route change
+- **`validate`** — async function returning `true` to render or `false` to trigger 404
+- **`ssr: false`** — opt out of SSR for purely client-side pages (authenticated dashboards)
+
+```vue
+<script setup lang="ts">
+definePageMeta({
+  layout: 'dashboard',
+  middleware: ['auth', 'subscription'],
+  keepalive: true,
+  transition: 'fade',
+  validate: async (route) => {
+    return !isNaN(Number(route.params.id))
+  },
+})
+</script>
+```
+
+### Error Handling
+
+- **`createError({ statusCode, statusMessage })`** — throw in server handlers, composables, and pages. Creates an error that Nuxt will convert into the error page.
+- **`showError(error)`** — display the error page programmatically from client code.
+- **`clearError({ redirect: '/' })`** — dismiss the error and optionally redirect.
+- **`error.vue`** in `app/` — custom error page component; receives `error` prop with `{ statusCode, statusMessage, message }`.
+
+```ts
+// server/api/users/[id].ts
+export default defineEventHandler(async (event) => {
+  const user = await db.user.findUnique({ where: { id: event.context.params.id } })
+  if (!user) throw createError({ statusCode: 404, statusMessage: 'User not found' })
+  return user
+})
+```
+
+```vue
+<!-- app/error.vue -->
+<script setup lang="ts">
+const props = defineProps<{ error: { statusCode: number; message: string } }>()
+</script>
+<template>
+  <div>
+    <h1>{{ props.error.statusCode }}</h1>
+    <p>{{ props.error.message }}</p>
+    <button @click="clearError({ redirect: '/' })">Go home</button>
+  </div>
+</template>
+```
+
+### Plugins (`plugins/` Directory)
+
+Use plugins for: registering third-party libraries, providing app-level typed injections, one-time async setup. Export `provide` to make the plugin injectable via `useNuxtApp().$myPlugin`. Plugins run in sorted filename order — prefix with `01.`, `02.` when order matters. Keep plugins lightweight — no heavy synchronous startup work.
+
+```ts
+// plugins/01.logger.ts
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.provide('logger', {
+    info: (msg: string) => console.info(`[nuxt] ${msg}`),
+    error: (msg: string) => console.error(`[nuxt] ${msg}`),
+  })
+})
+```
+
+### `useRuntimeConfig` vs `useAppConfig`
+
+- **`useRuntimeConfig()`** — for secrets and environment-specific values. Server-only by default. Public keys under `runtimeConfig.public` are available client-side. Values come from environment variables and `nuxt.config.ts`.
+- **`useAppConfig()`** — for static, typed, non-secret app configuration that can be overridden per layer. Always available on both client and server. Defined in `app.config.ts`.
+
+Never put secrets in `appConfig` — it is serialised to the client bundle.
+
+### Nitro Caching
+
+Use `defineCachedEventHandler` or `cachedFunction` to cache expensive server computations. Set `maxAge` in seconds. Use `staleWhileRevalidate` for background refresh without blocking requests.
+
+```ts
+// server/api/expensive.ts
+export default defineCachedEventHandler(
+  async (event) => {
+    const data = await fetchFromExternalService()
+    return data
+  },
+  {
+    maxAge: 60 * 5,           // 5 minutes
+    staleWhileRevalidate: 60, // serve stale for 1 min while revalidating
+  },
+)
+```
+
+### Nuxt Layers
+
+A layer is a composable Nuxt app that another Nuxt app extends — use for shared UI kits, theme configuration, and composables across multiple Nuxt apps in a monorepo. Do NOT use a layer for code that non-Nuxt packages consume — use a regular npm package instead. Extend in `nuxt.config.ts` via `extends: ['../layers/ui']`.

--- a/agents/frameworks/vue-component-design.md
+++ b/agents/frameworks/vue-component-design.md
@@ -1,0 +1,128 @@
+## Vue 3 Component Design
+
+### Prop Drilling Prevention — Depth Rules
+
+- **1–2 levels deep** — passing props is fine. Direct parent-to-child or parent-to-grandchild is acceptable.
+- **3+ levels deep** — use `provide`/`inject` with typed Symbol keys. Never pass props through intermediate components that do not use the data.
+- **Cross-feature, app-wide, or persisted state** — use a Pinia store.
+- Prop drilling is a code smell when the intermediate components have no reason to know about the data. If the component doesn't use it, it shouldn't receive it.
+
+### `defineModel()` (Vue 3.4+)
+
+`defineModel<T>()` replaces the `modelValue` + `update:modelValue` pattern entirely. It returns a writable ref that you can bind with `v-model` in the parent.
+
+Use it for custom inputs and form field wrappers.
+
+```vue
+<!-- Child: SearchInput.vue -->
+<script setup lang="ts">
+const modelValue = defineModel<string>({ default: '' })
+</script>
+
+<template>
+  <input v-model="modelValue" placeholder="Search…" />
+</template>
+```
+
+```vue
+<!-- Parent -->
+<SearchInput v-model="query" />
+```
+
+### Compound Components with `provide`/`inject`
+
+Export injection keys as typed Symbols from a dedicated `keys.ts` file. This prevents typos and gives TypeScript accurate type inference.
+
+```ts
+// keys.ts
+import type { InjectionKey } from 'vue'
+
+export const TabsKey: InjectionKey<{
+  activeTab: Readonly<Ref<string>>
+  registerTab: (id: string) => void
+  unregisterTab: (id: string) => void
+}> = Symbol('tabs')
+```
+
+```vue
+<!-- Tabs.vue — provides -->
+<script setup lang="ts">
+import { TabsKey } from './keys.ts'
+
+const activeTab = ref('')
+const tabs = ref<string[]>([])
+
+function registerTab(id: string) { tabs.value.push(id) }
+function unregisterTab(id: string) {
+  tabs.value = tabs.value.filter(t => t !== id)
+}
+
+provide(TabsKey, { activeTab: readonly(activeTab), registerTab, unregisterTab })
+</script>
+```
+
+```vue
+<!-- Tab.vue — injects -->
+<script setup lang="ts">
+import { TabsKey } from './keys.ts'
+
+const ctx = inject(TabsKey)!
+// Call registerTab in onMounted, unregisterTab in onUnmounted
+</script>
+```
+
+Never expose injection keys as plain strings — use typed Symbols.
+
+### Component Public API Surface
+
+Keep the surface minimal. Each element earns its place.
+
+- **Props** — primary data and configuration. Use TypeScript interfaces, `withDefaults` for optionals.
+- **Emits** — one typed event per user action: `defineEmits<{ saved: [id: string] }>()`
+- **Slots** — prefer default + named slots over render-prop composables for visual composition. Use scoped slots when the parent needs child-provided state.
+- **`expose()`** — only when consumers need imperative control (focus, open/close, reset). Never expose internal state.
+
+```vue
+<script setup lang="ts">
+defineExpose({ focus, open, close })
+</script>
+```
+
+```vue
+<!-- Consumer -->
+<Modal ref="modal" />
+<!-- later: modal.open() -->
+```
+
+### `<Teleport>` for Overlay Elements
+
+Use `<Teleport to="body">` for modals, toasts, and dropdowns that must escape their stacking context. Always wrap in `v-if` so the element is not rendered until needed.
+
+```vue
+<Teleport to="body">
+  <div v-if="isOpen" class="modal-backdrop" @click.self="close">
+    <div class="modal-content">
+      <slot />
+    </div>
+  </div>
+</Teleport>
+```
+
+Pitfall: avoid teleporting large, stateful trees. Preserve focus management for accessibility.
+
+### Event Bus Is Banned
+
+Do not use mitt or any event bus for domain logic. The correct replacements are:
+
+- **Pinia actions** — for domain events and shared state
+- **Direct prop/emit** — for parent-child communication
+- **`provide`/`inject`** — for component families
+
+mitt is acceptable only for decoupling ephemeral UI events between unrelated UI components that cannot share a store.
+
+### Performance — Reactive Data Discipline
+
+- **`shallowRef`** — for large datasets (maps, arrays of hundreds of items) that do not need deep reactivity tracking.
+- **`markRaw`** — for third-party library instances (chart libraries, WebSocket clients, canvas objects) that must not be proxied.
+- **`v-memo="[dep1, dep2]"`** — on expensive list items to skip re-renders when the listed dependencies have not changed.
+- Never use `reactive()` for large immutable datasets.

--- a/agents/frameworks/vue-styling.md
+++ b/agents/frameworks/vue-styling.md
@@ -1,0 +1,88 @@
+## Vue 3 Styling Discipline
+
+### When to Use Each Approach
+
+- **`<style scoped>`** — for component-specific structural styles that cannot be expressed with utilities (complex selectors, pseudo-elements, animations, keyframes).
+- **Tailwind utility classes** — preferred for layout, spacing, colour, typography. Default choice.
+- **CSS Modules** — use when you need generated class names for deeply nested or dynamic class logic.
+- **Rule**: if a component needs more than 6 distinct utility class groups across states, extract a small component or use `@layer components`.
+
+### Tailwind v4 CSS-First Config
+
+Define design tokens in `@theme {}` block in a CSS file — this replaces `tailwind.config.js` for most customisation. Use CSS custom properties via `@theme` — they become available as Tailwind utilities automatically. Use `@utility` to create reusable utility classes and `@variant` for custom variants.
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --color-brand-50: #eff6ff;
+  --color-brand-500: #3b82f6;
+  --color-brand-600: #2563eb;
+}
+
+@layer components {
+  .btn {
+    @apply px-4 py-2 rounded-lg font-medium transition-colors;
+    background-color: var(--color-brand-500);
+    color: white;
+  }
+  .btn:hover {
+    background-color: var(--color-brand-600);
+  }
+}
+```
+
+### Template Readability with Utility Classes
+
+Use a `cn()` helper (`clsx` + `tailwind-merge` based) for conditional class composition. Break long class lists across multiple lines in template bindings. Extract repeated class patterns into a small component rather than copy-pasting class strings.
+
+```ts
+// lib/cn.ts
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+```
+
+```vue
+<script setup lang="ts">
+const cn = useCn()
+</script>
+
+<template>
+  <button
+    :class="cn(
+      'flex items-center gap-2 rounded-lg font-medium transition-colors',
+      'px-4 py-2',
+      isActive && 'bg-brand-500 text-white',
+      size === 'sm' && 'text-sm px-3 py-1',
+      size === 'lg' && 'text-lg px-6 py-3',
+    )"
+  >
+    <slot />
+  </button>
+</template>
+```
+
+### shadcn/vue Philosophy
+
+Consume via "copy-and-adapt" — components live in your repo, not installed as a black box. Override via CSS custom properties and props/slots — never reach into internals. Theme tokens via CSS variables; map to Tailwind `@theme` tokens.
+
+### `:deep()` Rules
+
+- **Legitimate**: styling third-party library components you cannot modify (e.g. date pickers, third-party rich text editors).
+- **Smell**: using `:deep()` to override a component you own — add a prop or slot instead.
+- **Never use `:deep()`** to bypass intentional encapsulation of a UI library you could instead theme or configure.
+
+### CSS Logical Properties (RTL Support)
+
+Use logical properties for directionality so layouts work correctly in RTL languages:
+
+- `inline-size` / `block-size` instead of `width` / `height`
+- `margin-inline-start` / `padding-inline-end` instead of `margin-left` / `padding-right`
+- `inset-inline-start` instead of `left`
+- `border-start-start-radius` instead of `border-top-left-radius`
+
+Tailwind v4 includes logical property utilities. Prefer them for any directional spacing.

--- a/agents/frameworks/vue-testing.md
+++ b/agents/frameworks/vue-testing.md
@@ -1,0 +1,110 @@
+## Vue 3 Testing Strategy
+
+### Three-Tier Test Taxonomy
+
+| Tier | Tool | What belongs here |
+|------|------|------------------|
+| Unit | Vitest (no DOM) | Pure functions, composables, Pinia store actions/getters, formatters, validators |
+| Component | Vitest + @testing-library/vue | Single component DOM/behaviour, user interactions, emitted events, slot rendering |
+| E2E / Acceptance | Playwright | Full user flows, page navigation, real or mocked backend, a11y |
+
+### Composable Unit Testing
+
+Import the composable and call it directly — no component wrapper needed for pure composables. If the composable uses a Pinia store, initialise a test Pinia first.
+
+```ts
+import { setActivePinia, createPinia } from 'pinia'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCounter } from './useCounter'
+
+beforeEach(() => { setActivePinia(createPinia()) })
+
+it('returns initial count of 0', () => {
+  const { count } = useCounter()
+  expect(count.value).toBe(0)
+})
+
+it('increments count', () => {
+  const { count, increment } = useCounter()
+  increment()
+  expect(count.value).toBe(1)
+})
+```
+
+### Pinia Store Testing
+
+Use `setActivePinia(createPinia())` in `beforeEach` — always reset between tests. Test actions by calling them directly and asserting state changes. Test getters by setting state and asserting getter output.
+
+```ts
+import { setActivePinia, createPinia } from 'pinestest'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCartStore } from './cart.store'
+
+let store: ReturnType<typeof useCartStore>
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  store = useCartStore()
+})
+
+it('addItem increases item count', async () => {
+  await store.addItem({ id: '1', name: 'Widget', price: 9.99 })
+  expect(store.items.length).toBe(1)
+})
+
+it('total getter sums prices', () => {
+  store.$patch({ items: [{ id: '1', name: 'W', price: 10 }, { id: '2', name: 'X', price: 5 }] })
+  expect(store.total).toBe(15)
+})
+```
+
+### Component Testing with @testing-library/vue
+
+Prefer `@testing-library/vue` over raw `@vue/test-utils` for user-centric assertions (`getByRole`, `findByText`). Use `@vue/test-utils` when you need to assert emitted events, inspect specific component output, or work with slots.
+
+Mount the real component (not shallow) unless the child is a heavy external library. Use `createTestingPinia()` from `@pinia/testing` to stub store actions.
+
+```ts
+import { render, screen, fireEvent } from '@testing-library/vue'
+import { createTestingPinia } from '@pinia/testing'
+import { describe, it, expect, vi } from 'vitest'
+import BaseButton from './BaseButton.vue'
+
+const mockTrack = vi.fn()
+vi.mock('./analytics', () => ({ track: mockTrack }))
+
+it('emits click and tracks analytics', async () => {
+  render(BaseButton, {
+    props: { label: 'Submit' },
+    global: { plugins: [createTestingPinia()] },
+  })
+  await fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+  expect(mockTrack).toHaveBeenCalledWith('button_click', expect.any(Object))
+})
+```
+
+### What NOT to Test
+
+- Internal `ref` values and private composable state
+- CSS classes (assert behaviour, not styling)
+- Snapshot blobs of entire component HTML — use targeted assertions
+- Implementation details that can change without breaking behaviour
+
+### Acceptance Testing — Component Level
+
+Use Playwright component testing (`@playwright/experimental-ct-vue`) for cross-browser component acceptance tests. Write acceptance tests in Given/When/Then language.
+
+Place in `tests/acceptance/*.acceptance.spec.ts` or mark with `.acceptance.spec.ts` suffix — separate from unit tests.
+
+```ts
+// tests/acceptance/Modal.acceptance.spec.ts
+import { test, expect } from '@playwright/test'
+
+test('modal opens and displays content', async ({ mount }) => {
+  const onClose = async () => {}
+  const component = await mount(Modal, { props: { onClose, isOpen: true } })
+
+  await expect(component.getByRole('dialog')).toBeVisible()
+  await expect(component.locator('.modal-body')).toContainText('Confirm action')
+})
+```

--- a/agents/frameworks/vue.md
+++ b/agents/frameworks/vue.md
@@ -41,3 +41,10 @@
 - Test components with `@vue/test-utils`. Prefer `mount` over `shallowMount` unless child component rendering is irrelevant to the test.
 - Use `flushPromises()` from `@vue/test-utils` after async operations before asserting DOM state.
 - Do not test implementation details (internal refs, private methods). Test observable behavior.
+
+### Performance
+
+- Use `shallowRef` instead of `ref` for large datasets (arrays of hundreds of items, maps) that do not need deep reactivity tracking.
+- Use `markRaw` to opt objects out of reactivity entirely — required for third-party class instances (chart libraries, WebSocket clients, canvas objects) that must not be proxied.
+- Use `v-memo="[dep]"` on expensive list items to skip re-renders when the listed dependencies have not changed.
+- Lazy-load heavy components with `defineAsyncComponent` and wrap with `<Suspense>` for graceful loading UI.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -6,6 +6,8 @@ A profile is a named YAML preset that selects which fragments, tech stack detail
 
 | Profile | What it's for | Language(s) |
 |---|---|---|
+| `typescript-vue-spa` | Standalone Vue 3 SPA with Vite, Pinia, Vue Router. No SSR. | TypeScript |
+| `typescript-nuxt-app` | Standalone Nuxt 3 app with SSR, file-based routing, Nitro | TypeScript |
 | `typescript-hexagonal-microservice` | TypeScript backend service with Hono, hexagonal architecture, DDD | TypeScript |
 | `typescript-bff` | Backend-for-Frontend aggregation layer | TypeScript |
 | `typescript-hexagonal-nuxt-vite-ui` | Hono backend + Nuxt 3 / Vue 3 frontend (SSR) | TypeScript |
@@ -78,5 +80,5 @@ tiers:
 Preview the composed AGENTS.md without writing any files:
 
 ```bash
-just dry-run typescript-hexagonal-microservice
+agentic compose typescript-hexagonal-microservice --dry-run
 ```

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-19T23:10:18Z",
+  "generated_at": "2026-04-20T21:19:08Z",
   "fragments": [
     {
       "name": "bff",
@@ -94,6 +94,13 @@
       "words": 363
     },
     {
+      "name": "nuxt-patterns",
+      "group": "frameworks",
+      "path": "agents/frameworks/nuxt-patterns.md",
+      "heading": "Nuxt 3 Patterns",
+      "words": 513
+    },
+    {
       "name": "nuxt",
       "group": "frameworks",
       "path": "agents/frameworks/nuxt.md",
@@ -108,11 +115,32 @@
       "words": 380
     },
     {
+      "name": "vue-component-design",
+      "group": "frameworks",
+      "path": "agents/frameworks/vue-component-design.md",
+      "heading": "Vue 3 Component Design",
+      "words": 591
+    },
+    {
+      "name": "vue-styling",
+      "group": "frameworks",
+      "path": "agents/frameworks/vue-styling.md",
+      "heading": "Vue 3 Styling Discipline",
+      "words": 432
+    },
+    {
+      "name": "vue-testing",
+      "group": "frameworks",
+      "path": "agents/frameworks/vue-testing.md",
+      "heading": "Vue 3 Testing Strategy",
+      "words": 524
+    },
+    {
       "name": "vue",
       "group": "frameworks",
       "path": "agents/frameworks/vue.md",
       "heading": "Vue 3",
-      "words": 394
+      "words": 476
     },
     {
       "name": "go",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-19T16:09:54Z",
+  "generated_at": "2026-04-20T21:19:08Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -407,6 +407,32 @@
         "vue",
         "typescript",
         "pinia"
+      ]
+    },
+    {
+      "name": "vue-component-design",
+      "group": "ui",
+      "path": "skills/ui/vue-component-design/SKILL.md",
+      "description": "Designs or reviews Vue 3 component APIs. Handles prop drilling decisions, applies compound component patterns with provi",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "vue",
+        "typescript",
+        "composition"
+      ]
+    },
+    {
+      "name": "vue-component-testing",
+      "group": "ui",
+      "path": "skills/ui/vue-component-testing/SKILL.md",
+      "description": "Applies the three-tier test taxonomy for Vue 3 applications: writes unit tests for composables and Pinia stores with Vit",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "vue",
+        "testing",
+        "vitest"
       ]
     },
     {

--- a/profiles/golang-hexagonal-vue-vite-ui.yaml
+++ b/profiles/golang-hexagonal-vue-vite-ui.yaml
@@ -49,6 +49,9 @@ tiers:
       - typescript
     frameworks:
       - vue
+      - vue-component-design
+      - vue-testing
+      - vue-styling
     architecture: []
     commands:
       build_command: "pnpm build"
@@ -75,6 +78,8 @@ skills:
   - write-readme
   - relational-database-design
   - vue-application-structure
+  - vue-component-design
+  - vue-component-testing
   - internationalization-i18n
   - sql-query-optimization
   - health-check-endpoints

--- a/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
@@ -53,6 +53,10 @@ tiers:
     frameworks:
       - vue
       - nuxt
+      - vue-component-design
+      - vue-testing
+      - vue-styling
+      - nuxt-patterns
     architecture: []
     commands:
       build_command: "pnpm --filter ui build"
@@ -86,6 +90,8 @@ skills:
   - write-readme
   - relational-database-design
   - vue-application-structure
+  - vue-component-design
+  - vue-component-testing
   - internationalization-i18n
   - wireframe-prototyping
   - static-code-analysis

--- a/profiles/typescript-hexagonal-vue-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-vue-vite-ui.yaml
@@ -48,6 +48,9 @@ tiers:
       - typescript
     frameworks:
       - vue
+      - vue-component-design
+      - vue-testing
+      - vue-styling
     architecture: []
     commands:
       build_command: "pnpm --filter ui build"
@@ -74,6 +77,8 @@ skills:
   - write-readme
   - relational-database-design
   - vue-application-structure
+  - vue-component-design
+  - vue-component-testing
   - internationalization-i18n
   - wireframe-prototyping
   - static-code-analysis

--- a/profiles/typescript-nuxt-app.yaml
+++ b/profiles/typescript-nuxt-app.yaml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
+meta:
+  name: "TypeScript Nuxt 3 App"
+  description: >
+    Standalone Nuxt 3 application with Vue 3, Pinia, Tailwind CSS v4, and Vitest.
+    SSR-capable with file-based routing. Covers Nuxt-specific patterns (definePageMeta,
+    error handling, plugins, runtime config, Nitro caching, Layers), Vue component
+    design, composition patterns, prop drilling prevention, styling discipline, and
+    a three-tier test strategy (unit / component / acceptance).
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+  languages:
+    - typescript
+  frameworks:
+    - vue
+    - nuxt
+    - vue-component-design
+    - vue-testing
+    - vue-styling
+    - nuxt-patterns
+  architecture: []
+  practices:
+    - tdd
+    - api-design
+    - ci-cd
+  domains: []
+
+tech_stack:
+  language_runtime: "Node 22+"
+  package_manager: "pnpm"
+  frontend_framework: "Nuxt 3"
+  ui_component_library: "shadcn/vue"
+  css_framework: "Tailwind CSS v4"
+  build_tool: "Vite 6 (via Nuxt)"
+  test_framework: "Vitest + @testing-library/vue"
+  additional:
+    - "Vue 3"
+    - "Pinia"
+    - "Vue Router 4 (via Nuxt)"
+    - "Nitro"
+    - "Playwright (acceptance)"
+
+skills:
+  - code-review
+  - add-tests
+  - vue-application-structure
+  - vue-component-design
+  - vue-component-testing
+  - wireframe-prototyping
+  - internationalization-i18n
+  - static-code-analysis
+  - write-readme
+  - write-adr
+  - github-actions-workflow
+
+output:
+  build_command: "pnpm build"
+  test_command: "pnpm test"
+  lint_command: "pnpm lint"
+  project_header: |
+    Standalone Nuxt 3 application with SSR.
+    All components use <script setup lang="ts"> exclusively — no Options API.
+    State management via Pinia setup stores. File-based routing via Nuxt.
+    Styling via Tailwind CSS v4; shadcn/vue for UI primitives.
+    Server routes under server/api/ via Nitro. SSR safety rules apply everywhere.
+    Three-tier testing: Vitest unit tests for composables/stores, @testing-library/vue
+    for component behaviour, Playwright for acceptance tests.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/profiles/typescript-vue-spa.yaml
+++ b/profiles/typescript-vue-spa.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
+meta:
+  name: "TypeScript Vue 3 SPA"
+  description: >
+    Standalone Vue 3 single-page application with Vite, Pinia, Vue Router,
+    and Vitest. No server-side rendering. Covers component design, composition
+    patterns, prop drilling prevention, Tailwind v4 styling discipline, and a
+    three-tier test strategy (unit / component / acceptance).
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+  languages:
+    - typescript
+  frameworks:
+    - vue
+    - vue-component-design
+    - vue-testing
+    - vue-styling
+  architecture: []
+  practices:
+    - tdd
+    - api-design
+    - ci-cd
+  domains: []
+
+tech_stack:
+  language_runtime: "Node 22+"
+  package_manager: "pnpm"
+  frontend_framework: "Vue 3 (SPA)"
+  ui_component_library: "shadcn/vue"
+  css_framework: "Tailwind CSS v4"
+  build_tool: "Vite 6"
+  test_framework: "Vitest + @testing-library/vue"
+  additional:
+    - "Pinia"
+    - "Vue Router 4"
+    - "Playwright (acceptance)"
+
+skills:
+  - code-review
+  - add-tests
+  - vue-application-structure
+  - vue-component-design
+  - vue-component-testing
+  - wireframe-prototyping
+  - internationalization-i18n
+  - static-code-analysis
+  - write-readme
+  - github-actions-workflow
+
+output:
+  build_command: "pnpm build"
+  test_command: "pnpm test"
+  lint_command: "pnpm lint"
+  project_header: |
+    Standalone Vue 3 SPA — no server-side rendering.
+    All components use <script setup lang="ts"> exclusively — no Options API.
+    State management via Pinia setup stores. Routing via Vue Router 4 with typed routes.
+    Styling via Tailwind CSS v4 utility classes; shadcn/vue for UI primitives.
+    Three-tier testing: Vitest unit tests for composables/stores, @testing-library/vue
+    for component behaviour, Playwright for acceptance tests.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/skills/ui/vue-component-design/SKILL.md
+++ b/skills/ui/vue-component-design/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: vue-component-design
+description: >
+  Designs or reviews Vue 3 component APIs. Handles prop drilling decisions,
+  applies compound component patterns with provide/inject, defines minimal public
+  API surfaces with typed props/emits/slots, and enforces Vue 3.4+ composition
+  conventions. Invoked when creating new components, refactoring existing ones,
+  or reviewing component contracts.
+version: 1.0.0
+tags:
+  - ui
+  - vue
+  - typescript
+  - composition
+resources: []
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Vue Component Design Skill
+
+### Step 1 — Identify the Component's Responsibility
+
+Determine the component type before designing the API:
+
+- **Page component** — orchestrates data fetching, permissions, and layout. Coordinates child components. Tests: mock data fetching, verify correct children are rendered.
+- **Feature component** — contains feature-specific business logic and local state. May call store actions. Tests: mock store, assert state changes.
+- **UI component** — pure presentational, props + slots only, no async logic, no store access. Tests: assert correct markup for given props.
+
+### Step 2 — Design the Public API Surface
+
+- **Props**: minimal, typed with TypeScript interfaces, `withDefaults` for optional props with safe defaults.
+- **Emits**: typed `defineEmits<{ eventName: [payload] }>()` — one event per user action.
+- **Slots**: default for content, named for layout regions, scoped when parent needs child-provided state.
+- **`expose()`**: only for imperative handles (focus, open, reset) — never expose internal state.
+- Use `defineModel<T>()` (Vue 3.4+) for two-way binding instead of `modelValue` + `update:modelValue`.
+
+### Step 3 — Evaluate Prop Drilling Depth
+
+Count how many component levels the data crosses:
+
+- **1–2 levels** → props are acceptable
+- **3+ levels** through components that do not use the data → refactor to `provide`/`inject` with typed Symbol keys
+- **Global / cross-feature / persisted** → Pinia store
+
+```ts
+// keys.ts
+import type { InjectionKey } from 'vue'
+
+export const AccordionKey: InjectionKey<{
+  openId: Readonly<Ref<string | null>>
+  toggle: (id: string) => void
+}> = Symbol('accordion')
+```
+
+### Step 4 — Composition Review
+
+- Does the component do too much? Apply single responsibility: extract orchestration logic into a composable, keep the template as a thin consumer.
+- Are slots used where a child component should receive data and render itself? Prefer scoped slots over prop-drilling display logic.
+- Is `<Teleport>` needed? Use for modals, toasts, and dropdowns that must escape their stacking context.
+
+### Step 5 — Verify
+
+- [ ] No props passed through more than 2 intermediate components that do not use them
+- [ ] `defineModel()` used instead of manual `modelValue` + `update:modelValue` pattern
+- [ ] Provide/inject keys are typed Symbols, not plain strings
+- [ ] `expose()` only used for imperative handles (never internal state)
+- [ ] UI components contain no async logic or store access
+- [ ] `pnpm tsc --noEmit` passes with no errors

--- a/skills/ui/vue-component-testing/SKILL.md
+++ b/skills/ui/vue-component-testing/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: vue-component-testing
+description: >
+  Applies the three-tier test taxonomy for Vue 3 applications: writes unit tests for
+  composables and Pinia stores with Vitest, component tests for behaviour and user
+  interactions with @testing-library/vue, and acceptance tests for full user flows
+  with Playwright. Ensures tests focus on observable behaviour, not implementation
+  details. Invoked when adding or reviewing tests for a Vue project.
+version: 1.0.0
+tags:
+  - ui
+  - vue
+  - testing
+  - vitest
+resources: []
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Vue Component Testing Skill
+
+### Step 1 — Classify What Needs to Be Tested
+
+For each piece of code, assign a test tier:
+
+- **Composable / store action / pure function** → Unit test (Vitest, no DOM)
+- **Component behaviour / user interaction / emitted events** → Component test (@testing-library/vue + Vitest)
+- **User flow across pages / real navigation** → E2E (Playwright)
+
+List all files in scope and assign each a tier before writing any tests.
+
+### Step 2 — Write Unit Tests (Composables and Stores)
+
+- **Composable**: import and call directly, assert returned refs/computed values. Use `setActivePinia(createPinia())` in `beforeEach` if the composable accesses a store.
+- **Store**: `setActivePinia(createPinia())` in `beforeEach`, call actions directly, assert state. Test getters by patching state.
+- No DOM, no component mounting — pure JS/TS only.
+
+```ts
+import { setActivePinia, createPinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useAuthStore } from './auth.store'
+
+let store: ReturnType<typeof useAuthStore>
+beforeEach(() => { setActivePinia(createPinia()); store = useAuthStore() })
+
+it('login sets user', async () => {
+  await store.login({ email: 'a@b.com', password: 'secret' })
+  expect(store.user).not.toBeNull()
+})
+```
+
+### Step 3 — Write Component Tests
+
+- Use `@testing-library/vue` for user-centric assertions: `getByRole`, `findByText`, `userEvent`.
+- Use `@vue/test-utils` when asserting emitted events, inspecting component output, or working with slots.
+- Use `createTestingPinia()` from `@pinia/testing` to stub store actions.
+- Mount the real component (not shallow) unless the child is a heavy external library.
+- Assert: what the user sees (text, roles, visibility), which events are emitted, which store actions are called.
+- Do NOT assert: internal refs, CSS classes, snapshot blobs.
+
+```ts
+import { render, screen, fireEvent } from '@testing-library/vue'
+import { createTestingPinia } from '@pinia/testing'
+import { describe, expect, it, vi } from 'vitest'
+import BaseButton from './BaseButton.vue'
+
+const mockTrack = vi.fn()
+vi.mock('./analytics', () => ({ trackEvent: mockTrack }))
+
+it('tracks click event on button press', async () => {
+  render(BaseButton, {
+    props: { label: 'Save' },
+    global: { plugins: [createTestingPinia()] },
+  })
+  await fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+  expect(mockTrack).toHaveBeenCalledWith('button_click', expect.any(Object))
+})
+```
+
+### Step 4 — Write Acceptance Tests (Component Level)
+
+- Use Playwright component testing (`@playwright/experimental-ct-vue`) for cross-browser component acceptance tests.
+- Write in Given/When/Then language: "Given a user is on the login page, when they submit invalid credentials, then an error message is displayed."
+- Test the full component contract from a user perspective: inputs → visible output.
+- Place in `tests/acceptance/*.acceptance.spec.ts` — separate from unit and component tests.
+
+```ts
+// tests/acceptance/LoginForm.acceptance.spec.ts
+import { test, expect } from '@playwright/test'
+
+test('shows error on invalid credentials', async ({ mount }) => {
+  const component = await mount(LoginForm, { props: { onSuccess: () => {} } })
+
+  await component.getByPlaceholder('Email').fill('bad@example.com')
+  await component.getByPlaceholder('Password').fill('wrong')
+  await component.getByRole('button', { name: 'Sign in' }).click()
+
+  await expect(component.locator('.error-message')).toContainText('Invalid credentials')
+})
+```
+
+### Step 5 — Verify
+
+- [ ] Each composable has at least one unit test
+- [ ] Each Pinia store has unit tests for actions and getters
+- [ ] Each interactive component has component tests for its primary interactions
+- [ ] No test asserts internal implementation details (refs, private state, CSS classes)
+- [ ] `pnpm test` passes with zero failures


### PR DESCRIPTION
## Summary

Extends the library with Vue 3 / Nuxt 3 frontend depth: four new fragments, two new skills, two new pure-frontend profiles, three updated full-stack profiles, and docs kept in sync.

---

## Files added

| File | Type | Purpose |
|---|---|---|
| `agents/frameworks/vue-component-design.md` | Fragment | Prop drilling depth rules, `defineModel()`, compound `provide`/`inject`, `expose()`, `<Teleport>`, event bus ban, `shallowRef`/`markRaw`/`v-memo` |
| `agents/frameworks/vue-testing.md` | Fragment | Three-tier test taxonomy (unit / component / acceptance), composable unit tests, Pinia store testing, `@testing-library/vue`, Playwright CT |
| `agents/frameworks/vue-styling.md` | Fragment | Tailwind v4 CSS-first `@theme` config, `cn()` helper, shadcn/vue copy-don't-install philosophy, `:deep()` legitimacy rules, CSS logical properties |
| `agents/frameworks/nuxt-patterns.md` | Fragment | `definePageMeta` full options, `createError`/`showError`/`error.vue`, plugins, `useRuntimeConfig` vs `useAppConfig`, Nitro caching, Nuxt Layers |
| `skills/ui/vue-component-design/SKILL.md` | Skill | 5-step skill: identify responsibility → design API → evaluate prop drilling → composition review → verify |
| `skills/ui/vue-component-testing/SKILL.md` | Skill | 5-step skill: classify tier → unit tests → component tests → acceptance tests → verify |
| `profiles/typescript-vue-spa.yaml` | Profile | 100% frontend — standalone Vue 3 SPA, Vite, Pinia, Vue Router, no SSR |
| `profiles/typescript-nuxt-app.yaml` | Profile | 100% frontend — standalone Nuxt 3 app, SSR, file-based routing, Nitro |

## Files modified

| File | Change |
|---|---|
| `agents/frameworks/vue.md` | Appended `### Performance` section (`shallowRef`, `markRaw`, `v-memo`, `defineAsyncComponent`) |
| `profiles/typescript-hexagonal-vue-vite-ui.yaml` | Added `vue-component-design`, `vue-testing`, `vue-styling` to `ui` tier frameworks; added `vue-component-design`, `vue-component-testing` to skills |
| `profiles/typescript-hexagonal-nuxt-vite-ui.yaml` | Same as above + `nuxt-patterns` in `ui` tier frameworks |
| `profiles/golang-hexagonal-vue-vite-ui.yaml` | Same as `typescript-hexagonal-vue-vite-ui` |
| `docs/profiles.md` | Added `typescript-vue-spa` and `typescript-nuxt-app` to profiles table; fixed `just dry-run` → `agentic compose --dry-run` |
| `README.md` | Added `typescript-vue-spa` and `typescript-nuxt-app` to the Available Profiles table |
| `index/fragments.json` | Rebuilt — 30 fragments (+4) |
| `index/skills.json` | Rebuilt — 35 skills (+2) |

## Quality gates

| Gate | Result |
|---|---|
| `just lint` | ✅ 0 findings — 30 fragments, 35 skills, 15 profiles, 5 vendor adapters |
| `just index` | ✅ Rebuilt |
| `just test` | ✅ 310/310 passed |