### PR TITLE
docs(skills): add skills index and out-of-profile usage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,9 @@ project repositories via the tooling provided here.
 - When adding a new `just` recipe or CLI command, add it to `docs/commands.md`.
 - When adding or updating a skill that references tooling paths or output filenames,
   verify those paths are still accurate before committing.
+- When skills are added, renamed, regrouped, removed, or their user-visible metadata
+  (for example `name`/`description` in skill frontmatter) changes under `skills/`,
+  update `docs/skills.md` in the same change.
 
 ### Profiles
 

--- a/docs/.mkdocs/mkdocs.yml
+++ b/docs/.mkdocs/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
   - Reference:
       - Commands: commands.md
       - Profiles: profiles.md
+      - Skills: skills.md
       - Vendors: vendors.md
       - Customization: customization.md
       - Custom Rules: custom-rules.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,7 @@ agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
 - [**Quickstart**](getting-started/quickstart.md) — deploy examples, sync, vendor switching
 - [**Commands**](commands.md) — full CLI reference
 - [**Profiles**](profiles.md) — all available profiles and their fragments
+- [**Skills**](skills.md) — shared skill catalog plus persistent and ad hoc (selective) skill usage paths
 - [**Vendors**](vendors.md) — supported AI tools and their output files
 - [**Customization**](customization.md) — per-project overrides, project skills, proprietary libraries, link mode vs copy mode
 - [**Custom Rules**](custom-rules.md) — `AGENTS.local.md` injection

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,73 @@
+# Skills
+
+This page indexes all shared skills in this library, grouped by top-level skill type.
+
+## agentic
+
+- `compose-agents-md` — Create project-specific `AGENTS.md` instructions from the agentic library.
+- `configure-mcp` — Set up and configure MCP servers for agent tool access.
+- `deploy-config` — Deploy composed config, vendor files, and skills to a target project.
+- `persist-plan` — Save the current plan as a structured file under `.agentic/plans/`.
+- `write-plan` — Auto-persist generated plans and keep a local plans index updated.
+
+## backend
+
+- `golang-manual-di` — Implement explicit dependency injection wiring patterns for Go services.
+- `health-check-endpoints` — Add liveness/readiness health endpoints aligned with probe conventions.
+- `microservices-architecture` — Design microservice boundaries, communication, and resilience strategy.
+- `nosql-database-design` — Model NoSQL schemas from access patterns and consistency needs.
+- `serverless-architecture` — Design and implement serverless workloads with operational guardrails.
+- `sql-query-optimization` — Diagnose and optimize SQL performance using plans, indexes, and rewrites.
+- `technical-roadmap-planning` — Build prioritized engineering roadmaps with dependencies and milestones.
+- `terraform-infrastructure` — Structure and review Terraform IaC modules, state, and pipelines.
+- `webhook-development` — Build secure, reliable webhook receivers/senders with retries and idempotency.
+
+## data
+
+- `json-to-toon` — Convert JSON into TOON format to reduce LLM token usage.
+- `relational-database-design` — Design or review relational schemas, constraints, and migrations.
+
+## development
+
+- `add-tests` — Add focused tests for existing code based on behavior and edge cases.
+- `code-review` — Perform structured code review focused on correctness, risk, and quality.
+- `fix-bug` — Investigate root cause and implement a verified bug fix with regression coverage.
+- `git-flow-pr` — Execute branch, commit, rebase, push, and pull request workflow end-to-end.
+- `git-worktree-workspaces` — Use Git worktrees to run parallel branch workspaces safely.
+- `github-actions-workflow` — Create or improve GitHub Actions CI/CD workflows.
+- `monorepo-management` — Set up and govern monorepo layout, tooling, and CI strategy.
+- `pull-request-automation` — Improve PR process with templates, labels, checks, and branch policies.
+- `refactor` — Refactor code for clarity and structure without changing behavior.
+- `static-code-analysis` — Configure and integrate static analysis tooling into local and CI workflows.
+
+## devops
+
+- `write-dockerfile` — Generate production-ready Dockerfiles with secure, efficient build patterns.
+
+## documentation
+
+- `sync-confluence` — Sync engineering docs from the repo into Confluence Cloud.
+- `write-adr` — Create Architecture Decision Records with context, decision, and consequences.
+- `write-changelog` — Generate release changelog entries from commit history.
+- `write-readme` — Generate or update README content based on project source and structure.
+
+## ui
+
+- `internationalization-i18n` — Add or improve i18n/l10n architecture, messages, and workflows.
+- `next-application-structure` — Define scalable Next.js App Router project structure and conventions.
+- `react-application-structure` — Define scalable React application architecture and folder layout.
+- `react-component-design` — Design maintainable React component APIs and composition boundaries.
+- `react-component-testing` — Apply layered React testing strategy with RTL and Playwright.
+- `vue-application-structure` — Define scalable Vue application architecture and conventions.
+- `vue-component-design` — Design robust Vue component APIs with clear contracts.
+- `vue-component-testing` — Apply layered Vue testing strategy for logic, components, and flows.
+- `wireframe-prototyping` — Produce low-fidelity wireframes with interaction and acceptance notes.
+
+## Using a skill outside a profile
+
+Some profiles do not include every skill by default. There are two supported paths:
+
+1. Persistent/additive path: add the skill to `.agentic/profile.yaml`, then run `agentic sync` to apply the updated profile-defined skill set.
+2. Ad hoc selective path: pass explicit skills during deploy, for example `agentic deploy <profile> <target> <vendor> --skills <skill-name>`.
+
+When `--skills` is used, it acts as a selective override for that deployment rather than merging with all profile-default skills.


### PR DESCRIPTION
## Summary
- add a new docs skills index page grouped by skill type
- add clear guidance for using skills that are not included by a profile by default
- add a maintenance directive in `AGENTS.md` to keep `docs/skills.md` synchronized when skills change
- wire the new skills page into docs navigation and docs home sections

## Changes
- Added:
  - `docs/skills.md`
- Updated:
  - `docs/.mkdocs/mkdocs.yml` (navigation entry)
  - `docs/index.md` (sections link/description)
  - `AGENTS.md` (documentation maintenance rule)

## Important behavior clarification
- `.agentic/profile.yaml` + `agentic sync` is the persistent/additive path for skill configuration.
- `agentic deploy ... --skills <skill-name>` is documented as a selective override for that deploy command, not a merge with all profile-default skills.

## Validation
- `just lint` passed
- `cd docs/.mkdocs && mkdocs build --strict` passed

Closes #107
