### PR TITLE
fix(docs): remove just legacy references, drop migration section, slim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A centralized, vendor-agnostic library for composing AI agent instructions — p
 
 ![CI](https://github.com/soulcodex/agentic/actions/workflows/validate.yml/badge.svg)
 
-One library. One deploy. All your AI tools stay in sync.
-
 ---
 
 ## The Problem
@@ -49,129 +47,80 @@ my-project/
 
 Instructions drift and contradict each other. Every new project starts from scratch. Adding a new AI tool means updating N files manually.
 
-Customize per-project with local profiles and project-specific skills → [docs/customization.md](docs/customization.md)
-
 ---
 
-## Quickstart
-
-### One-line Install
+## Install
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash
 ```
 
-This clones the library to `~/.local/share/agentic` and installs the `agentic` CLI to `~/.local/bin`.
-
-### Manual Install
-
-```bash
-# 1. Clone the library
-git clone https://github.com/soulcodex/agentic ~/agentic-library
-
-# 2. Install the global CLI
-cd ~/agentic-library
-just install
-# (installs to ~/.local/bin — add to PATH if needed)
-```
-
-### Deploy to a Project
-
-```bash
-# List available profiles
-agentic list profiles
-
-# Deploy to your project
-agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
-```
-
-Writes `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`, `GEMINI.md`, `.gemini/system.md`, and `.agentic/config.yaml` into `~/code/my-api`. Run `agentic sync` from within any project to regenerate from local profile.
+Installs the `agentic` CLI to `~/.local/bin`. Requires `bash`, `just`, `yq`, `jq` — run `just setup` from the library directory to check prerequisites.
 
 ---
 
-## Available Profiles
+## Deploy to a project
 
-| Profile | What it's for | Language(s) |
-|---|---|---|
-| `typescript-vue-spa` | Standalone Vue 3 SPA — Vite, Pinia, Vue Router, no SSR | TypeScript |
-| `typescript-nuxt-app` | Standalone Nuxt 3 app — SSR, file-based routing, Nitro | TypeScript |
-| `typescript-hexagonal-microservice` | TypeScript backend service with Hono | TypeScript |
-| `typescript-bff` | Backend-for-Frontend aggregation layer | TypeScript |
-| `typescript-hexagonal-nuxt-vite-ui` | Hono backend + Nuxt 3 / Vue 3 (SSR) | TypeScript |
-| `typescript-hexagonal-vue-vite-ui` | Hono backend + Vue 3 SPA (no SSR) | TypeScript |
-| `go-hexagonal-microservice` | Go backend microservice | Go |
-| `golang-hexagonal-nuxt-vite-ui` | Go backend + Nuxt 3 / Vue 3 (SSR) | Go + TypeScript |
-| `golang-hexagonal-vue-vite-ui` | Go backend + Vue 3 SPA (no SSR) | Go + TypeScript |
-| `golang-hexagonal-cobra-cli` | Go CLI tool with Cobra + Viper | Go |
-| `python-fastapi-microservice` | FastAPI service with uv + Pydantic | Python |
-| `python-hexagonal-typer-cli` | Python CLI tool with Typer + Rich | Python |
-| `php-hexagonal-ddd` | PHP 8.3+ Symfony application | PHP |
-| `go-library` | Go reusable library/package with stable public API | Go |
-| `typescript-library` | TypeScript reusable library for npm/private registry | TypeScript |
+```bash
+# See what profiles are available
+agentic list profiles
 
-[Full profile details, nested mode, and tier config →](docs/profiles.md)
+# Deploy — assembles AGENTS.md, generates vendor files, deploys skills
+agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
+```
+
+Run `agentic sync` from within any project to regenerate from the local profile.
+
+---
+
+## Commands
+
+```bash
+agentic deploy <profile> [target] <vendors>   # full deploy pipeline
+agentic compose <profile> [target]            # assemble AGENTS.md only
+agentic switch [target] <vendors>             # switch active AI tool
+agentic sync [target]                         # regenerate from local profile
+agentic list profiles|skills|vendors          # list available resources
+```
+
+→ [Full command reference](https://agentic.soulcodex.link/commands)
+
+---
+
+## Profiles
+
+15 ready-made profiles covering TypeScript, Go, Python, PHP — frontend SPAs, microservices, CLIs, full-stack.
+
+→ [Browse all profiles](https://agentic.soulcodex.link/profiles)
 
 ---
 
 ## Supported AI Tools
 
-| Vendor | Output file(s) |
-|---|---|
-| **Claude** (Claude Code) | `AGENTS.md`, `CLAUDE.md`, `.claude/skills/` |
-| **GitHub Copilot** | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` |
-| **OpenAI Codex** | `AGENTS.md` |
-| **Gemini CLI** | `GEMINI.md`, `.gemini/system.md`, `.gemini/skills/` |
-| **Opencode** | `AGENTS.md` (native), `.opencode/skills/` |
+Claude, GitHub Copilot, Gemini CLI, OpenAI Codex, Opencode — all from one `AGENTS.md`.
 
-[Vendor details, glob mechanism, and vendor-switch →](docs/vendors.md)
+→ [Vendor details](https://agentic.soulcodex.link/vendors)
 
 ---
 
-## Key Commands
+## Customise
 
-```bash
-# Global CLI (install with: just install)
-agentic deploy PROFILE TARGET VENDORS    # compose + vendor-gen + deploy skills
-agentic compose PROFILE [TARGET]         # assemble AGENTS.md from profile
-agentic switch [TARGET] VENDORS          # switch active vendor(s)
-agentic sync [TARGET]                    # regenerate from local profile
-agentic list profiles|skills|vendors     # list available resources
+Edit `.agentic/profile.yaml` and run `agentic sync` to update your project.
+Add project-specific skills in `.agentic/project-skills/`.
 
-# Legacy just recipes (still work from library dir)
-just deploy PROFILE TARGET VENDORS       # same as agentic deploy
-just dry-run PROFILE                     # preview without writing files
-just lint && just test                   # validate the library
-```
-
-<details>
-<summary>Full command reference</summary>
-
-See [docs/commands.md](docs/commands.md) for the complete reference including discovery, composition, deployment, maintenance, MCP server commands, and platform notes on link mode.
-
-</details>
+→ [Customization guide](https://agentic.soulcodex.link/customization) · [Custom rules](https://agentic.soulcodex.link/custom-rules)
 
 ---
 
-## Extending
+## Contributing
 
-Add a fragment, profile, skill, or vendor adapter — all in plain Markdown and YAML.
+Contributions are welcome — new fragments, profiles, and skills.
+Run `just lint && just test` before opening a PR.
 
-**Project-local skills**: Create project-specific skills in `.agentic/project-skills/` and reference them with the `project:` prefix. See the extending guide for details.
-
-[Extending guide →](docs/extending.md)
-
-Add project-specific rules without touching the library → [docs/custom-rules.md](docs/custom-rules.md)
-
----
-
-## Prerequisites & Contributing
-
-Run `just setup` to check (and install on macOS) all required tools: `just`, `bash`, `yq`, `jq`.
-
-Contributions are welcome — new fragments, profiles, vendor adapters, and skills. Please see our [Contributing Guide](.github/CONTRIBUTING.md) for details on how to set up the development environment, run quality checks, and submit pull requests. Run `just lint && just test` before opening a PR.
+→ [Extending guide](https://agentic.soulcodex.link/extending) · [Contributing guide](.github/CONTRIBUTING.md)
 
 ---
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
+[MIT](LICENSE)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,22 +1,19 @@
 # Command Reference
 
-## Global CLI
+## CLI Overview
 
-The `agentic` CLI provides a unified interface for managing agent instructions across all your projects.
+The `agentic` CLI provides a unified interface for managing agent instructions
+across all your projects.
 
 ### Installation
 
-```bash
-# From the agentic library directory
-just install           # Installs to ~/.local/bin (default)
-just install global    # Installs to /usr/local/bin (requires sudo)
+One-line install (installs to ~/.local/bin):
 
-# Uninstall
-just uninstall         # Remove from ~/.local/bin
-just uninstall global  # Remove from /usr/local/bin
+```bash
+curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash
 ```
 
-After installation, ensure `~/.local/bin` is in your `PATH`:
+Ensure `~/.local/bin` is in your PATH:
 
 ```bash
 export PATH="$HOME/.local/bin:$PATH"
@@ -74,6 +71,11 @@ agentic deploy golang-hexagonal-cobra-cli ./my-cli claude
 agentic deploy typescript-hexagonal-microservice . claude,copilot
 agentic deploy python-fastapi-microservice gemini --full
 ```
+
+> **Link mode (`--link`):** Creates POSIX symlinks instead of copying files — POSIX only,
+> not supported on Windows without WSL. The target repo stays minimal: only `config.yaml`,
+> `profile.yaml`, and `project-skills/` are committed; fragments, skills, and vendor-files
+> are live symlinks to the library. Run `agentic sync` to re-create broken symlinks.
 
 ### compose
 
@@ -145,130 +147,6 @@ agentic list <resource>
 agentic list profiles
 agentic list skills
 agentic list vendors
-```
-
----
-
-## Just Recipes (Legacy)
-
-These recipes still work when run from the agentic library directory. They're useful
-for library development and for users who haven't installed the global CLI.
-
-### Discovery
-
-```bash
-just list-profiles          # List all available composition profiles
-just list-skills            # List all available skills
-just list-fragments         # List all available fragment files
-```
-
-### Composition
-
-```bash
-just compose PROFILE TARGET           # Compose AGENTS.md (lean mode)
-just compose-full PROFILE TARGET      # Compose AGENTS.md (full mode)
-just dry-run PROFILE                  # Preview without writing files
-just validate TARGET                  # Validate AGENTS.md in a project
-just sync-check TARGET                # Check for config drift
-just sync TARGET                      # Re-sync configuration
-```
-
-### Link Mode (POSIX only)
-
-> **Platform note:** The `--link` / `compose-linked` / `deploy-linked` commands use
-> POSIX symlinks and are **not supported on Windows** (without WSL). On non-POSIX
-> systems these commands will fail with a clear error. Use the standard `compose` /
-> `deploy` commands instead, which copy files and work on all platforms.
->
-> These commands create POSIX symlinks instead of copying files. The target repo stays
-> minimal — only `config.yaml`, `profile.yaml`, and `project-skills/` are committed;
-> fragments, skills, and vendor-files are live symlinks back to the library.
-
-```bash
-just compose-linked PROFILE TARGET          # Compose using symlinks
-just deploy-linked PROFILE TARGET VENDORS   # Full pipeline using symlinks
-just sync-links TARGET                      # Re-create broken symlinks from config
-```
-
-### Deployment
-
-```bash
-just deploy PROFILE TARGET VENDORS          # Full pipeline
-just deploy-full PROFILE TARGET VENDORS     # Full pipeline (monolithic)
-just vendor-gen TARGET [VENDORS]            # Generate vendor files only
-just deploy-skills TARGET SKILLS VENDORS    # Deploy skills only
-just vendor-switch TARGET VENDORS           # Switch active vendors
-```
-
-### Library Maintenance
-
-```bash
-just lint    # Validate fragments, profiles, adapters, skills
-just test    # Run integration test suite
-just index   # Rebuild index files
-just setup   # Check/install required tools
-```
-
-### MCP Servers
-
-```bash
-just mcp-add TARGET                  # Add an MCP server (interactive)
-just mcp-remove TARGET SERVER_NAME   # Remove an MCP server
-just mcp-list TARGET                 # List configured MCP servers
-```
-
----
-
-## Migration from ./agentic Wrapper
-
-If you have projects using the old `./agentic` wrapper script, follow these steps
-to migrate to the global CLI.
-
-### 1. Update the Library
-
-```bash
-cd ~/agentic-library   # or wherever you cloned it
-git pull origin main
-```
-
-### 2. Install the Global CLI
-
-```bash
-just install
-# Installs to ~/.local/bin — add to PATH if needed
-```
-
-### 3. Remove the Old Wrapper
-
-For each project with the old wrapper:
-
-```bash
-cd /path/to/your-project
-rm ./agentic                    # Remove the wrapper script
-
-# Edit .gitignore to remove the /agentic line if present
-```
-
-### 4. Update Config (Automatic)
-
-The old `library_path` key is now `agentic_root`. This updates automatically
-on the next `agentic sync` or `agentic deploy`. You can also update manually:
-
-```yaml
-# In .agentic/config.yaml
-# Old:
-library_path: "/path/to/agentic"
-
-# New:
-agentic_root: "/path/to/agentic"
-```
-
-### 5. Verify
-
-```bash
-cd /path/to/your-project
-agentic sync              # Should work from within project
-agentic switch list       # Show available vendors
 ```
 
 ---

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,6 +1,6 @@
 # Extending agentic
 
-The library is designed to be forked and extended. Here is how to add each type of asset.
+Here is how to extend the library with new fragments, profiles, skills, and project-local customisations.
 
 ## Add a Fragment
 
@@ -14,14 +14,10 @@ Rules:
 ```bash
 # 1. Create the file
 touch agents/practices/my-practice.md
-# Write your guidelines (one ## H2 heading at the top)
-
-# 2. Rebuild the index so lint and compose can find it
-just index
-
-# 3. Validate
-just lint
+# Write your guidelines — one ## H2 heading at the top, plain Markdown, no project-specific content
 ```
+
+After creating the file, run `agentic list fragments` to confirm it is discovered.
 
 Then add the fragment name to any profile's `fragments.practices` list:
 
@@ -40,8 +36,9 @@ Profiles are YAML presets in `profiles/{name}.yaml`.
 ```bash
 cp profiles/golang-hexagonal-cobra-cli.yaml profiles/my-profile.yaml
 # Edit: name, description, fragment lists, tech_stack, skills, output commands
-just lint
-just dry-run my-profile
+
+# Preview the assembled AGENTS.md without writing any files
+agentic compose my-profile --dry-run
 ```
 
 Minimum required fields:
@@ -79,9 +76,9 @@ Skills are reusable agent task definitions in `skills/{group}/{name}/SKILL.md`.
 mkdir -p skills/development/my-skill
 # Groups: development, agentic, data, quality, architecture, or any custom name
 # Write skills/development/my-skill/SKILL.md with frontmatter + steps
-just index
-just lint
 ```
+
+Run `agentic list skills` to confirm the skill is discovered after creating it.
 
 Required frontmatter:
 
@@ -198,13 +195,7 @@ tiers:
 
 ## Add a Vendor Adapter
 
-Vendor adapters live in `vendors/{name}/`. Each adapter transforms `AGENTS.md`
-into the format expected by a specific AI tool.
-
-1. Create `vendors/my-tool/` directory.
-2. Add a template file (e.g., `template.my-tool.md`).
-3. Create `tooling/lib/vendors/my-tool.sh` with a `gen_mytool()` function (see existing vendor scripts for the pattern).
-4. Add a `# shellcheck source=tooling/lib/vendors/my-tool.sh` directive and `source` call to `tooling/lib/vendor-gen.sh`'s vendor-loading block.
-5. Add `my-tool` to the `AGENTIC_VENDORS` array in `tooling/lib/common.sh`.
-6. Add `my-tool` to the `vendors.enabled` list in any profiles that should use it.
-7. Run `just lint && just test`.
+Adding a new vendor adapter requires changes to the library internals. Open an issue
+or pull request on the [GitHub repository](https://github.com/soulcodex/agentic)
+describing the vendor and its expected output format. See the existing adapters in
+`vendors/` for the implementation pattern.


### PR DESCRIPTION
## Summary

- **`docs/commands.md`**: Full rewrite — replaced `just install` block with curl install script, moved the Link Mode platform note from the Just Recipes section to the `deploy` command, removed the entire "Just Recipes (Legacy)" and "Migration from ./agentic Wrapper" sections.
- **`docs/extending.md`**: Targeted edits — dropped "forked" framing from intro, replaced `just index` / `just lint` / `just dry-run` bash blocks with `agentic list` / `agentic compose --dry-run` equivalents, reframed the Vendor Adapter section as a contribution note.
- **`README.md`**: Slimmed to ~75 lines — removed the full profile table, legacy just recipe block, detailed quickstart sections; kept the problem/solution, install, deploy, commands, profiles, vendors, customise, and contributing sections; all docs links now point to the live docs site.

## Editorial principles applied

1. **agentic is a CLI tool** — `agentic <subcommand>` is the only user-facing interface; `just` recipes are internal library dev tools.
2. **No legacy migration content** — `./agentic` wrapper references removed entirely.
3. **No fork framing** — library is extended through profiles, skills, and project-local customisation via `agentic` commands.
4. **README is a lean hook** — earns attention and gets users to the first deploy; detail lives in the docs site.