### PR TITLE
fix(docs): remove dead extending.md link from index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | 
 ```
 
 Installs the `agentic` CLI to `~/.local/bin`. Requires `bash`, `just`, `yq`, `jq`.
-Run `just setup` to check and install prerequisites on macOS.
+The installer auto-detects missing prerequisites and offers to install them.
 
 ---
 
@@ -48,6 +48,5 @@ agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
 - [**Commands**](commands.md) — full CLI reference
 - [**Profiles**](profiles.md) — all available profiles and their fragments
 - [**Vendors**](vendors.md) — supported AI tools and their output files
-- [**Customization**](customization.md) — per-project overrides, link mode vs copy mode
+- [**Customization**](customization.md) — per-project overrides, project skills, proprietary libraries, link mode vs copy mode
 - [**Custom Rules**](custom-rules.md) — `AGENTS.local.md` injection
-- [**Extending**](extending.md) — adding fragments, profiles, skills, vendor adapters


### PR DESCRIPTION
## Summary

- Removes the broken `[Extending](extending.md)` link from `docs/index.md` — `extending.md` was deleted when its content was merged into `customization.md`, but the index page was never updated, causing `mkdocs build --strict` to fail on every docs deploy
- Updates the `Customization` entry description to reflect the merged content (project skills, proprietary libraries)
- Replaces the stale `just setup` reference with a plain prose sentence (no internal `just` commands in user-facing docs)

## Root cause

The link removal from `docs/index.md` was applied to the already-merged branch (`feat/uninstall-command-and-smart-prereqs`) rather than a fresh branch off `main`, so it never reached `origin/main`.