### PR TITLE
fix(docs): restructure extending page and add Linux install support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,6 +41,61 @@ just lint && just test
 
 All tests must pass before your PR can be merged.
 
+## Adding Library Assets
+
+### Add a Fragment
+
+Fragments are composable Markdown building blocks in `agents/{group}/{name}.md`.
+Groups: `base`, `languages`, `frameworks`, `architecture`, `practices`, `domains`.
+
+```bash
+touch agents/practices/my-practice.md
+# Write your guidelines — one ## H2 heading at the top, plain Markdown, no project-specific content
+```
+
+Add the fragment name to any profile's `fragments.<group>` list:
+
+```yaml
+fragments:
+  practices:
+    - tdd
+    - my-practice
+```
+
+Run `just index && just lint` before opening a PR.
+
+### Add a Profile
+
+Profiles are YAML presets in `profiles/{name}.yaml`. Naming convention: `{language}-{framework}-{pattern}.yaml`.
+
+```bash
+cp profiles/golang-hexagonal-cobra-cli.yaml profiles/my-profile.yaml
+# Edit: name, description, fragment lists, tech_stack, skills, output commands
+agentic compose my-profile --dry-run   # Preview the assembled AGENTS.md
+```
+
+Minimum required fields: `meta` (name, description, version), `fragments`, `output` (build/test/lint commands), `vendors.enabled`.
+Optional: `tech_stack`, `skills`, `output.structure: nested`, `tiers`.
+
+Run `just lint` before opening a PR.
+
+### Add a Skill
+
+Skills are reusable agent task definitions in `skills/{group}/{name}/SKILL.md`.
+
+```bash
+mkdir -p skills/development/my-skill
+# Write skills/development/my-skill/SKILL.md with frontmatter and steps
+```
+
+Required frontmatter: `name`, `description` (>=20 chars), `version` (SemVer), `tags`, `resources`, `vendor_support` (claude/opencode: `native`; copilot/codex/gemini: `prompt-inject`).
+
+Run `just index && just lint` before opening a PR.
+
+### Add a Vendor Adapter
+
+Adding a vendor adapter requires changes to the library internals. Open an issue or PR describing the vendor and its expected output format. See existing adapters in `vendors/` for the implementation pattern.
+
 ## Fragment Authoring Rules
 
 Fragments are composable building blocks in `agents/`. Each fragment must be:

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,125 +1,23 @@
-# Extending agentic
+# Project Customisation
 
-Here is how to extend the library with new fragments, profiles, skills, and project-local customisations.
+How to extend your project's agentic setup with project-local skills and proprietary library declarations.
 
-## Add a Fragment
+## Project-Local Skills
 
-Fragments are composable Markdown building blocks in `agents/{group}/{name}.md`.
+For skills specific to a single project that shouldn't live in the shared library,
+create them in the project's `.agentic/project-skills/` directory.
 
-Rules:
-- Exactly one `## Heading` per file (no subheadings at H1 level).
-- Plain Markdown — no hardcoded project names, paths, or secrets.
-- Group: `base`, `languages`, `frameworks`, `architecture`, `practices`, or `domains`.
+> See also: [Customization](customization.md) for a quick overview of all project customisation options.
 
-```bash
-# 1. Create the file
-touch agents/practices/my-practice.md
-# Write your guidelines — one ## H2 heading at the top, plain Markdown, no project-specific content
-```
-
-After creating the file, run `agentic list fragments` to confirm it is discovered.
-
-Then add the fragment name to any profile's `fragments.practices` list:
-
-```yaml
-fragments:
-  practices:
-    - tdd
-    - api-design
-    - my-practice     # ← add here
-```
-
-## Add a Profile
-
-Profiles are YAML presets in `profiles/{name}.yaml`.
+### Create a skill
 
 ```bash
-cp profiles/golang-hexagonal-cobra-cli.yaml profiles/my-profile.yaml
-# Edit: name, description, fragment lists, tech_stack, skills, output commands
-
-# Preview the assembled AGENTS.md without writing any files
-agentic compose my-profile --dry-run
-```
-
-Minimum required fields:
-
-```yaml
-meta:
-  name: "My Profile"
-  description: What this profile is for.
-  version: "1.0.0"
-
-fragments:
-  base: [git-conventions, security, code-review, testing-philosophy, documentation]
-  languages: [go]
-  frameworks: []
-  architecture: [hexagonal]
-  practices: [tdd]
-  domains: []
-
-output:
-  build_command: "go build ./..."
-  test_command:  "go test ./..."
-  lint_command:  "golangci-lint run"
-
-vendors:
-  enabled: [claude, copilot, codex, gemini, opencode]
-```
-
-Optional fields: `tech_stack`, `skills`, `output.structure: nested`, `tiers`.
-
-## Add a Skill
-
-Skills are reusable agent task definitions in `skills/{group}/{name}/SKILL.md`.
-
-```bash
-mkdir -p skills/development/my-skill
-# Groups: development, agentic, data, quality, architecture, or any custom name
-# Write skills/development/my-skill/SKILL.md with frontmatter + steps
-```
-
-Run `agentic list skills` to confirm the skill is discovered after creating it.
-
-Required frontmatter:
-
-```yaml
----
-name: my-skill
-description: >
-  What this skill does. Invoked when the user asks to ...
-version: 1.0.0
-tags: [quality, ...]
-resources: []
-vendor_support:
-  claude: native
-  opencode: native
-  copilot: prompt-inject
-  codex: prompt-inject
-  gemini: prompt-inject
----
-```
-
-Then add the skill name to any profile's `skills` list:
-
-```yaml
-skills:
-  - code-review
-  - my-skill
-```
-
-## Add Project-Local Skills
-
-> See also: [customization.md](customization.md) for a quick overview of all project customization options.
-
-For skills that are specific to a single project and shouldn't live in the shared library,
-create them in the project's `.agentic/project-skills/` directory:
-
-```bash
-# In your target project
 mkdir -p .agentic/project-skills/my-custom-workflow
+```
 
-# Create the skill file
-cat > .agentic/project-skills/my-custom-workflow/SKILL.md << 'EOF'
+Create `.agentic/project-skills/my-custom-workflow/SKILL.md`:
+
+```yaml
 ---
 name: my-custom-workflow
 description: >
@@ -141,36 +39,34 @@ vendor_support:
 2. Build the artifact: `make build`
 3. Deploy to staging: `make deploy-staging`
 4. Run smoke tests: `make smoke-test`
-EOF
 ```
 
-Then reference it in your profile or deploy command with the `project:` prefix:
+### Reference it in your profile
 
 ```yaml
 # In .agentic/profile.yaml
 skills:
-  - code-review           # from library
-  - project:my-custom-workflow  # from .agentic/project-skills/
+  - code-review                    # from library
+  - project:my-custom-workflow     # from .agentic/project-skills/
 ```
 
-Or deploy directly:
+### Or deploy with it directly
 
 ```bash
 agentic deploy <profile> [target] <vendors> --skills project:my-custom-workflow
-
-# Example:
-agentic deploy typescript-hexagonal-microservice ./my-project claude --skills project:my-custom-workflow
 ```
 
-Project skills are copied to `.agentic/skills/` alongside library skills and symlinked
-to vendor-specific paths just like regular skills.
+Project skills are copied to `.agentic/skills/` alongside library skills and
+symlinked to vendor-specific paths just like regular skills.
 
 ## Declare Proprietary Libraries
 
 List internal packages that agents need to be aware of. Agents are told to load
-the relevant documentation before making changes.
+the relevant documentation before making changes to code that uses these packages.
 
-**Project-wide** (in `tech_stack`, appears in root `AGENTS.md`):
+### Project-wide
+
+Declared in `tech_stack` in `.agentic/profile.yaml` — appears in the root `AGENTS.md`:
 
 ```yaml
 tech_stack:
@@ -180,7 +76,9 @@ tech_stack:
       url_doc: "https://docs.acme.internal/core"   # optional
 ```
 
-**Tier-specific** (nested profiles only — appears in that tier's `AGENTS.md`):
+### Tier-specific (nested profiles only)
+
+Declared under the relevant tier — appears in that tier's `AGENTS.md`:
 
 ```yaml
 tiers:
@@ -191,11 +89,9 @@ tiers:
         url_doc: "https://docs.acme.internal/domain-kit"
 ```
 
-`url_doc` is optional. When omitted the Docs column shows `—`.
+`url_doc` is optional. When omitted the Docs column in `AGENTS.md` shows `—`.
 
-## Add a Vendor Adapter
+## Contributing to the Library
 
-Adding a new vendor adapter requires changes to the library internals. Open an issue
-or pull request on the [GitHub repository](https://github.com/soulcodex/agentic)
-describing the vendor and its expected output format. See the existing adapters in
-`vendors/` for the implementation pattern.
+Want to add a new fragment, profile, skill, or vendor adapter to the shared library?
+See the [Contributing guide](https://github.com/soulcodex/agentic/blob/main/.github/CONTRIBUTING.md).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,15 +1,28 @@
 # Installation
 
+## Prerequisites
+
+| Tool | Purpose | macOS | Linux |
+|---|---|---|---|
+| `bash` | Shell runtime | Pre-installed | Pre-installed |
+| `git` | Clone the library | Pre-installed | `sudo apt install git` / `sudo dnf install git` |
+| `just` | Task runner | `brew install just` | `cargo install just` or [prebuilt binary](https://just.systems) |
+| `yq` | YAML processor | `brew install yq` | `snap install yq` or [prebuilt binary](https://github.com/mikefarah/yq/releases) |
+| `jq` | JSON processor | `brew install jq` | `sudo apt install jq` / `sudo dnf install jq` |
+
+On macOS, run `just setup` from the library directory to auto-install missing tools via Homebrew.
+On Linux, install missing tools with your package manager then run `just setup` to verify.
+
 ## One-line Install (Recommended)
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash
 ```
 
-Clones the library to `~/.local/share/agentic` and installs the `agentic` CLI
-to `~/.local/bin`.
+Clones the library to `~/.local/share/agentic`, installs the `agentic` CLI to `~/.local/bin`,
+and checks that all prerequisites are present before proceeding.
 
-After installation, ensure `~/.local/bin` is in your `PATH`.
+After installation, ensure `~/.local/bin` is in your `PATH`:
 
 **macOS (zsh):**
 ```bash
@@ -21,7 +34,14 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 ```
 
+**Linux/macOS (fish):**
+```bash
+fish_add_path ~/.local/bin
+```
+
 ## Manual Install
+
+Once prerequisites are met:
 
 ```bash
 # 1. Clone the library
@@ -30,22 +50,7 @@ git clone https://github.com/soulcodex/agentic ~/agentic-library
 # 2. Install the global CLI
 cd ~/agentic-library
 just install
-# Installs to ~/.local/bin — add to PATH if needed
-```
-
-### Linux — PATH persistence
-
-After manual install, add the CLI to your PATH permanently:
-
-```bash
-# bash (most Linux distros)
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
-
-# zsh
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
-
-# fish
-fish_add_path ~/.local/bin
+# Installs to ~/.local/bin — add to PATH if needed (see PATH section above)
 ```
 
 ## Verify Installation

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,11 +9,16 @@ curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | 
 Clones the library to `~/.local/share/agentic` and installs the `agentic` CLI
 to `~/.local/bin`.
 
-After installation, ensure `~/.local/bin` is in your `PATH`:
+After installation, ensure `~/.local/bin` is in your `PATH`.
 
+**macOS (zsh):**
 ```bash
-export PATH="$HOME/.local/bin:$PATH"
-# Add to ~/.bashrc or ~/.zshrc to make it permanent
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
+```
+
+**Linux (bash):**
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 ```
 
 ## Manual Install
@@ -28,16 +33,20 @@ just install
 # Installs to ~/.local/bin — add to PATH if needed
 ```
 
-## Prerequisites
+### Linux — PATH persistence
 
-Run `just setup` from the library directory to check and install all required tools:
+After manual install, add the CLI to your PATH permanently:
 
-| Tool | Purpose | Install |
-|---|---|---|
-| `bash` | Shell runtime | Usually pre-installed |
-| `just` | Task runner | `brew install just` / [just.systems](https://just.systems) |
-| `yq` | YAML processor | `brew install yq` / [github.com/mikefarah/yq](https://github.com/mikefarah/yq) |
-| `jq` | JSON processor | `brew install jq` / [stedolan.github.io/jq](https://stedolan.github.io/jq) |
+```bash
+# bash (most Linux distros)
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
+
+# zsh
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
+
+# fish
+fish_add_path ~/.local/bin
+```
 
 ## Verify Installation
 

--- a/install.sh
+++ b/install.sh
@@ -203,15 +203,20 @@ Remove it first or choose a different --dir"
   else
     warn "CLI installed but not found in PATH"
     echo ""
-    echo "  Add this to your shell profile (~/.bashrc, ~/.zshrc):"
+    echo "  Add this to your shell profile:"
+    echo ""
     if [[ "$cli_target" == "global" ]]; then
-      echo "    export PATH=\"/usr/local/bin:\$PATH\""
+      echo "    bash/zsh:  export PATH=\"/usr/local/bin:\$PATH\""
+      echo "    fish:      fish_add_path /usr/local/bin"
     else
-      echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+      echo "    bash/zsh:  export PATH=\"\$HOME/.local/bin:\$PATH\""
+      echo "    fish:      fish_add_path ~/.local/bin"
     fi
     echo ""
-    echo "  Then restart your shell or run:"
-    echo "    source ~/.bashrc  # or ~/.zshrc"
+    echo "  Then reload your shell:"
+    echo "    source ~/.bashrc   # bash"
+    echo "    source ~/.zshrc    # zsh"
+    echo "    exec fish          # fish"
     echo ""
   fi
 }


### PR DESCRIPTION
## Summary
- Restructure `docs/extending.md` to focus on user-facing content (project-local skills, proprietary libraries); library contributor how-to moved to CONTRIBUTING.md
- Add "Adding Library Assets" section to `.github/CONTRIBUTING.md` covering fragments, profiles, skills, and vendor adapters
- Expand `docs/getting-started/installation.md` with Linux-specific PATH and tool install instructions
- Update `install.sh` post-install output to show bash/zsh/fish shell-specific PATH instructions