### PR TITLE
fix(docs): add pymdownx.emoji so Material icons render in grid cards

### DIFF
--- a/docs/.mkdocs/mkdocs.yml
+++ b/docs/.mkdocs/mkdocs.yml
@@ -56,3 +56,6 @@ markdown_extensions:
   - tables
   - toc:
       permalink: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
## Summary

- Adds the missing `pymdownx.emoji` markdown extension with the Material icon index and SVG generator to `mkdocs.yml`
- Without it, icon shortcodes like `:material-puzzle:{ .lg .middle }` are passed through as raw text instead of rendering as SVG icons in the grid cards on the home page

## Root cause

The `attr_list` and `md_in_html` extensions (added in #78) enable the grid card layout, but the icon shortcodes themselves require `pymdownx.emoji` with `material.extensions.emoji.twemoji` + `to_svg` — this was the missing piece.

## Verified

- `mkdocs build --strict` ✅ — clean build, no warnings
- `just lint` ✅
- `just test` ✅ 319/319