### PR TITLE
feat(skills): add git worktree workspace workflow skill

### DIFF
--- a/agents/base/git-conventions.md
+++ b/agents/base/git-conventions.md
@@ -46,8 +46,9 @@ test(orders): add edge case for zero-amount orders
 
 ### PR Workflow
 
-- Always branch from an updated `main` for new work.
+- Always branch from an updated `main` for new independent work.
 - Each logical change should result in a single PR ready for review.
+- Exception: when intentionally using stacked/chained PRs, branch child work from the parent feature branch and use `Refs #N` until the final PR.
 - Keep PRs small and focused — one PR = one logical change.
 - Avoid mixing unrelated changes to reduce review fatigue.
 - Prefer completing and merging smaller PRs over accumulating large diffs.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -110,6 +110,23 @@ agentic deploy <profile> [target] <vendors> --skills project:my-custom-workflow
 Project skills are copied to `.agentic/skills/` alongside library skills and
 symlinked to vendor-specific paths just like regular skills.
 
+### Example: Use a Library Skill for Parallel Branch Work
+
+Enable the shared `git-worktree-workspaces` skill in your local profile:
+
+```yaml
+# In .agentic/profile.yaml
+skills:
+  - git-worktree-workspaces
+  - git-flow-pr
+```
+
+Then regenerate:
+
+```bash
+agentic sync
+```
+
 ## Declare Proprietary Libraries
 
 List internal packages that agents need to be aware of. Agents are told to load

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-28T19:43:10Z",
+  "generated_at": "2026-04-28T20:18:29Z",
   "fragments": [
     {
       "name": "bff",
@@ -70,7 +70,7 @@
       "group": "base",
       "path": "agents/base/git-conventions.md",
       "heading": "Git Conventions",
-      "words": 244
+      "words": 268
     },
     {
       "name": "security",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-28T19:43:09Z",
+  "generated_at": "2026-04-28T20:10:25Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -258,6 +258,19 @@
         "github",
         "pull-request",
         "workflow"
+      ]
+    },
+    {
+      "name": "git-worktree-workspaces",
+      "group": "development",
+      "path": "skills/development/git-worktree-workspaces/SKILL.md",
+      "description": "Sets up and uses Git worktrees for parallel task workspaces in the same repository clone, including safe cleanup of loca",
+      "version": "1.0.0",
+      "tags": [
+        "git",
+        "worktree",
+        "workflow",
+        "productivity"
       ]
     },
     {

--- a/skills/development/git-flow-pr/SKILL.md
+++ b/skills/development/git-flow-pr/SKILL.md
@@ -3,10 +3,10 @@ name: git-flow-pr
 description: >
   Executes the full PR-driven development workflow: create an isolated feature
   branch from the current work, commit all staged changes, rebase cleanly onto
-  origin/main (skipping any ancestor commits already merged), push the branch,
-  and open a GitHub pull request linked to a related issue. Invoked when the
-  user says "open a PR", "create a pull request", "push and PR", or "branch,
-  rebase and PR".
+  the selected base branch (skipping any ancestor commits already merged), push
+  the branch, and open a GitHub pull request linked to a related issue.
+  Includes guidance for stacked/chained PRs. Invoked when the user says "open a
+  PR", "create a pull request", "push and PR", or "branch, rebase and PR".
 version: 1.0.0
 tags:
   - git
@@ -34,12 +34,13 @@ Before doing anything, understand what exists:
 git status --short          # Are there uncommitted changes?
 git log --oneline -10       # What commits exist on this branch?
 git branch --show-current   # Which branch are we on?
-git fetch origin main       # Get latest state of main
-git log --oneline origin/main..HEAD   # Commits unique to this branch
+BASE_BRANCH="<base-branch>" # e.g. main, develop, release/*
+git fetch origin "$BASE_BRANCH"
+git log --oneline "origin/$BASE_BRANCH"..HEAD   # Commits unique to this branch
 ```
 
 Identify:
-- The **base branch** (usually `main`)
+- The **base branch** (often `main`, but use the repo's actual target)
 - Any **uncommitted changes** that need to be staged
 - Whether the current branch's ancestor commits are **already merged into main**
   (this determines which `--onto` strategy to use in Step 4)
@@ -60,7 +61,8 @@ Closes #<issue-number>"
 Commit message rules:
 - Follow Conventional Commits: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
 - Scope should reflect the area changed: `(gemini)`, `(tooling)`, `(docs)`, `(skills)`, etc.
-- Reference the issue with `Closes #N` or `Fixes #N` in the commit body
+- For final PRs that should auto-close the issue on merge, use `Closes #N` or `Fixes #N`
+- For stacked/chained PRs or partial work, use `Refs #N` to link without auto-closing
 - Keep the subject line ≤ 72 characters
 
 ### Step 3 — Create the Feature Branch
@@ -80,38 +82,38 @@ Branch naming convention:
 
 Use kebab-case. Keep it short but descriptive (3–5 words max).
 
-### Step 4 — Rebase onto origin/main
+### Step 4 — Rebase onto origin/<base-branch>
 
 **Critical:** determine the correct rebase strategy before running.
 
-#### Case A — No ancestor commits already in main (simple case)
+#### Case A — No ancestor commits already in the selected base branch (simple case)
 
-The branch was created fresh and diverged directly from main:
+The branch was created fresh and diverged directly from the selected base branch:
 
 ```bash
-git rebase origin/main
+git rebase "origin/$BASE_BRANCH"
 ```
 
-#### Case B — Ancestor commits are already merged into main (squash-merge or similar)
+#### Case B — Ancestor commits are already merged into the selected base branch (squash-merge or similar)
 
 This happens when:
 - The branch was created on top of another branch that was already merged
-- The repo uses squash-merge PRs, so commit SHAs on the branch differ from main
+- The repo uses squash-merge PRs, so commit SHAs on the branch differ from the selected base branch
 
-Identify the last commit **not** in main:
+Identify the last commit **not** in the selected base branch:
 
 ```bash
-# Find the oldest commit on this branch not present in main
-git log --oneline origin/main..HEAD
+# Find the oldest commit on this branch not present in the selected base branch
+git log --oneline "origin/$BASE_BRANCH"..HEAD
 # The last line shows the oldest unique commit — its *parent* is the rebase base
-ANCESTOR=$(git log --oneline origin/main..HEAD | tail -1 | awk '{print $1}')
+ANCESTOR=$(git log --oneline "origin/$BASE_BRANCH"..HEAD | tail -1 | awk '{print $1}')
 PARENT=$(git rev-parse "$ANCESTOR"^)
 ```
 
-Then rebase only the unique commits onto main:
+Then rebase only the unique commits onto the selected base branch:
 
 ```bash
-git rebase --onto origin/main "$PARENT" HEAD
+git rebase --onto "origin/$BASE_BRANCH" "$PARENT" HEAD
 ```
 
 This replays only the commits that are genuinely new, dropping the already-merged ones.
@@ -119,7 +121,7 @@ This replays only the commits that are genuinely new, dropping the already-merge
 #### After rebase — verify
 
 ```bash
-git log --oneline -5          # Should show: new commit(s) on top of origin/main HEAD
+git log --oneline -5          # Should show: new commit(s) on top of origin/<base-branch> HEAD
 git status                    # Should be clean
 ```
 
@@ -157,7 +159,7 @@ git push origin <branch-name> --force-with-lease
 ```bash
 gh pr create \
   --title "<type>(<scope>): <concise summary>" \
-  --base main \
+  --base "$BASE_BRANCH" \
   --head <branch-name> \
   --body "$(cat <<'EOF'
 ## Summary
@@ -172,7 +174,7 @@ gh pr create \
 |------|-------|
 | <area> | <files> |
 
-Closes #<issue-number>
+<issue-footer: Refs #<issue-number> | Closes #<issue-number>>
 EOF
 )"
 ```
@@ -185,7 +187,22 @@ PR title rules:
 Body rules:
 - 2–4 bullet summary (what + why, not just what)
 - Changes table for non-trivial diffs
-- `Closes #N` links the PR to the issue and auto-closes it on merge
+- Use `Refs #N` for stacked/chained PRs and intermediate slices
+- Use `Closes #N` only on the final PR that should auto-close the issue
+
+### Step 7.1 — Stacked/Chained PRs
+
+When a change is too large for one reviewable PR, split into a chain:
+
+1. Create `feat/<topic>-base` from the base branch and open PR A (`--base "$BASE_BRANCH"`).
+2. Create `feat/<topic>-part-2` from `feat/<topic>-base` and open PR B (`--base feat/<topic>-base`).
+3. Continue similarly for PR C, D, etc., each targeting the prior branch.
+
+Rules for stacked PRs:
+- Keep each PR independently reviewable and logically scoped.
+- PR body should include `Refs #N` (not `Closes #N`) until final branch in the chain.
+- After lower PRs merge, rebase higher branches onto the updated base branch and force-push with lease.
+- Update PR base with `gh pr edit --base <new-base>` when needed.
 
 ### Step 8 — Verify
 
@@ -197,7 +214,7 @@ gh pr view        # Confirm PR is open with correct title, base branch, and issu
 
 Check:
 - [ ] PR title follows Conventional Commits format
-- [ ] Base branch is `main` (not another feature branch)
-- [ ] Issue is linked via `Closes #N` in the body
+- [ ] Base branch is correct for the workflow (`$BASE_BRANCH` or parent branch for stacked PRs)
+- [ ] Issue linkage uses `Refs #N` for intermediate PRs and `Closes #N` only for final PRs
 - [ ] CI checks are triggered and passing (check `gh pr checks`)
-- [ ] Branch is up to date with `main` (no "behind by N commits" warning)
+- [ ] Branch is up to date with the selected base branch (no "behind by N commits" warning)

--- a/skills/development/git-worktree-workspaces/SKILL.md
+++ b/skills/development/git-worktree-workspaces/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: git-worktree-workspaces
+description: >
+  Sets up and uses Git worktrees for parallel task workspaces in the same
+  repository clone, including safe cleanup of local worktrees. Invoked when the
+  user asks to work on multiple branches at once, isolate tasks without extra
+  clones, or create/remove worktrees.
+version: 1.0.0
+tags:
+  - git
+  - worktree
+  - workflow
+  - productivity
+resources: []
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Git Worktree Workspaces Skill
+
+### Step 1 — Discover Current Repo State
+
+```bash
+git rev-parse --show-toplevel
+git branch --show-current
+git worktree list --porcelain
+git remote show origin | sed -n '/HEAD branch/s/.*: //p'
+```
+
+Capture:
+- Current repository root and active branch
+- Existing worktrees and paths
+- Remote default branch (do not assume a fixed branch name)
+
+### Step 2 — Pick Naming and Layout
+
+Use a predictable directory pattern outside the main working tree:
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_NAME="$(basename "$REPO_ROOT")"
+WORKTREE_ROOT="$(dirname "$REPO_ROOT")/${REPO_NAME}-worktrees"
+mkdir -p "$WORKTREE_ROOT"
+```
+
+Recommended names:
+- Branch: `feat/<topic>`, `fix/<topic>`, `docs/<topic>`
+- Path: `$WORKTREE_ROOT/<branch-slug>`
+
+### Step 3 — Create a New Worktree
+
+For a new branch:
+
+```bash
+BASE_BRANCH="$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')"
+NEW_BRANCH="feat/<topic>"
+TARGET_PATH="$WORKTREE_ROOT/${NEW_BRANCH//\//-}"
+
+git fetch origin "$BASE_BRANCH"
+git worktree add -b "$NEW_BRANCH" "$TARGET_PATH" "origin/$BASE_BRANCH"
+```
+
+For an existing branch:
+
+```bash
+EXISTING_BRANCH="<branch>"
+TARGET_PATH="$WORKTREE_ROOT/${EXISTING_BRANCH//\//-}"
+
+git fetch origin
+git worktree add "$TARGET_PATH" "$EXISTING_BRANCH"
+```
+
+### Step 4 — Work Independently Per Task
+
+Inside each worktree:
+
+```bash
+cd "$TARGET_PATH"
+git status --short
+git add <files>
+git commit -m "feat(<scope>): <summary>"
+```
+
+Rules:
+- One task per worktree branch.
+- Keep commits scoped to that task only.
+- Run project quality gates before pushing.
+
+### Step 5 — Push and Open PRs
+
+```bash
+git push -u origin "$(git branch --show-current)"
+gh pr create --base "<base-branch>" --head "$(git branch --show-current)"
+```
+
+Use `Refs #<issue>` for stacked/chained PRs that should not auto-close yet.
+Use `Closes #<issue>` only on the final PR intended to close the issue on merge.
+
+### Step 6 — Safe Cleanup (Local Only)
+
+After a branch is merged and no longer needed locally:
+
+```bash
+WORKTREE_PATH="<absolute-path-to-worktree>"
+BRANCH_NAME="<branch-name>"
+
+git -C "$WORKTREE_PATH" status --short
+git worktree remove "$WORKTREE_PATH"
+git branch -d "$BRANCH_NAME"
+git worktree prune
+```
+
+Safety checks:
+- Ensure there are no uncommitted changes before removing.
+- Use `-d` (not `-D`) so Git blocks branch deletion when unmerged.
+- Do not script remote branch deletion by default in this skill.

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -340,6 +340,7 @@ bash "$DEPLOY_SKILLS" \
 
 assert_file_exists "$TMP/t12/.agentic/skills/code-review/SKILL.md" "T12"
 assert_file_exists "$TMP/t12/.agentic/skills/add-tests/SKILL.md" "T12"
+assert_file_exists "$TMP/t12/.agentic/skills/git-worktree-workspaces/SKILL.md" "T12"
 assert_file_exists "$TMP/t12/.agentic/skills/README.md" "T12"
 
 # T13 — deploy-skills: selective deployment to .agentic/skills/
@@ -374,6 +375,7 @@ assert_json_valid "$LIBRARY/index/skills.json" "T15"
 assert_json_valid "$LIBRARY/index/fragments.json" "T15"
 assert_json_min_count "$LIBRARY/index/skills.json" '.skills | length' 10 "T15 skills"
 assert_json_min_count "$LIBRARY/index/fragments.json" '.fragments | length' 19 "T15 fragments"
+assert_file_contains "$LIBRARY/index/skills.json" "\"name\": \"git-worktree-workspaces\"" "T15 skills"
 
 # T16 — compose: profile with tech_stack produces ## Technical Stack section
 run_test "T16 — compose: tech_stack profile produces ## Technical Stack"
@@ -729,7 +731,7 @@ mkdir -p "$TMP/t34"
 bash "$DEPLOY_SKILLS" \
   --library "$LIBRARY" \
   --target "$TMP/t34" \
-  --skills code-review \
+  --skills code-review,git-worktree-workspaces \
   > /dev/null 2>&1
 
 assert_file_exists "$TMP/t34/.agentic/skills/README.md" "T34"
@@ -737,6 +739,7 @@ assert_file_contains "$TMP/t34/.agentic/skills/README.md" "Vendor Compatibility"
 assert_file_contains "$TMP/t34/.agentic/skills/README.md" ".claude/skills" "T34"
 assert_file_contains "$TMP/t34/.agentic/skills/README.md" ".agents/skills" "T34"
 assert_file_contains "$TMP/t34/.agentic/skills/README.md" "code-review" "T34"
+assert_file_contains "$TMP/t34/.agentic/skills/README.md" "git-worktree-workspaces" "T34"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # LOCAL PROFILE SUPPORT TESTS
@@ -1582,6 +1585,11 @@ bash "$LINT" \
   > /dev/null 2>&1 || T73_EXIT=$?
 
 assert_exit_code 0 "$T73_EXIT" "T73"
+
+# T110 — CLI: list skills includes new worktree skill
+run_test "T110 — CLI: list skills includes git-worktree-workspaces"
+T110_OUTPUT=$(LIBRARY_ROOT="$LIBRARY" bash -c 'source "$1/tooling/lib/cli.sh"; cmd_list skills' -- "$LIBRARY" 2>&1)
+assert_stdout_contains "$T110_OUTPUT" "git-worktree-workspaces" "T110"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # INDEX STABILITY TESTS


### PR DESCRIPTION
## Summary
- add a new `git-worktree-workspaces` skill for multi-agent workspace setup with safe cleanup guidance
- update `git-flow-pr` skill with stacked/chained PR guidance and explicit `Refs #N` vs `Closes/Fixes #N` usage
- add customization docs example for enabling the new skill
- extend tests and index assertions to ensure skill discoverability/deployment

## Changes
- Added:
  - `skills/development/git-worktree-workspaces/SKILL.md`
- Updated:
  - `skills/development/git-flow-pr/SKILL.md`
  - `agents/base/git-conventions.md` (explicit stacked PR exception to avoid contradictory guidance)
  - `docs/customization.md`
  - `tooling/lib/test.sh`
  - `index/skills.json`
  - `index/fragments.json`

## Validation
- `just index` passed
- `just lint` passed
- `just test` passed (`377/377`)

## Notes
- Scope kept skill-first: no new CLI commands, config keys, or worktree path persistence.
- Branch was rebased from latest `main` before implementation.

Closes #102
