### PR TITLE
feat(profiles): add React/Next profile families and align Go baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ agentic list profiles|skills|vendors          # list available resources
 
 ## Profiles
 
-15 ready-made profiles covering TypeScript, Go, Python, PHP — frontend SPAs, microservices, CLIs, full-stack.
+21 ready-made profiles covering TypeScript, Go, Python, PHP — frontend SPAs, microservices, CLIs, full-stack.
 
 → [Browse all profiles](https://agentic.soulcodex.link/profiles)
 

--- a/agents/frameworks/next-patterns.md
+++ b/agents/frameworks/next-patterns.md
@@ -1,0 +1,57 @@
+## Next.js App Router Patterns
+
+### Server-First Composition
+
+- Build pages as Server Components that assemble data and pass minimal props to client islands.
+- Keep interactivity boundaries explicit with small `'use client'` leaves.
+- Push expensive logic and secret-bearing operations to server-only modules.
+- Use `server-only` for modules that must never enter client bundles.
+
+### Loading, Error, and Not Found Files
+
+- `loading.tsx` should render skeletons sized to final content to avoid layout shifts.
+- `error.tsx` must include a clear recovery action and call `reset()` when retry is meaningful.
+- `not-found.tsx` should provide navigation back to a useful parent route.
+- Prefer local segment fallbacks over one global catch-all fallback.
+
+### Route Handlers
+
+- Co-locate handlers in `app/<segment>/route.ts` and support only required verbs.
+- Validate params, query, and body with a schema at the handler boundary.
+- Return typed JSON payloads and explicit cache headers when needed.
+- Keep handlers thin: orchestration only; domain logic belongs in shared server modules.
+
+### Server Actions
+
+- Use server actions for authenticated mutations triggered by forms or user events.
+- Validate `FormData`/input on the server before mutating.
+- Return structured action results (`ok`, `fieldErrors`, `message`) for predictable UI handling.
+- After mutation, call `revalidatePath('/target')` or `revalidateTag('resource')` to refresh reads.
+
+### Metadata Patterns
+
+- Use `generateMetadata` for param-based pages and fetched entities.
+- Keep metadata fetching aligned with page data fetching to avoid duplicate remote calls.
+- Include title templates and canonical URLs for nested routes.
+- Use robots directives intentionally for private or duplicate-content routes.
+
+### Cache and Revalidation Matrix
+
+- **Static, slow-changing content**: `fetch(..., { cache: 'force-cache', next: { revalidate: 3600 } })`.
+- **User-specific or highly dynamic content**: `fetch(..., { cache: 'no-store' })`.
+- **Shared data invalidated by writes**: tag fetches and call `revalidateTag` in mutation paths.
+- **Route-level refresh after mutation**: call `revalidatePath` for affected segments.
+
+### Boundary Contracts
+
+- Keep server-to-client props serializable (`string`, `number`, `boolean`, plain objects/arrays).
+- Pass IDs and display-ready values, not ORM entities or class instances.
+- Normalize dates to ISO strings at the server boundary.
+- Keep client state UI-focused; source-of-truth data remains server-owned.
+
+### Common Failure Modes to Avoid
+
+- Marking entire routes with `'use client'` when only a leaf needs interactivity.
+- Mixing multiple caching strategies without documenting intent.
+- Failing to revalidate after server action mutations.
+- Throwing generic errors where `notFound()` or typed action errors are expected.

--- a/agents/frameworks/next.md
+++ b/agents/frameworks/next.md
@@ -1,0 +1,57 @@
+## Next.js App Router
+
+### Routing Model
+
+- Use App Router (`app/`) as the default architecture.
+- Route segments map to folders; `page.tsx` defines route UI and `layout.tsx` defines shared shells.
+- Keep layouts persistent and push data dependencies down to the segment that needs them.
+- Use route groups (`(group)`) for organization without URL changes.
+
+### Server and Client Boundaries
+
+- Components are Server Components by default.
+- Add `'use client'` only where browser APIs, stateful interactivity, or client hooks are required.
+- Keep client islands as small as possible; compose them inside server-rendered shells.
+- Props passed from Server Components to Client Components must be serializable.
+
+### Data Fetching
+
+- Fetch on the server whenever possible.
+- Use `fetch` in Server Components, route handlers, or server actions.
+- Explicitly choose cache mode (`force-cache`, `no-store`) and revalidation strategy.
+- Avoid client-side duplicate fetches for data already available on the server.
+
+### Route Files and Fallback UX
+
+- Provide segment-level `loading.tsx` for streaming and perceived performance.
+- Provide segment-level `error.tsx` to recover from runtime failures.
+- Provide `not-found.tsx` for missing resources and unmatched segment states.
+- Throw `notFound()` when resource lookup fails and 404 is the expected UX.
+
+### Route Handlers and Server Actions
+
+- Use route handlers (`app/**/route.ts`) for HTTP APIs and webhook endpoints.
+- Validate input at the boundary and return explicit status codes.
+- Use server actions (`'use server'`) for form mutations and authenticated write flows.
+- Keep server actions close to the owning route segment or feature module.
+
+### Metadata
+
+- Use static `metadata` exports for stable page metadata.
+- Use `generateMetadata` for metadata derived from async data or route params.
+- Canonical URL, title, description, and social tags are required for indexable pages.
+- Keep metadata generation fast and deterministic.
+
+### Caching and Revalidation
+
+- Document caching intent near each fetch path.
+- Use time-based revalidation for mostly-static content.
+- Use tag/path invalidation after mutations to refresh stale reads.
+- Default to dynamic rendering only when data freshness or per-request personalization requires it.
+
+### Runtime and Environment
+
+- Choose Node.js runtime for ecosystem-heavy server code.
+- Choose Edge runtime only for latency-sensitive, compatible handlers.
+- Read secrets only on the server and avoid exposing non-public env vars to clients.
+- Keep shared modules runtime-safe (no accidental Node-only imports in client trees).

--- a/agents/frameworks/react-component-design.md
+++ b/agents/frameworks/react-component-design.md
@@ -1,0 +1,66 @@
+## React 19 Component Design
+
+### Composition Over Configuration
+
+- Prefer composing smaller components over large prop-heavy components.
+- Keep public APIs narrow: only expose props that express real variation.
+- Prefer explicit child components and slots-by-composition (`children`, render props) over many boolean flags.
+- If a component has many mutually exclusive modes, split it into focused components.
+
+### State Ownership Rules
+
+- **1-2 levels deep**: pass props directly.
+- **3+ levels deep within one feature tree**: use React Context with a typed provider hook.
+- **Cross-feature or persisted state**: use a dedicated app state layer.
+- Do not pass props through intermediates that do not use the value.
+
+### Context Design
+
+- Create one context per domain concern, not a global catch-all context.
+- Export a typed `useXContext()` hook that throws when provider is missing.
+- Keep context values stable using memoized value objects.
+- Put mutation functions in context only when consumers genuinely need them.
+
+```ts
+import { createContext, useContext } from 'react'
+
+type TabsContextValue = {
+  activeId: string
+  setActiveId: (id: string) => void
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null)
+
+export function useTabsContext(): TabsContextValue {
+  const ctx = useContext(TabsContext)
+  if (!ctx) throw new Error('useTabsContext must be used within <TabsProvider>')
+  return ctx
+}
+```
+
+### Compound Components
+
+- Use compound components for coordinated UI families (`Tabs`, `Accordion`, `Menu`).
+- Share state through local context created by the parent component.
+- Keep child components usable only inside the parent boundary when they depend on that context.
+- Expose controlled and uncontrolled variants when a component is a reusable primitive.
+
+### Controlled vs Uncontrolled
+
+- Offer controlled APIs when parent orchestration is needed (`value`, `onChange`).
+- Offer uncontrolled APIs for ergonomics (`defaultValue`) in leaf UI usage.
+- Never mix controlled and uncontrolled modes in the same render path.
+- Document precedence when both `value` and `defaultValue` are provided.
+
+### Public API Surface
+
+- Prefer typed props and standard event handlers.
+- Use `forwardRef` only when consumers need imperative DOM access (focus, measure, scroll).
+- Keep imperative handles minimal with `useImperativeHandle`.
+- Avoid leaking internal state shape through callback arguments.
+
+### Client-Only Boundaries
+
+- Encapsulate browser-only APIs (selection, resize observers, drag/drop) in dedicated client components/hooks.
+- Keep server-renderable wrappers free from browser assumptions.
+- Expose serializable props across boundaries.

--- a/agents/frameworks/react-styling.md
+++ b/agents/frameworks/react-styling.md
@@ -1,0 +1,50 @@
+## React 19 Styling Discipline
+
+### Approach Selection
+
+- Utility-first classes are the default for layout, spacing, typography, and color.
+- CSS Modules are preferred for component-scoped structural styles and complex selectors.
+- CSS-in-JS is acceptable only when dynamic runtime styling is required by the product.
+- Keep one styling strategy dominant in a codebase to reduce cognitive load.
+
+### Design Tokens
+
+- All colors, spacing, radius, typography, and motion values come from design tokens.
+- Reference tokens via CSS variables and shared theme files.
+- Never hardcode brand values directly in component files.
+- Use semantic token names (`--color-surface`, `--color-text-muted`) over raw intent-less names.
+
+### Class Composition
+
+- Use a `cn()` helper for conditional class composition.
+- Keep class lists readable by grouping layout, spacing, typography, and state classes.
+- Extract repeated class patterns into reusable components or style utilities.
+
+```ts
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+```
+
+### Theming and Variants
+
+- Build variants through explicit prop maps (`size`, `tone`, `intent`) instead of ad hoc string concatenation.
+- Keep default, hover, active, disabled, and focus-visible states defined for every interactive component.
+- Ensure contrast and state differentiation meet accessibility requirements.
+- Prefer `data-*` attributes for state-driven styling over deep selector chains.
+
+### Motion and Layout Safety
+
+- Respect reduced motion preferences.
+- Keep animations purposeful and short; avoid perpetual decorative motion.
+- Prevent layout shift with reserved space for async content, media, and skeletons.
+- Use logical CSS properties for RTL-safe spacing and positioning.
+
+### Escape Hatches
+
+- Avoid global overrides except for resets, typography primitives, and legacy integration boundaries.
+- Do not style third-party internals unless no public API exists.
+- If deep overrides are required, isolate them behind a wrapper component.

--- a/agents/frameworks/react-testing.md
+++ b/agents/frameworks/react-testing.md
@@ -1,0 +1,62 @@
+## React 19 Testing Strategy
+
+### Three-Tier Test Taxonomy
+
+| Tier | Tool | What belongs here |
+|------|------|------------------|
+| Unit | Vitest/Jest (no DOM) | Pure functions, reducers, mappers, validators, custom hook logic with mocked adapters |
+| Component | Testing Library + Vitest/Jest | DOM behavior, accessibility roles, user interactions, form states, conditional rendering |
+| E2E / Acceptance | Playwright | Full user flows, routing transitions, auth gates, integration with backend or API mocks |
+
+### Testing Philosophy
+
+- Test observable behavior, not implementation details.
+- Prefer user-centric queries (`getByRole`, `getByLabelText`, `findByText`) over brittle selectors.
+- Use one assertion block per behavior and keep tests intention-revealing.
+- Mock network boundaries, not internal component methods.
+
+### Component Tests
+
+- Render real components; avoid shallow rendering.
+- Drive interactions with `@testing-library/user-event`.
+- Assert loading, success, empty, and error states for data-driven components.
+- Verify keyboard behavior for interactive components.
+
+```ts
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect } from 'vitest'
+import { SearchForm } from './SearchForm'
+
+it('submits query from form', async () => {
+  const user = userEvent.setup()
+  const onSubmit = vi.fn()
+
+  render(<SearchForm onSubmit={onSubmit} />)
+
+  await user.type(screen.getByLabelText('Search'), 'react')
+  await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+  expect(onSubmit).toHaveBeenCalledWith('react')
+})
+```
+
+### Hook and Reducer Tests
+
+- Test reducers as pure functions with explicit action/state tables.
+- Test hooks through a small harness component or `renderHook` utility.
+- Reset shared state between tests.
+- Assert cleanup behavior for hooks with subscriptions or timers.
+
+### What Not to Test
+
+- Internal state variable names.
+- CSS class implementation details unless class changes are the behavior.
+- Large snapshots of full markup trees.
+- Third-party library internals.
+
+### Coverage Priorities
+
+- Prioritize critical flows: auth, checkout/submission, permission-gated actions, data mutation paths.
+- Include at least one test per component state branch.
+- Add regression tests for every production bug fix.

--- a/agents/frameworks/react.md
+++ b/agents/frameworks/react.md
@@ -1,0 +1,50 @@
+## React 19 + TypeScript
+
+### Component Architecture
+
+- Use function components only. Class components are not allowed.
+- Keep one component per file. Use PascalCase for component files and exported component names.
+- Keep rendering logic in components and domain logic in hooks or services.
+- Extract reusable stateful logic into custom hooks (`use*.ts`) instead of utility classes.
+
+### TypeScript Discipline
+
+- Prefer explicit interfaces/types for public component props.
+- Avoid `any`. Use `unknown` at boundaries and narrow with type guards.
+- Type event handlers precisely (`React.ChangeEvent<HTMLInputElement>`, `React.FormEvent<HTMLFormElement>`).
+- Use discriminated unions for UI states (`idle | loading | success | error`) instead of multiple booleans.
+
+### State and Data Flow
+
+- Use local state (`useState`) for view-local concerns.
+- Use reducers (`useReducer`) for state with multiple transitions or domain rules.
+- Derive values during render or with `useMemo` when expensive. Do not mirror derived values into state.
+- Lift state only to the nearest common owner. Avoid globalizing state prematurely.
+
+### Effects and Side Effects
+
+- `useEffect` is for synchronizing with external systems (network subscriptions, timers, DOM APIs), not for derived data.
+- Keep effect dependencies complete and stable. If dependencies cause loops, fix identity issues with `useMemo`/`useCallback`.
+- Always clean up subscriptions, intervals, and listeners in effect cleanup.
+- Prefer event handlers and framework data APIs over effect-driven fetching when possible.
+
+### Forms and Actions
+
+- Prefer native `<form>` semantics and progressive enhancement over custom click-only flows.
+- Use controlled components for complex validation and formatting.
+- Use uncontrolled inputs with refs for very large forms when performance is critical.
+- Model form submission state explicitly (`pending`, `fieldErrors`, `formError`, `result`).
+
+### Rendering and Performance
+
+- Default to simple components first; profile before optimizing.
+- Use `React.memo` only for proven hot paths with stable props.
+- Use stable keys from domain IDs for lists. Never use array index as key when order can change.
+- Split large pages into route-level and section-level boundaries to reduce re-render scope.
+
+### Accessibility
+
+- Use semantic HTML first (`button`, `label`, `fieldset`, `nav`, `main`).
+- Every form control has an accessible label.
+- Keyboard interactions must mirror pointer interactions.
+- Use ARIA only when native semantics cannot express intent.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ Installs the `agentic` CLI to `~/.local/bin`. The installer checks prerequisites
 
     Pick a profile and run `agentic deploy`. Claude, Copilot, Gemini, Codex and Opencode all configured instantly.
 
--   :material-shape:{ .lg .middle } **15 ready-made profiles**
+-   :material-shape:{ .lg .middle } **21 ready-made profiles**
 
     ---
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -6,13 +6,19 @@ A profile is a named YAML preset that selects which fragments, tech stack detail
 
 | Profile | What it's for | Language(s) |
 |---|---|---|
+| `typescript-react-spa` | Standalone React SPA with Vite, React Router. No SSR. | TypeScript |
+| `typescript-next-app` | Standalone Next.js app with SSR, App Router | TypeScript |
 | `typescript-vue-spa` | Standalone Vue 3 SPA with Vite, Pinia, Vue Router. No SSR. | TypeScript |
 | `typescript-nuxt-app` | Standalone Nuxt 3 app with SSR, file-based routing, Nitro | TypeScript |
 | `typescript-hexagonal-microservice` | TypeScript backend service with Hono, hexagonal architecture, DDD | TypeScript |
 | `typescript-bff` | Backend-for-Frontend aggregation layer | TypeScript |
+| `typescript-hexagonal-next-ui` | Hono backend + Next.js frontend (SSR) | TypeScript |
+| `typescript-hexagonal-react-vite-ui` | Hono backend + React SPA frontend (no SSR) | TypeScript |
 | `typescript-hexagonal-nuxt-vite-ui` | Hono backend + Nuxt 3 / Vue 3 frontend (SSR) | TypeScript |
 | `typescript-hexagonal-vue-vite-ui` | Hono backend + Vue 3 SPA frontend (no SSR) | TypeScript |
 | `go-hexagonal-microservice` | Go backend microservice, hexagonal + DDD | Go |
+| `golang-hexagonal-next-ui` | Go backend + Next.js frontend (SSR) | Go + TypeScript |
+| `golang-hexagonal-react-vite-ui` | Go backend + React SPA frontend (no SSR) | Go + TypeScript |
 | `golang-hexagonal-nuxt-vite-ui` | Go backend + Nuxt 3 / Vue 3 frontend (SSR) | Go + TypeScript |
 | `golang-hexagonal-vue-vite-ui` | Go backend + Vue 3 SPA frontend (no SSR) | Go + TypeScript |
 | `golang-hexagonal-cobra-cli` | Go CLI tool with Cobra + Viper, hexagonal + DDD | Go |
@@ -24,7 +30,7 @@ A profile is a named YAML preset that selects which fragments, tech stack detail
 
 ## Nested Output Mode
 
-Full-stack profiles (`*-nuxt-vite-ui`, `*-vue-vite-ui`) use `output.structure: nested`. Instead of a single `AGENTS.md`, they produce:
+Full-stack profiles (`*-next-ui`, `*-nuxt-vite-ui`, `*-react-vite-ui`, `*-vue-vite-ui`) use `output.structure: nested`. Instead of a single `AGENTS.md`, they produce:
 
 ```
 my-project/
@@ -52,7 +58,7 @@ tiers:
       lint_command:  "golangci-lint run"
   ui:
     languages: [typescript]
-    frameworks: [vue, nuxt]
+    frameworks: [react, next]
     architecture: []
     commands:
       build_command: "pnpm build"

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-20T21:19:08Z",
+  "generated_at": "2026-04-28T19:43:10Z",
   "fragments": [
     {
       "name": "bff",
@@ -94,6 +94,20 @@
       "words": 363
     },
     {
+      "name": "next-patterns",
+      "group": "frameworks",
+      "path": "agents/frameworks/next-patterns.md",
+      "heading": "Next.js App Router Patterns",
+      "words": 398
+    },
+    {
+      "name": "next",
+      "group": "frameworks",
+      "path": "agents/frameworks/next.md",
+      "heading": "Next.js App Router",
+      "words": 386
+    },
+    {
       "name": "nuxt-patterns",
       "group": "frameworks",
       "path": "agents/frameworks/nuxt-patterns.md",
@@ -106,6 +120,34 @@
       "path": "agents/frameworks/nuxt.md",
       "heading": "Nuxt 3",
       "words": 475
+    },
+    {
+      "name": "react-component-design",
+      "group": "frameworks",
+      "path": "agents/frameworks/react-component-design.md",
+      "heading": "React 19 Component Design",
+      "words": 378
+    },
+    {
+      "name": "react-styling",
+      "group": "frameworks",
+      "path": "agents/frameworks/react-styling.md",
+      "heading": "React 19 Styling Discipline",
+      "words": 301
+    },
+    {
+      "name": "react-testing",
+      "group": "frameworks",
+      "path": "agents/frameworks/react-testing.md",
+      "heading": "React 19 Testing Strategy",
+      "words": 314
+    },
+    {
+      "name": "react",
+      "group": "frameworks",
+      "path": "agents/frameworks/react.md",
+      "heading": "React 19 + TypeScript",
+      "words": 366
     },
     {
       "name": "typer",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-20T21:19:08Z",
+  "generated_at": "2026-04-28T19:43:09Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -394,6 +394,58 @@
         "i18n",
         "l10n",
         "frontend"
+      ]
+    },
+    {
+      "name": "next-application-structure",
+      "group": "ui",
+      "path": "skills/ui/next-application-structure/SKILL.md",
+      "description": "Establishes or reviews directory layout, server/client boundaries, routing, data-fetching strategy, and testing structur",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "nextjs",
+        "react",
+        "typescript"
+      ]
+    },
+    {
+      "name": "react-application-structure",
+      "group": "ui",
+      "path": "skills/ui/react-application-structure/SKILL.md",
+      "description": "Establishes or reviews the directory layout, feature boundaries, state design, routing approach, and data-fetching conve",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "react",
+        "typescript",
+        "architecture"
+      ]
+    },
+    {
+      "name": "react-component-design",
+      "group": "ui",
+      "path": "skills/ui/react-component-design/SKILL.md",
+      "description": "Designs or reviews React component APIs. Handles prop drilling decisions, composition patterns, controlled/uncontrolled ",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "react",
+        "typescript",
+        "composition"
+      ]
+    },
+    {
+      "name": "react-component-testing",
+      "group": "ui",
+      "path": "skills/ui/react-component-testing/SKILL.md",
+      "description": "Applies the three-tier test taxonomy for React applications: unit tests for hooks and pure logic, component tests for be",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "react",
+        "testing",
+        "vitest"
       ]
     },
     {

--- a/profiles/go-library.yaml
+++ b/profiles/go-library.yaml
@@ -25,7 +25,7 @@ fragments:
   domains: []
 
 tech_stack:
-  language_runtime: "Go 1.23+"
+  language_runtime: "Go 1.26+"
   package_manager: "Go modules"
   test_framework: "testify / stdlib testing"
 

--- a/profiles/golang-hexagonal-cobra-cli.yaml
+++ b/profiles/golang-hexagonal-cobra-cli.yaml
@@ -34,7 +34,7 @@ fragments:
   domains: []
 
 tech_stack:
-  language_runtime: "Go 1.23+"
+  language_runtime: "Go 1.26+"
   package_manager: "Go modules"
   cli_framework: "Cobra + Viper"
   test_framework: "testify"

--- a/profiles/golang-hexagonal-next-ui.yaml
+++ b/profiles/golang-hexagonal-next-ui.yaml
@@ -1,10 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
 meta:
-  name: "Go Hexagonal + Nuxt/Vite UI"
+  name: "Go Hexagonal + Next UI"
   description: >
-    Full-stack application with a Go hexagonal backend and a Nuxt 3 / Vue 3
-    frontend. Go handles all business logic and HTTP APIs; Nuxt delivers
-    SSR-capable pages with Vite for fast builds and Vitest for unit tests.
+    Full-stack application with a Go hexagonal backend and a Next.js
+    frontend. Go handles all business logic and HTTP APIs; Next.js delivers
+    SSR-capable pages with modern build performance and Vitest for unit tests.
   version: "1.0.0"
 
 fragments:
@@ -47,8 +47,8 @@ tiers:
     languages:
       - typescript
     frameworks:
-      - vue
-      - nuxt
+      - react
+      - next
     architecture: []
     commands:
       build_command: "pnpm build"
@@ -59,15 +59,14 @@ tech_stack:
   language_runtime: "Go 1.26+ (backend) / Node 22+ (frontend)"
   package_manager: "Go modules (backend) / pnpm (frontend)"
   backend_framework: "gorilla/mux"
-  frontend_framework: "Nuxt 3"
-  ui_component_library: "shadcn/vue"
+  frontend_framework: "Next.js"
+  ui_component_library: "shadcn/ui"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Vite 6"
+  build_tool: "Turbopack (Next.js)"
   test_framework: "Vitest (frontend) / testify (backend)"
   additional:
-    - "Vue 3"
-    - "pinia"
-    - "VueRouter"
+    - "React"
+    - "App Router"
 
 skills:
   - code-review
@@ -75,7 +74,7 @@ skills:
   - write-adr
   - write-readme
   - relational-database-design
-  - vue-application-structure
+  - react-application-structure
   - internationalization-i18n
   - sql-query-optimization
   - health-check-endpoints
@@ -89,9 +88,9 @@ output:
   lint_command: "golangci-lint run && pnpm lint"
   structure: nested
   project_header: |
-    Full-stack project: Go hexagonal backend + Nuxt 3 frontend.
+    Full-stack project: Go hexagonal backend + Next.js frontend.
     Backend domain package must have zero external dependencies.
-    Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    Frontend uses strict TypeScript with functional components and hooks.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/golang-hexagonal-react-vite-ui.yaml
+++ b/profiles/golang-hexagonal-react-vite-ui.yaml
@@ -1,10 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
 meta:
-  name: "Go Hexagonal + Nuxt/Vite UI"
+  name: "Go Hexagonal + React/Vite SPA"
   description: >
-    Full-stack application with a Go hexagonal backend and a Nuxt 3 / Vue 3
-    frontend. Go handles all business logic and HTTP APIs; Nuxt delivers
-    SSR-capable pages with Vite for fast builds and Vitest for unit tests.
+    Full-stack application with a Go hexagonal backend and a React SPA
+    frontend. Go handles all business logic and HTTP APIs; React delivers a
+    client-side single-page application with Vite for fast builds and Vitest
+    for unit tests. No SSR.
   version: "1.0.0"
 
 fragments:
@@ -47,8 +48,10 @@ tiers:
     languages:
       - typescript
     frameworks:
-      - vue
-      - nuxt
+      - react
+      - react-component-design
+      - react-testing
+      - react-styling
     architecture: []
     commands:
       build_command: "pnpm build"
@@ -59,15 +62,13 @@ tech_stack:
   language_runtime: "Go 1.26+ (backend) / Node 22+ (frontend)"
   package_manager: "Go modules (backend) / pnpm (frontend)"
   backend_framework: "gorilla/mux"
-  frontend_framework: "Nuxt 3"
-  ui_component_library: "shadcn/vue"
+  frontend_framework: "React (SPA)"
+  ui_component_library: "shadcn/ui"
   css_framework: "Tailwind CSS v4"
   build_tool: "Vite 6"
   test_framework: "Vitest (frontend) / testify (backend)"
   additional:
-    - "Vue 3"
-    - "pinia"
-    - "VueRouter"
+    - "React Router"
 
 skills:
   - code-review
@@ -75,7 +76,9 @@ skills:
   - write-adr
   - write-readme
   - relational-database-design
-  - vue-application-structure
+  - react-application-structure
+  - react-component-design
+  - react-component-testing
   - internationalization-i18n
   - sql-query-optimization
   - health-check-endpoints
@@ -89,9 +92,9 @@ output:
   lint_command: "golangci-lint run && pnpm lint"
   structure: nested
   project_header: |
-    Full-stack project: Go hexagonal backend + Nuxt 3 frontend.
+    Full-stack project: Go hexagonal backend + React SPA frontend (no SSR).
     Backend domain package must have zero external dependencies.
-    Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    Frontend uses strict TypeScript with functional components and hooks.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/typescript-hexagonal-next-ui.yaml
+++ b/profiles/typescript-hexagonal-next-ui.yaml
@@ -1,0 +1,118 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
+meta:
+  name: "TypeScript Hexagonal + Next UI"
+  description: >
+    Full-stack TypeScript application with a Hono hexagonal backend and a
+    Next.js frontend. Hono handles all business logic and HTTP APIs;
+    Next.js delivers SSR-capable pages with modern build performance and Vitest
+    for unit tests. Monorepo or split-repo — same language end to end.
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+
+  languages: []       # ignored in nested mode — declared in tiers below
+
+  frameworks: []      # ignored in nested mode — declared in tiers below
+
+  architecture: []    # ignored in nested mode — each tier defines its own
+
+  practices:
+    - tdd
+    - api-design
+    - observability
+    - ci-cd
+
+  domains: []
+
+tiers:
+  backend:
+    languages:
+      - typescript
+    frameworks: []
+    architecture:
+      - hexagonal
+      - ddd
+      - microservices
+    commands:
+      build_command: "pnpm --filter backend build"
+      test_command:  "pnpm --filter backend test"
+      lint_command:  "pnpm --filter backend lint"
+    proprietary_libraries:
+      - name: "@acme/domain-kit"
+        description: "Backend domain kit"
+        url_doc: "https://docs.acme.internal/domain-kit"
+  ui:
+    languages:
+      - typescript
+    frameworks:
+      - react
+      - next
+      - react-component-design
+      - react-testing
+      - react-styling
+      - next-patterns
+    architecture: []
+    commands:
+      build_command: "pnpm --filter ui build"
+      test_command:  "pnpm --filter ui test"
+      lint_command:  "pnpm --filter ui lint"
+    proprietary_libraries:
+      - name: "@acme/ui-tokens"
+        description: "Design system tokens"
+
+tech_stack:
+  language_runtime: "Node 22+"
+  package_manager: "pnpm"
+  backend_framework: "Hono"
+  frontend_framework: "Next.js"
+  ui_component_library: "shadcn/ui"
+  css_framework: "Tailwind CSS v4"
+  build_tool: "Turbopack (Next.js)"
+  test_framework: "Vitest"
+  additional:
+    - "React"
+    - "App Router"
+  proprietary_libraries:
+    - name: "@acme/core"
+      description: "Core domain primitives shared across all services"
+
+skills:
+  - code-review
+  - add-tests
+  - write-adr
+  - write-readme
+  - relational-database-design
+  - react-application-structure
+  - react-component-design
+  - react-component-testing
+  - internationalization-i18n
+  - wireframe-prototyping
+  - static-code-analysis
+  - pull-request-automation
+  - github-actions-workflow
+  - monorepo-management
+
+output:
+  build_command: "pnpm build"
+  test_command: "pnpm test"
+  lint_command: "pnpm lint"
+  structure: nested
+  project_header: |
+    Full-stack TypeScript project: Hono hexagonal backend + Next.js frontend.
+    Backend domain layer must have zero framework dependencies.
+    Frontend uses strict TypeScript with functional components and hooks.
+    All dependencies are injected via interfaces defined in the domain or application layer.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/profiles/typescript-hexagonal-react-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-react-vite-ui.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
 meta:
-  name: "Go Hexagonal + Vue/Vite SPA"
+  name: "TypeScript Hexagonal + React/Vite SPA"
   description: >
-    Full-stack application with a Go hexagonal backend and a Vue 3 SPA
-    frontend. Go handles all business logic and HTTP APIs; Vue delivers a
+    Full-stack TypeScript application with a Hono hexagonal backend and a React
+    SPA frontend. Hono handles all business logic and HTTP APIs; React delivers a
     client-side single-page application with Vite for fast builds and Vitest
     for unit tests. No SSR.
   version: "1.0.0"
@@ -27,49 +27,47 @@ fragments:
     - api-design
     - observability
     - ci-cd
-    - go-standard-layout
 
   domains: []
 
 tiers:
   backend:
     languages:
-      - go
+      - typescript
     frameworks: []
     architecture:
       - hexagonal
       - ddd
       - microservices
     commands:
-      build_command: "go build ./..."
-      test_command:  "go test ./... -race -cover"
-      lint_command:  "golangci-lint run"
+      build_command: "pnpm --filter backend build"
+      test_command:  "pnpm --filter backend test"
+      lint_command:  "pnpm --filter backend lint"
   ui:
     languages:
       - typescript
     frameworks:
-      - vue
-      - vue-component-design
-      - vue-testing
-      - vue-styling
+      - react
+      - react-component-design
+      - react-testing
+      - react-styling
     architecture: []
     commands:
-      build_command: "pnpm build"
-      test_command:  "pnpm test"
-      lint_command:  "pnpm lint"
+      build_command: "pnpm --filter ui build"
+      test_command:  "pnpm --filter ui test"
+      lint_command:  "pnpm --filter ui lint"
 
 tech_stack:
-  language_runtime: "Go 1.26+ (backend) / Node 22+ (frontend)"
-  package_manager: "Go modules (backend) / pnpm (frontend)"
-  backend_framework: "gorilla/mux"
-  frontend_framework: "Vue 3 (SPA)"
-  ui_component_library: "shadcn/vue"
+  language_runtime: "Node 22+"
+  package_manager: "pnpm"
+  backend_framework: "Hono"
+  frontend_framework: "React (SPA)"
+  ui_component_library: "shadcn/ui"
   css_framework: "Tailwind CSS v4"
   build_tool: "Vite 6"
-  test_framework: "Vitest (frontend) / testify (backend)"
+  test_framework: "Vitest"
   additional:
-    - "pinia"
-    - "VueRouter"
+    - "React Router"
 
 skills:
   - code-review
@@ -77,25 +75,25 @@ skills:
   - write-adr
   - write-readme
   - relational-database-design
-  - vue-application-structure
-  - vue-component-design
-  - vue-component-testing
+  - react-application-structure
+  - react-component-design
+  - react-component-testing
   - internationalization-i18n
-  - sql-query-optimization
-  - health-check-endpoints
+  - wireframe-prototyping
   - static-code-analysis
+  - pull-request-automation
   - github-actions-workflow
   - monorepo-management
 
 output:
-  build_command: "go build ./... && pnpm build"
-  test_command: "go test ./... -race -cover && pnpm test"
-  lint_command: "golangci-lint run && pnpm lint"
+  build_command: "pnpm build"
+  test_command: "pnpm test"
+  lint_command: "pnpm lint"
   structure: nested
   project_header: |
-    Full-stack project: Go hexagonal backend + Vue 3 SPA frontend (no SSR).
-    Backend domain package must have zero external dependencies.
-    Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    Full-stack TypeScript project: Hono hexagonal backend + React SPA frontend (no SSR).
+    Backend domain layer must have zero framework dependencies.
+    Frontend uses strict TypeScript with functional components and hooks.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/typescript-next-app.yaml
+++ b/profiles/typescript-next-app.yaml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
+meta:
+  name: "TypeScript Next App"
+  description: >
+    Standalone Next.js application with React, Tailwind CSS v4, and Vitest.
+    SSR-capable with App Router. Covers Next-specific patterns (Server Components,
+    route handlers, caching, middleware, runtime config), React component design,
+    hooks patterns, styling discipline, and a three-tier test strategy
+    (unit / component / acceptance).
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+  languages:
+    - typescript
+  frameworks:
+    - next
+    - react-component-design
+    - react-testing
+    - react-styling
+    - next-patterns
+  architecture: []
+  practices:
+    - tdd
+    - api-design
+    - ci-cd
+  domains: []
+
+tech_stack:
+  language_runtime: "Node 22+"
+  package_manager: "pnpm"
+  frontend_framework: "Next.js"
+  ui_component_library: "shadcn/ui"
+  css_framework: "Tailwind CSS v4"
+  build_tool: "Turbopack (Next.js)"
+  test_framework: "Vitest + @testing-library/react"
+  additional:
+    - "React"
+    - "App Router"
+    - "Playwright (acceptance)"
+
+skills:
+  - code-review
+  - add-tests
+  - react-application-structure
+  - react-component-design
+  - react-component-testing
+  - wireframe-prototyping
+  - internationalization-i18n
+  - static-code-analysis
+  - write-readme
+  - write-adr
+  - github-actions-workflow
+
+output:
+  build_command: "pnpm build"
+  test_command: "pnpm test"
+  lint_command: "pnpm lint"
+  project_header: |
+    Standalone Next.js application with SSR via App Router.
+    Components and hooks use TypeScript strictly, with functional components only.
+    Server/client boundaries must be explicit and intentional.
+    Styling via Tailwind CSS v4; shadcn/ui for UI primitives.
+    API endpoints via route handlers. SSR safety rules apply everywhere.
+    Three-tier testing: Vitest unit tests for hooks/utils, @testing-library/react
+    for component behaviour, Playwright for acceptance tests.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/profiles/typescript-react-spa.yaml
+++ b/profiles/typescript-react-spa.yaml
@@ -1,0 +1,74 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
+meta:
+  name: "TypeScript React SPA"
+  description: >
+    Standalone React single-page application with Vite, React Router,
+    and Vitest. No server-side rendering. Covers component design, hooks
+    patterns, prop drilling prevention, Tailwind v4 styling discipline, and a
+    three-tier test strategy (unit / component / acceptance).
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+  languages:
+    - typescript
+  frameworks:
+    - react
+    - react-component-design
+    - react-testing
+    - react-styling
+  architecture: []
+  practices:
+    - tdd
+    - api-design
+    - ci-cd
+  domains: []
+
+tech_stack:
+  language_runtime: "Node 22+"
+  package_manager: "pnpm"
+  frontend_framework: "React (SPA)"
+  ui_component_library: "shadcn/ui"
+  css_framework: "Tailwind CSS v4"
+  build_tool: "Vite 6"
+  test_framework: "Vitest + @testing-library/react"
+  additional:
+    - "React Router"
+    - "Playwright (acceptance)"
+
+skills:
+  - code-review
+  - add-tests
+  - react-application-structure
+  - react-component-design
+  - react-component-testing
+  - wireframe-prototyping
+  - internationalization-i18n
+  - static-code-analysis
+  - write-readme
+  - github-actions-workflow
+
+output:
+  build_command: "pnpm build"
+  test_command: "pnpm test"
+  lint_command: "pnpm lint"
+  project_header: |
+    Standalone React SPA — no server-side rendering.
+    Components and hooks use TypeScript strictly, with functional components only.
+    Routing via React Router with explicit route ownership and boundaries.
+    Styling via Tailwind CSS v4 utility classes; shadcn/ui for UI primitives.
+    Three-tier testing: Vitest unit tests for hooks/utils, @testing-library/react
+    for component behaviour, Playwright for acceptance tests.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/skills/backend/technical-roadmap-planning/SKILL.md
+++ b/skills/backend/technical-roadmap-planning/SKILL.md
@@ -111,7 +111,7 @@ Produce the roadmap in this format:
 | 1 | DB connection pooling | High | S | Platform | Week 1 | Planned |
 | 2 | Event-driven orders | High | L | Backend | Week 6 | Planned |
 | 3 | Remove legacy auth | Medium | M | Backend | Week 4 | Planned |
-| 4 | Upgrade Go 1.23 | Low | S | Platform | Week 2 | Planned |
+| 4 | Upgrade Go 1.26 | Low | S | Platform | Week 2 | Planned |
 
 ### Dependencies
 - Item 3 (Remove legacy auth) is blocked by item X (New auth rollout, owned by product).

--- a/skills/devops/write-dockerfile/SKILL.md
+++ b/skills/devops/write-dockerfile/SKILL.md
@@ -27,7 +27,7 @@ Create a production-ready Dockerfile for the current project.
 
 Read: `package.json`, `go.mod`, `pyproject.toml`, `composer.json`, or other manifest files.
 Identify:
-- Runtime and version (Node 22, Go 1.23, Python 3.12, PHP 8.3)
+- Runtime and version (Node 22, Go 1.26, Python 3.12, PHP 8.3)
 - Build process (compile, bundle, install dependencies)
 - Entry point / start command
 

--- a/skills/ui/next-application-structure/SKILL.md
+++ b/skills/ui/next-application-structure/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: next-application-structure
+description: >
+  Establishes or reviews directory layout, server/client boundaries, routing,
+  data-fetching strategy, and testing structure for Next.js 14+ App Router
+  TypeScript applications. Invoked when the user asks to structure a Next app,
+  set App Router conventions, or review architecture for React parity.
+version: 1.0.0
+tags:
+  - ui
+  - nextjs
+  - react
+  - typescript
+resources:
+  - resources/app-router-guidance.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Next Application Structure Skill
+
+### Step 1 — App Router Directory Layout
+
+Organise by route segment and feature ownership:
+
+```
+src/
+  app/
+    (marketing)/
+      page.tsx
+    (app)/
+      dashboard/
+        page.tsx
+        loading.tsx
+        error.tsx
+    api/
+      auth/
+        route.ts
+    layout.tsx
+  features/
+    auth/
+      components/
+      server/
+      client/
+      auth.types.ts
+  components/
+    ui/
+  lib/
+    db/
+    auth/
+    validation/
+```
+
+### Step 2 — Server and Client Boundaries
+
+- Default to Server Components; add `'use client'` only when interactivity or browser APIs are needed.
+- Keep data fetching and secrets in server modules/route handlers.
+- Pass serialized data to client components via props.
+- Avoid importing server-only modules into client components.
+
+### Step 3 — Data Fetching and Mutations
+
+- Read data in Server Components when possible.
+- Use Route Handlers or Server Actions for mutations.
+- Revalidate with `revalidatePath`/`revalidateTag` after mutations.
+- Centralize schema validation (for example Zod) at request boundaries.
+
+### Step 4 — State and Caching Strategy
+
+- URL and route params: App Router primitives.
+- Shared client interaction state: React context or local store in client layer.
+- Remote data cache: Next fetch cache + query library only when client-side refetching is needed.
+
+### Step 5 — Testing Parity with React Stack
+
+- Unit and component tests: Vitest + React Testing Library.
+- E2E flows: Playwright.
+- For Server Components and route handlers, test logic in extracted server utilities where possible.
+
+### Step 6 — Verify
+
+- [ ] App Router segments contain `page.tsx`/`layout.tsx` and special files only where needed
+- [ ] Server-first component model is respected, with minimal `'use client'`
+- [ ] Secrets and privileged logic stay server-side
+- [ ] Mutation flows trigger explicit revalidation
+- [ ] `pnpm tsc --noEmit` and `pnpm test` pass

--- a/skills/ui/next-application-structure/resources/app-router-guidance.md
+++ b/skills/ui/next-application-structure/resources/app-router-guidance.md
@@ -1,0 +1,7 @@
+## Next App Router Guidance
+
+- Prefer Server Components by default
+- Use `'use client'` only where interaction/browser APIs are required
+- Keep mutations in Route Handlers or Server Actions
+- Revalidate cache explicitly after writes
+- Keep secrets and privileged code server-only

--- a/skills/ui/react-application-structure/SKILL.md
+++ b/skills/ui/react-application-structure/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: react-application-structure
+description: >
+  Establishes or reviews the directory layout, feature boundaries, state design,
+  routing approach, and data-fetching conventions for a React 18+ TypeScript
+  application. Invoked when the user asks to structure a React app, set up a
+  scalable architecture, or review React project organization.
+version: 1.0.0
+tags:
+  - ui
+  - react
+  - typescript
+  - architecture
+resources:
+  - resources/stack-guidance.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## React Application Structure Skill
+
+### Step 1 — Directory Layout (Feature-Based)
+
+Organise by feature, not by file type. Co-locate everything a feature needs:
+
+```
+src/
+  app/
+    providers/
+      QueryProvider.tsx
+      RouterProvider.tsx
+  features/
+    auth/
+      components/
+        AuthLoginForm.tsx
+      hooks/
+        useAuth.ts
+      state/
+        auth.store.ts
+      api/
+        auth.api.ts
+      types/
+        auth.types.ts
+  components/
+    ui/
+      Button.tsx
+      Modal.tsx
+  routes/
+    index.tsx
+  lib/
+    http.ts
+    env.ts
+  styles/
+  main.tsx
+```
+
+### Step 2 — Component and Hook Conventions
+
+- Use function components with TypeScript; no class components.
+- Keep components thin; move reusable logic to custom hooks.
+- Name hooks with the `use` prefix and keep single responsibility.
+- Keep side effects in hooks/components where they are consumed; avoid hidden global effects.
+
+```tsx
+interface Props {
+  userId: string
+  readonly?: boolean
+}
+
+export function UserCard({ userId, readonly = false }: Props) {
+  const { user } = useAuthUser(userId)
+  return <section>{readonly ? user.name : <strong>{user.name}</strong>}</section>
+}
+```
+
+### Step 3 — State Management Boundaries
+
+- Local transient UI state: `useState` / `useReducer`.
+- Shared server state: TanStack Query (queries + mutations).
+- Shared client state across features: Zustand or Redux Toolkit slice per domain.
+- Do not duplicate server state into client stores unless offline/derived behaviour requires it.
+
+### Step 4 — Routing and Entry Points
+
+- Use a typed router setup (`react-router-dom` data routers or framework router).
+- Keep route definitions in `routes/` and route-level loaders/actions with route modules.
+- Lazy-load route components where possible.
+- Route guards should be centralized helper wrappers, not repeated inline logic.
+
+### Step 5 — Data and API Layer
+
+- Keep API clients in `features/*/api` or shared `lib/http.ts`.
+- Normalize error handling in one place (interceptor or query/mutation wrapper).
+- Validate API payloads at boundaries (for example Zod schemas) before wider app use.
+
+### Step 6 — Verify
+
+- [ ] Feature-first directory layout is used
+- [ ] Hooks handle reusable logic; components stay presentation-focused
+- [ ] Server state is handled by query layer, not duplicated into global client state
+- [ ] Route modules are lazy-loaded where appropriate
+- [ ] `pnpm tsc --noEmit` passes with zero errors

--- a/skills/ui/react-application-structure/resources/stack-guidance.md
+++ b/skills/ui/react-application-structure/resources/stack-guidance.md
@@ -1,0 +1,9 @@
+## React Stack Guidance
+
+- Runtime: React 19+
+- Language: TypeScript strict mode
+- Routing: `react-router-dom` data APIs (or framework router)
+- Server state: TanStack Query
+- Client shared state: Zustand or Redux Toolkit
+- Validation: Zod for API boundaries
+- Tests: Vitest + React Testing Library + Playwright

--- a/skills/ui/react-component-design/SKILL.md
+++ b/skills/ui/react-component-design/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: react-component-design
+description: >
+  Designs or reviews React component APIs. Handles prop drilling decisions,
+  composition patterns, controlled/uncontrolled contracts, and minimal public
+  API surfaces for React 18+ TypeScript components. Invoked when creating new
+  components, refactoring existing ones, or reviewing component contracts.
+version: 1.0.0
+tags:
+  - ui
+  - react
+  - typescript
+  - composition
+resources:
+  - resources/component-api-checklist.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## React Component Design Skill
+
+### Step 1 — Identify the Component Responsibility
+
+Determine the component type before designing the API:
+
+- Page component: orchestrates data fetching, permissions, and layout.
+- Feature component: contains feature-specific state and business behavior.
+- UI component: pure presentational; props and callbacks only.
+
+### Step 2 — Design the Public API Surface
+
+- Keep props minimal and strongly typed.
+- Prefer explicit callback names (`onSave`, `onDismiss`) over generic handlers.
+- Support controlled and uncontrolled modes only when both are needed.
+- Forward refs only for imperative handles (focus, scroll, open).
+
+```tsx
+interface TextInputProps {
+  value?: string
+  defaultValue?: string
+  onValueChange?: (next: string) => void
+}
+
+export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+  ({ value, defaultValue, onValueChange }, ref) => {
+    return (
+      <input
+        ref={ref}
+        value={value}
+        defaultValue={defaultValue}
+        onChange={(e) => onValueChange?.(e.target.value)}
+      />
+    )
+  },
+)
+```
+
+### Step 3 — Evaluate Prop Drilling Depth
+
+- 1-2 levels: props are acceptable.
+- 3+ levels through intermediates that do not use data: refactor to context or composition.
+- Global cross-feature state: dedicated store.
+
+### Step 4 — Composition and Extensibility
+
+- Prefer composition over inheritance.
+- Use compound components with context for tightly-related primitives.
+- Use render props or slot-like `children` patterns when parent-controlled rendering is required.
+- Do not expose internal implementation state through props.
+
+### Step 5 — Accessibility and Semantics
+
+- Base UI components must render semantic HTML first.
+- Ensure keyboard navigation and focus management are first-class API concerns.
+- Tie labels and descriptions to controls via `id`, `aria-*`, and role-appropriate markup.
+
+### Step 6 — Verify
+
+- [ ] Component responsibility is single-purpose
+- [ ] Public props are minimal and typed
+- [ ] No prop drilling through more than two uninterested layers
+- [ ] `forwardRef` is only used for imperative handles
+- [ ] Interactive components meet semantic and keyboard accessibility basics
+- [ ] `pnpm tsc --noEmit` passes with no errors

--- a/skills/ui/react-component-design/resources/component-api-checklist.md
+++ b/skills/ui/react-component-design/resources/component-api-checklist.md
@@ -1,0 +1,8 @@
+## Component API Checklist
+
+- Single responsibility per component
+- Typed props with minimal surface area
+- Explicit callback naming (`onX`)
+- Controlled/uncontrolled contract only when needed
+- `forwardRef` only for imperative handles
+- Accessible semantic HTML by default

--- a/skills/ui/react-component-testing/SKILL.md
+++ b/skills/ui/react-component-testing/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: react-component-testing
+description: >
+  Applies the three-tier test taxonomy for React applications: unit tests for
+  hooks and pure logic, component tests for behavior and interactions, and end-to-end
+  tests for user flows. Uses Vitest, React Testing Library, and Playwright while
+  focusing on observable behavior over implementation details.
+version: 1.0.0
+tags:
+  - ui
+  - react
+  - testing
+  - vitest
+resources:
+  - resources/testing-matrix.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## React Component Testing Skill
+
+### Step 1 — Classify What Needs to Be Tested
+
+Assign each file to a test tier before writing tests:
+
+- Hook / reducer / pure function -> unit test.
+- Component behavior / interaction -> component test.
+- Multi-page user flow -> end-to-end test.
+
+### Step 2 — Write Unit Tests
+
+- Test hooks with `renderHook` and explicit inputs.
+- Test reducers and utilities as pure functions.
+- Mock network boundaries; do not mount full UI.
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { authReducer } from './auth.reducer'
+
+it('sets user on login success', () => {
+  const state = authReducer({ user: null }, { type: 'login/success', payload: { id: '1' } })
+  expect(state.user?.id).toBe('1')
+})
+```
+
+### Step 3 — Write Component Tests
+
+- Use React Testing Library queries by role/label/text.
+- Use `userEvent` for interactions, not low-level DOM event simulation unless necessary.
+- Wrap with providers used in production (router, query client, store) via a shared test render utility.
+- Assert user-visible output and callback side effects.
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SaveButton } from './SaveButton'
+
+it('calls onSave when clicked', async () => {
+  const onSave = vi.fn()
+  render(<SaveButton onSave={onSave} />)
+  await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+  expect(onSave).toHaveBeenCalledTimes(1)
+})
+```
+
+### Step 4 — Write End-to-End Tests
+
+- Use Playwright for full browser flows across routes.
+- Cover one happy path and key failure path for each critical user journey.
+- Keep E2E focused on integration risks, not exhaustive branch coverage.
+
+### Step 5 — Verify
+
+- [ ] Each custom hook has unit tests for success and edge behavior
+- [ ] Interactive components test primary user interactions
+- [ ] No tests assert private state or implementation-only details
+- [ ] Critical journeys have Playwright coverage (happy path + failure path)
+- [ ] `pnpm test` passes with zero failures

--- a/skills/ui/react-component-testing/resources/testing-matrix.md
+++ b/skills/ui/react-component-testing/resources/testing-matrix.md
@@ -1,0 +1,7 @@
+## Testing Matrix
+
+- Unit: hooks, reducers, pure utilities (Vitest)
+- Component: interactive UI behavior (React Testing Library)
+- E2E: critical multi-route user journeys (Playwright)
+- Prefer role-based queries and user interactions
+- Avoid assertions on internal implementation details

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -384,7 +384,7 @@ bash "$COMPOSE" \
   > /dev/null 2>&1
 
 assert_file_contains "$TMP/t16/AGENTS.md" "## Technical Stack" "T16"
-assert_file_contains "$TMP/t16/AGENTS.md" "Go 1.23+" "T16"
+assert_file_contains "$TMP/t16/AGENTS.md" "Go 1.26+" "T16"
 assert_file_contains "$TMP/t16/AGENTS.md" "Cobra + Viper" "T16"
 
 # T17 — compose: profile with skills produces slim ## Skills listing
@@ -2302,6 +2302,102 @@ assert_exit_code 0 "$T103_EXIT" "T103"
 assert_stdout_contains "$T103_OUTPUT" "Deprecated MCP declaration in profile detected" "T103 warning"
 assert_file_exists "$TMP/t103/.mcp.json" "T103 mcp json"
 assert_file_contains "$TMP/t103/.mcp.json" "legacy-only" "T103 legacy server seeded"
+
+# T104 — compose: standalone typescript-react-spa profile
+run_test "T104 — compose: standalone typescript-react-spa profile"
+T104_EXIT=0
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-react-spa \
+  --target "$TMP/t104" \
+  > /dev/null 2>&1 || T104_EXIT=$?
+
+assert_exit_code 0 "$T104_EXIT" "T104"
+assert_file_exists "$TMP/t104/AGENTS.md" "T104"
+assert_file_contains "$TMP/t104/AGENTS.md" ".agentic/fragments/react.md" "T104"
+assert_file_not_contains "$TMP/t104/AGENTS.md" ".agentic/fragments/next.md" "T104"
+
+# T105 — compose: standalone typescript-next-app profile
+run_test "T105 — compose: standalone typescript-next-app profile"
+T105_EXIT=0
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-next-app \
+  --target "$TMP/t105" \
+  > /dev/null 2>&1 || T105_EXIT=$?
+
+assert_exit_code 0 "$T105_EXIT" "T105"
+assert_file_exists "$TMP/t105/AGENTS.md" "T105"
+assert_file_contains "$TMP/t105/AGENTS.md" ".agentic/fragments/next.md" "T105"
+assert_file_not_contains "$TMP/t105/AGENTS.md" ".agentic/fragments/react.md" "T105"
+
+# T106 — compose: nested typescript-hexagonal-react-vite-ui backend/ui split
+run_test "T106 — compose: nested typescript-hexagonal-react-vite-ui backend/ui split"
+T106_EXIT=0
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-react-vite-ui \
+  --target "$TMP/t106" \
+  > /dev/null 2>&1 || T106_EXIT=$?
+
+assert_exit_code 0 "$T106_EXIT" "T106"
+assert_file_exists "$TMP/t106/backend/AGENTS.md" "T106"
+assert_file_exists "$TMP/t106/ui/AGENTS.md" "T106"
+assert_file_contains "$TMP/t106/backend/AGENTS.md" ".agentic/fragments/hexagonal.md" "T106"
+assert_file_not_contains "$TMP/t106/backend/AGENTS.md" ".agentic/fragments/react.md" "T106"
+assert_file_contains "$TMP/t106/ui/AGENTS.md" ".agentic/fragments/react.md" "T106"
+assert_file_not_contains "$TMP/t106/ui/AGENTS.md" ".agentic/fragments/hexagonal.md" "T106"
+
+# T107 — compose: nested golang-hexagonal-react-vite-ui backend/ui split
+run_test "T107 — compose: nested golang-hexagonal-react-vite-ui backend/ui split"
+T107_EXIT=0
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-react-vite-ui \
+  --target "$TMP/t107" \
+  > /dev/null 2>&1 || T107_EXIT=$?
+
+assert_exit_code 0 "$T107_EXIT" "T107"
+assert_file_exists "$TMP/t107/backend/AGENTS.md" "T107"
+assert_file_exists "$TMP/t107/ui/AGENTS.md" "T107"
+assert_file_contains "$TMP/t107/backend/AGENTS.md" ".agentic/fragments/hexagonal.md" "T107"
+assert_file_not_contains "$TMP/t107/backend/AGENTS.md" ".agentic/fragments/react.md" "T107"
+assert_file_contains "$TMP/t107/ui/AGENTS.md" ".agentic/fragments/react.md" "T107"
+assert_file_not_contains "$TMP/t107/ui/AGENTS.md" ".agentic/fragments/hexagonal.md" "T107"
+
+# T108 — compose: nested typescript-hexagonal-next-ui backend/ui split
+run_test "T108 — compose: nested typescript-hexagonal-next-ui backend/ui split"
+T108_EXIT=0
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-next-ui \
+  --target "$TMP/t108" \
+  > /dev/null 2>&1 || T108_EXIT=$?
+
+assert_exit_code 0 "$T108_EXIT" "T108"
+assert_file_exists "$TMP/t108/backend/AGENTS.md" "T108"
+assert_file_exists "$TMP/t108/ui/AGENTS.md" "T108"
+assert_file_contains "$TMP/t108/backend/AGENTS.md" ".agentic/fragments/hexagonal.md" "T108"
+assert_file_not_contains "$TMP/t108/backend/AGENTS.md" ".agentic/fragments/next.md" "T108"
+assert_file_contains "$TMP/t108/ui/AGENTS.md" ".agentic/fragments/next.md" "T108"
+assert_file_not_contains "$TMP/t108/ui/AGENTS.md" ".agentic/fragments/hexagonal.md" "T108"
+
+# T109 — compose: nested golang-hexagonal-next-ui backend/ui split
+run_test "T109 — compose: nested golang-hexagonal-next-ui backend/ui split"
+T109_EXIT=0
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-next-ui \
+  --target "$TMP/t109" \
+  > /dev/null 2>&1 || T109_EXIT=$?
+
+assert_exit_code 0 "$T109_EXIT" "T109"
+assert_file_exists "$TMP/t109/backend/AGENTS.md" "T109"
+assert_file_exists "$TMP/t109/ui/AGENTS.md" "T109"
+assert_file_contains "$TMP/t109/backend/AGENTS.md" ".agentic/fragments/hexagonal.md" "T109"
+assert_file_not_contains "$TMP/t109/backend/AGENTS.md" ".agentic/fragments/next.md" "T109"
+assert_file_contains "$TMP/t109/ui/AGENTS.md" ".agentic/fragments/next.md" "T109"
+assert_file_not_contains "$TMP/t109/ui/AGENTS.md" ".agentic/fragments/hexagonal.md" "T109"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary
- add React/Next framework fragments, UI skills, and profile families for issue #104
- add tests-first compose coverage for standalone and nested React/Next profiles (`T104`-`T109`)
- update docs and profile counts for new profile catalog entries
- update Go-related runtime references from `Go 1.23+` to `Go 1.26+` (latest stable line)

## Added
- React fragments:
  - `agents/frameworks/react.md`
  - `agents/frameworks/react-component-design.md`
  - `agents/frameworks/react-testing.md`
  - `agents/frameworks/react-styling.md`
- Next fragments:
  - `agents/frameworks/next.md`
  - `agents/frameworks/next-patterns.md`
- UI skills:
  - `skills/ui/react-application-structure/`
  - `skills/ui/react-component-design/`
  - `skills/ui/react-component-testing/`
  - `skills/ui/next-application-structure/`
- Profiles:
  - `profiles/typescript-react-spa.yaml`
  - `profiles/typescript-next-app.yaml`
  - `profiles/typescript-hexagonal-react-vite-ui.yaml`
  - `profiles/golang-hexagonal-react-vite-ui.yaml`
  - `profiles/typescript-hexagonal-next-ui.yaml`
  - `profiles/golang-hexagonal-next-ui.yaml`

## Changed
- Tests:
  - `tooling/lib/test.sh` with new compose coverage `T104`-`T109`
- Docs:
  - `README.md`
  - `docs/profiles.md`
  - `docs/index.md`
- Indexes:
  - `index/skills.json`
  - `index/fragments.json`
- Go runtime baseline references updated to `Go 1.26+` in relevant profiles and skills.

## Validation
- `just lint` passed
- `just index` passed
- `just test` passed (`373/373`)

## Notes
- Latest stable Go line verified from official Go release history/blog (`go.dev`): Go `1.26` with current patch `1.26.2` (released 2026-04-07).

Closes #104
