### PR TITLE
feat(docs): puzzle logo, grid cards on home, mobile-friendly commands, remove just refs

### DIFF
--- a/docs/.mkdocs/mkdocs.yml
+++ b/docs/.mkdocs/mkdocs.yml
@@ -22,6 +22,8 @@ nav:
 
 theme:
   name: material
+  icon:
+    logo: material/puzzle
   palette:
     - scheme: default
       toggle:
@@ -41,6 +43,8 @@ theme:
     - content.code.annotate
 
 markdown_extensions:
+  - attr_list
+  - md_in_html
   - admonition
   - pymdownx.details
   - pymdownx.superfences

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -55,15 +55,17 @@ Full deployment pipeline: compose + vendor-gen + deploy skills + activate vendor
 agentic deploy <profile> [target] <vendors> [options]
 ```
 
-**Arguments:**
-- `profile` — Name of the profile (see `agentic list profiles`)
-- `target` — Project directory (auto-detected if omitted)
-- `vendors` — Comma-separated vendors to activate (e.g., `claude,copilot`)
+| Argument | Required | Description |
+|---|---|---|
+| `profile` | ✅ | Profile name — see `agentic list profiles` |
+| `target` | optional | Project directory, auto-detected from current dir if omitted |
+| `vendors` | ✅ | Comma-separated vendors to activate: `claude`, `copilot`, `gemini`, `codex`, `opencode` |
 
-**Options:**
-- `--full` — Inline all fragment content (monolithic AGENTS.md)
-- `--link` — Use symlinks instead of file copies (POSIX only; see Link Mode section below)
-- `--skills LIST` — Deploy specific skills (default: all from profile)
+| Option | Description |
+|---|---|
+| `--full` | Inline all fragment content into a monolithic `AGENTS.md` |
+| `--link` | Use symlinks instead of file copies (POSIX only, not Windows without WSL) |
+| `--skills LIST` | Deploy specific skills only (default: all skills declared in the profile) |
 
 **Examples:**
 ```bash
@@ -85,9 +87,15 @@ Assemble AGENTS.md from a profile without generating vendor files.
 agentic compose <profile> [target] [options]
 ```
 
-**Options:**
-- `--full` — Inline all fragment content
-- `--link` — Use symlinks instead of file copies (POSIX only)
+| Argument | Required | Description |
+|---|---|---|
+| `profile` | ✅ | Profile name — see `agentic list profiles` |
+| `target` | optional | Project directory, auto-detected from current dir if omitted |
+
+| Option | Description |
+|---|---|
+| `--full` | Inline all fragment content into a monolithic `AGENTS.md` |
+| `--link` | Use symlinks instead of file copies (POSIX only, not Windows without WSL) |
 
 **Examples:**
 ```bash
@@ -136,11 +144,9 @@ List available resources.
 agentic list <resource>
 ```
 
-**Resources:**
-- `profiles` — Available composition profiles
-- `skills` — Available skills (group, name, description)
-- `fragments` — Available fragment files
-- `vendors` — Supported vendor adapters
+| Argument | Required | Description |
+|---|---|---|
+| `resource` | ✅ | Resource type to list: `profiles`, `skills`, `fragments`, or `vendors` |
 
 **Examples:**
 ```bash
@@ -161,27 +167,3 @@ agentic uninstall --global  # remove from /usr/local/bin (requires sudo)
 This removes only the CLI binary. The library directory (`~/.local/share/agentic`)
 is left untouched — reinstall at any time with the one-line installer.
 To fully remove the library: `rm -rf ~/.local/share/agentic`
-
----
-
-## Config Lock File
-
-Every `agentic deploy` or `agentic compose` writes `TARGET/.agentic/config.yaml`:
-
-```yaml
-# Managed by agentic library — do not edit manually
-library_commit: "abc123..."
-profile: "golang-hexagonal-cobra-cli"
-profile_version: "1.0.0"
-composed_at: "2026-03-03T12:00:00Z"
-mode: lean
-agentic_root: "/Users/you/agentic"
-active_vendors:
-  - claude
-  - copilot
-structure: nested          # only for nested profiles
-tiers: [backend, ui]       # only for nested profiles
-```
-
-The `agentic_root` and `active_vendors` fields enable the global CLI to work
-from any directory within your project.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -175,3 +175,25 @@ are gitignored automatically.
    git commit -m "chore: switch agentic to copy mode"
    ```
 3. The managed `.gitignore` block is updated automatically — the three paths are removed from it.
+
+## Config Lock File
+
+Every `agentic deploy` or `agentic compose` writes `TARGET/.agentic/config.yaml`:
+
+```yaml
+# Managed by agentic library — do not edit manually
+library_commit: "abc123..."
+profile: "golang-hexagonal-cobra-cli"
+profile_version: "1.0.0"
+composed_at: "2026-03-03T12:00:00Z"
+mode: lean
+agentic_root: "/Users/you/agentic"
+active_vendors:
+  - claude
+  - copilot
+structure: nested          # only for nested profiles
+tiers: [backend, ui]       # only for nested profiles
+```
+
+The `agentic_root` and `active_vendors` fields enable the global CLI to work
+from any directory within your project.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,8 +10,7 @@
 | `yq` | YAML processor | `brew install yq` | `snap install yq` or [prebuilt binary](https://github.com/mikefarah/yq/releases) |
 | `jq` | JSON processor | `brew install jq` | `sudo apt install jq` / `sudo dnf install jq` |
 
-On macOS, run `just setup` from the library directory to auto-install missing tools via Homebrew.
-On Linux, install missing tools with your package manager then run `just setup` to verify.
+The one-line installer detects missing tools and offers to install them automatically (Homebrew on macOS, package manager on Linux).
 
 ## One-line Install (Recommended)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,37 @@ same `AGENTS.md` source of truth — automatically.
 curl -sSL https://raw.githubusercontent.com/soulcodex/agentic/main/install.sh | bash
 ```
 
-Installs the `agentic` CLI to `~/.local/bin`. Requires `bash`, `just`, `yq`, `jq`.
-The installer auto-detects missing prerequisites and offers to install them.
+Installs the `agentic` CLI to `~/.local/bin`. The installer checks prerequisites and offers to install any that are missing.
+
+---
+
+<div class="grid cards" markdown>
+
+-   :material-puzzle:{ .lg .middle } **One source of truth**
+
+    ---
+
+    Write `AGENTS.md` once. Every AI tool reads the same instructions — no drift, no duplication.
+
+-   :material-lightning-bolt:{ .lg .middle } **Deploy in one command**
+
+    ---
+
+    Pick a profile and run `agentic deploy`. Claude, Copilot, Gemini, Codex and Opencode all configured instantly.
+
+-   :material-shape:{ .lg .middle } **15 ready-made profiles**
+
+    ---
+
+    TypeScript, Go, Python, PHP — microservices, CLIs, SPAs, full-stack. Start from a proven template, customise from there.
+
+-   :material-brain:{ .lg .middle } **Skills system**
+
+    ---
+
+    Reusable agent task definitions. Deploy shared skills from the library or add project-local ones in `.agentic/project-skills/`.
+
+</div>
 
 ---
 


### PR DESCRIPTION
## Summary

- **Puzzle logo**: Added `material/puzzle` icon to MkDocs Material theme in `mkdocs.yml`
- **Grid cards on home page**: Added responsive 4-card feature grid to `docs/index.md` with `attr_list` and `md_in_html` markdown extensions enabled
- **Mobile-friendly commands page**: Replaced bullet-list argument/option blocks with tables for `deploy`, `compose`, `list`, and `switch` commands; removed `just` references throughout user-facing docs
- **Config Lock File moved**: Moved from `commands.md` to `customization.md` under its own `## Config Lock File` heading

## Quality gates

- `just lint` — PASSED
- `just index` — Unchanged
- `just test` — 319/319 passed
- `mkdocs build --strict` — Built with no link errors
- `grep just` in docs/ — Clean (no internal `just` tooling references in user-facing docs)