### PR TITLE
feat(docs): add Open Graph and Twitter Card meta tags for rich link previews

### DIFF
--- a/docs/.mkdocs/mkdocs.yml
+++ b/docs/.mkdocs/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
 
 theme:
   name: material
+  custom_dir: overrides
   icon:
     logo: material/puzzle
   palette:

--- a/docs/.mkdocs/overrides/main.html
+++ b/docs/.mkdocs/overrides/main.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {% set title = config.site_name %}
+  {% if page and page.title and not page.is_homepage %}
+    {% set title = page.title ~ " - " ~ config.site_name %}
+  {% endif %}
+  {% set description = config.site_description %}
+  {% if page and page.meta and page.meta.description %}
+    {% set description = page.meta.description %}
+  {% endif %}
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="{{ config.site_name }}" />
+  <meta property="og:title" content="{{ title }}" />
+  <meta property="og:description" content="{{ description }}" />
+  <meta property="og:url" content="{{ page.canonical_url }}" />
+  <meta property="og:image" content="https://opengraph.githubassets.com/1/soulcodex/agentic" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="{{ title }}" />
+  <meta name="twitter:description" content="{{ description }}" />
+  <meta name="twitter:image" content="https://opengraph.githubassets.com/1/soulcodex/agentic" />
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add theme override template at `docs/.mkdocs/overrides/main.html` that injects `og:type`, `og:site_name`, `og:title`, `og:description`, `og:url`, `og:image`, `og:image:width`, `og:image:height`, `twitter:card`, `twitter:title`, `twitter:description`, and `twitter:image` meta tags into every page.
- Wire up `custom_dir: overrides` under `theme:` in `mkdocs.yml` so MkDocs Material picks up the override.
- Use GitHub's auto-generated Open Graph image (`opengraph.githubassets.com`) so no static asset file needs to be committed; image dimensions are declared explicitly.
- MkDocs build passes with `--strict`; all quality gates (lint, index, 319 tests) pass.