### PR TITLE
feat(skills): add docker compose local setup skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -42,6 +42,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 
 ## devops
 
+- `docker-compose-local-setup` — Configure local multi-service `docker compose` stacks with readiness, envs, volumes, migrations, and verification.
 - `write-dockerfile` — Generate production-ready Dockerfiles with secure, efficient build patterns.
 
 ## documentation

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-28T20:10:25Z",
+  "generated_at": "2026-04-28T21:50:07Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -336,11 +336,24 @@
       ]
     },
     {
+      "name": "docker-compose-local-setup",
+      "group": "devops",
+      "path": "skills/devops/docker-compose-local-setup/SKILL.md",
+      "description": "Creates or updates local multi-service orchestration using docker compose. Covers compose.yaml design, service health ch",
+      "version": "1.0.0",
+      "tags": [
+        "devops",
+        "docker",
+        "compose",
+        "local-development"
+      ]
+    },
+    {
       "name": "write-dockerfile",
       "group": "devops",
       "path": "skills/devops/write-dockerfile/SKILL.md",
-      "description": "Creates an optimized, production-ready Dockerfile for the current project. Detects the language and framework, applies b",
-      "version": "1.0.0",
+      "description": "Creates or updates an optimized, production-ready Dockerfile and .dockerignore. Focuses on image build strategy, runtime",
+      "version": "1.1.0",
       "tags": [
         "devops",
         "docker",

--- a/profiles/go-hexagonal-microservice.yaml
+++ b/profiles/go-hexagonal-microservice.yaml
@@ -34,6 +34,8 @@ fragments:
   domains: []
 
 skills:
+  - docker-compose-local-setup
+  - write-dockerfile
   - relational-database-design
   - sql-query-optimization
   - webhook-development

--- a/profiles/golang-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/golang-hexagonal-nuxt-vite-ui.yaml
@@ -70,6 +70,8 @@ tech_stack:
     - "VueRouter"
 
 skills:
+  - docker-compose-local-setup
+  - write-dockerfile
   - code-review
   - add-tests
   - write-adr

--- a/profiles/golang-hexagonal-vue-vite-ui.yaml
+++ b/profiles/golang-hexagonal-vue-vite-ui.yaml
@@ -72,6 +72,8 @@ tech_stack:
     - "VueRouter"
 
 skills:
+  - docker-compose-local-setup
+  - write-dockerfile
   - code-review
   - add-tests
   - write-adr

--- a/profiles/php-hexagonal-ddd.yaml
+++ b/profiles/php-hexagonal-ddd.yaml
@@ -33,6 +33,8 @@ fragments:
   domains: []
 
 skills:
+  - docker-compose-local-setup
+  - write-dockerfile
   - relational-database-design
 
 output:

--- a/profiles/python-fastapi-microservice.yaml
+++ b/profiles/python-fastapi-microservice.yaml
@@ -32,6 +32,8 @@ fragments:
   domains: []
 
 skills:
+  - docker-compose-local-setup
+  - write-dockerfile
   - relational-database-design
 
 output:

--- a/profiles/typescript-bff.yaml
+++ b/profiles/typescript-bff.yaml
@@ -30,6 +30,10 @@ fragments:
 
   domains: []
 
+skills:
+  - docker-compose-local-setup
+  - write-dockerfile
+
 output:
   build_command: "pnpm build"
   test_command: "pnpm test --run"

--- a/profiles/typescript-hexagonal-microservice.yaml
+++ b/profiles/typescript-hexagonal-microservice.yaml
@@ -34,6 +34,8 @@ fragments:
   domains: []
 
 skills:
+  - docker-compose-local-setup
+  - write-dockerfile
   - relational-database-design
 
 output:

--- a/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
@@ -84,6 +84,8 @@ tech_stack:
       description: "Core domain primitives shared across all services"
 
 skills:
+  - docker-compose-local-setup
+  - write-dockerfile
   - code-review
   - add-tests
   - write-adr

--- a/profiles/typescript-hexagonal-vue-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-vue-vite-ui.yaml
@@ -71,6 +71,8 @@ tech_stack:
     - "VueRouter"
 
 skills:
+  - docker-compose-local-setup
+  - write-dockerfile
   - code-review
   - add-tests
   - write-adr

--- a/skills/devops/docker-compose-local-setup/SKILL.md
+++ b/skills/devops/docker-compose-local-setup/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: docker-compose-local-setup
+description: >
+  Creates or updates local multi-service orchestration using docker compose.
+  Covers compose.yaml design, service health checks, depends_on readiness,
+  env files, named volumes, migrations/seeds jobs, verification commands,
+  and cleanup workflows for local development.
+version: 1.0.0
+tags:
+  - devops
+  - docker
+  - compose
+  - local-development
+resources:
+  - compose-patterns-reference.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Docker Compose Local Setup Skill
+
+Set up or improve local multi-service orchestration with `docker compose`.
+
+### Step 1 — Model Local Services
+
+Define the local stack in `compose.yaml`:
+- app services (API, worker, frontend)
+- stateful dependencies (database, cache, broker)
+- one-off jobs (migrations, seeds)
+
+Keep local concerns explicit and avoid production-only orchestration details.
+
+### Step 2 — Configure Build, Runtime, and Networking
+
+For each service:
+- Use `build:` for local image workflows or `image:` when fixed images are preferred.
+- Set deterministic `container_name` only when needed for tooling compatibility.
+- Map ports required for local access.
+- Use the default compose network unless isolation is required.
+
+### Step 3 — Add Health Checks and Readiness
+
+For services that others depend on:
+- Add `healthcheck:` with realistic command, interval, timeout, retries, and start period.
+- Prefer `depends_on` with `condition: service_healthy` where supported by your compose implementation.
+- If condition-based readiness is unavailable, add explicit wait logic in dependent services.
+
+### Step 4 — Manage Configuration and Secrets for Local Use
+
+- Use `env_file:` for shared local defaults.
+- Keep per-service overrides in `environment:`.
+- Commit only safe sample files such as `.env.example`.
+- Never hardcode credentials in `compose.yaml` or checked-in env files.
+
+### Step 5 — Persist Data and Source Mounts
+
+- Use named volumes for database/cache durability across restarts.
+- Use bind mounts for hot-reload source workflows when appropriate.
+- Keep mount paths narrow to avoid accidental host pollution.
+
+### Step 6 — Handle Migrations and Seed Data
+
+Define one-off jobs for schema and seed flows:
+- migration service/command that runs after dependencies are healthy
+- optional seed service for local fixtures
+- idempotent commands so repeated local setup is safe
+
+### Step 7 — Verify End-to-End Startup
+
+Run and validate:
+1. `docker compose up --build -d`
+2. `docker compose ps`
+3. `docker compose logs --tail=200`
+4. service-specific checks (HTTP health endpoint, DB connectivity)
+
+Document expected healthy state and failure triage steps.
+
+### Step 8 — Cleanup and Reset
+
+Use the right cleanup level:
+- stop only: `docker compose stop`
+- stop and remove containers/network: `docker compose down`
+- full reset including named volumes: `docker compose down -v`
+
+Call out destructive reset commands before running them.
+
+### Step 9 — Keep Scope Boundaries Clear
+
+This skill is for local multi-service orchestration with `docker compose`.
+For Docker image authoring and production image hardening, use `write-dockerfile`.

--- a/skills/devops/docker-compose-local-setup/compose-patterns-reference.md
+++ b/skills/devops/docker-compose-local-setup/compose-patterns-reference.md
@@ -1,0 +1,97 @@
+## Docker Compose Patterns Reference
+
+Use this reference when creating or updating local `compose.yaml` files.
+
+### Service Skeleton
+
+```yaml
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    environment:
+      APP_ENV: local
+    ports:
+      - "8080:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+```
+
+### Dependency Services
+
+```yaml
+services:
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d app"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+```
+
+### Migrations and Seed Jobs
+
+```yaml
+services:
+  migrate:
+    build: .
+    command: ["sh", "-c", "npm run migrate"]
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"
+
+  seed:
+    build: .
+    command: ["sh", "-c", "npm run seed"]
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    restart: "no"
+```
+
+### Named Volumes
+
+```yaml
+volumes:
+  db-data:
+  redis-data:
+```
+
+### Local Workflow Commands
+
+```bash
+docker compose up --build -d
+docker compose ps
+docker compose logs --tail=200
+docker compose exec api sh
+docker compose down
+docker compose down -v
+```
+
+### Verification Checklist
+
+- All required services show `healthy` in `docker compose ps`.
+- API can reach its dependencies using compose DNS names.
+- Migrations run cleanly from a fresh volume state.
+- Restarting with existing volumes preserves expected data.
+- `docker compose down -v` reliably resets the stack.

--- a/skills/devops/write-dockerfile/SKILL.md
+++ b/skills/devops/write-dockerfile/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: write-dockerfile
 description: >
-  Creates an optimized, production-ready Dockerfile for the current project.
-  Detects the language and framework, applies best practices (multi-stage builds,
-  non-root user, minimal base image, layer caching optimization).
-  Invoked when the user asks to write or create a Dockerfile, containerize an app, or add Docker support.
-version: 1.0.0
+  Creates or updates an optimized, production-ready Dockerfile and .dockerignore.
+  Focuses on image build strategy, runtime hardening, caching, and minimal production images.
+  Invoked when the user asks to write a Dockerfile, improve container image quality, or harden image builds.
+version: 1.1.0
 tags:
   - devops
   - docker
@@ -22,6 +21,9 @@ vendor_support:
 ## Write Dockerfile Skill
 
 Create a production-ready Dockerfile for the current project.
+Scope boundary: Dockerfile and image concerns only. For local multi-service orchestration
+(`compose.yaml`, service dependencies/readiness, env files, volumes, migrations/seeds),
+use `docker-compose-local-setup`.
 
 ### Step 1 — Detect Language and Framework
 
@@ -31,7 +33,7 @@ Identify:
 - Build process (compile, bundle, install dependencies)
 - Entry point / start command
 
-### Step 2 — Apply Dockerfile Best Practices
+### Step 2 — Apply Dockerfile Build and Runtime Best Practices
 
 **Multi-stage build**: separate build stage from runtime stage to keep the final image small.
 
@@ -42,7 +44,7 @@ dependency install layer and only invalidates it when dependencies change.
 
 **Minimal base image**: use official slim/alpine variants for the runtime stage.
 
-**Health check**: include a HEALTHCHECK instruction.
+**Health check**: include a `HEALTHCHECK` instruction when the runtime supports it.
 
 **No secrets in the image**: all secrets come from environment variables at runtime.
 
@@ -74,7 +76,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
 CMD ["{start-command}"]
 ```
 
-### Step 4 — Write .dockerignore
+### Step 4 — Write `.dockerignore`
 
 Also create or update `.dockerignore` to exclude:
 - `.git/`
@@ -85,4 +87,10 @@ Also create or update `.dockerignore` to exclude:
 
 ### Step 5 — Verify
 
-State the final image size estimate and any security considerations specific to this project.
+Verify:
+- image builds successfully with `docker build`
+- runtime starts with expected command/entrypoint
+- image runs as non-root where applicable
+- no secrets are baked into the image layers
+
+State final image size considerations and production hardening notes specific to this project.

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2407,6 +2407,102 @@ assert_file_not_contains "$TMP/t109/backend/AGENTS.md" ".agentic/fragments/next.
 assert_file_contains "$TMP/t109/ui/AGENTS.md" ".agentic/fragments/next.md" "T109"
 assert_file_not_contains "$TMP/t109/ui/AGENTS.md" ".agentic/fragments/hexagonal.md" "T109"
 
+# T110 — deploy-skills: all-skills deployment includes docker-compose-local-setup
+run_test "T110 — deploy-skills: all-skills includes docker-compose-local-setup"
+mkdir -p "$TMP/t110"
+bash "$DEPLOY_SKILLS" \
+  --library "$LIBRARY" \
+  --target "$TMP/t110" \
+  --skills all \
+  > /dev/null 2>&1
+
+assert_file_exists "$TMP/t110/.agentic/skills/docker-compose-local-setup/SKILL.md" "T110"
+
+# T111 — index: skills index includes docker-compose-local-setup
+run_test "T111 — index: includes docker-compose-local-setup"
+bash "$INDEX" \
+  --library "$LIBRARY" \
+  > /dev/null 2>&1
+
+assert_file_contains "$LIBRARY/index/skills.json" "\"name\": \"docker-compose-local-setup\"" "T111"
+
+# T112 — compose: lean profile includes both docker skills
+run_test "T112 — compose: lean go-hexagonal-microservice includes docker skills"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile go-hexagonal-microservice \
+  --target "$TMP/t112" \
+  > /dev/null 2>&1
+
+assert_file_contains "$TMP/t112/AGENTS.md" "docker-compose-local-setup" "T112"
+assert_file_contains "$TMP/t112/AGENTS.md" "write-dockerfile" "T112"
+
+# T113 — compose: full mode includes docker-compose-local-setup content
+run_test "T113 — compose: full mode inlines docker-compose-local-setup content"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile go-hexagonal-microservice \
+  --target "$TMP/t113" \
+  --full \
+  > /dev/null 2>&1
+
+assert_file_contains "$TMP/t113/AGENTS.md" "## Docker Compose Local Setup Skill" "T113"
+
+# T114 — deploy-skills: README includes docker-compose-local-setup
+run_test "T114 — deploy-skills: README includes docker-compose-local-setup"
+mkdir -p "$TMP/t114"
+bash "$DEPLOY_SKILLS" \
+  --library "$LIBRARY" \
+  --target "$TMP/t114" \
+  --skills all \
+  > /dev/null 2>&1
+
+assert_file_exists "$TMP/t114/.agentic/skills/README.md" "T114"
+assert_file_contains "$TMP/t114/.agentic/skills/README.md" "docker-compose-local-setup" "T114"
+
+# T115 — compose: typescript-bff skills block regression
+run_test "T115 — compose: typescript-bff renders docker skills block"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-bff \
+  --target "$TMP/t115" \
+  > /dev/null 2>&1
+
+assert_file_contains "$TMP/t115/AGENTS.md" "## Skills" "T115"
+assert_file_contains "$TMP/t115/AGENTS.md" "docker-compose-local-setup" "T115"
+assert_file_contains "$TMP/t115/AGENTS.md" "write-dockerfile" "T115"
+
+# T116 — profiles: targeted service profiles must reference both docker skills
+run_test "T116 — profiles: targeted service profiles include both docker skills"
+T116_EXIT=0
+for profile in \
+  go-hexagonal-microservice \
+  typescript-hexagonal-microservice \
+  python-fastapi-microservice \
+  php-hexagonal-ddd \
+  typescript-bff \
+  golang-hexagonal-vue-vite-ui \
+  golang-hexagonal-nuxt-vite-ui \
+  typescript-hexagonal-vue-vite-ui \
+  typescript-hexagonal-nuxt-vite-ui; do
+  profile_file="$LIBRARY/profiles/$profile.yaml"
+  skills_list="$(yq '.skills[]' "$profile_file" 2>/dev/null || true)"
+  if grep -qFx "docker-compose-local-setup" <<< "$skills_list"; then
+    :
+  else
+    T116_EXIT=1
+    break
+  fi
+  if grep -qFx "write-dockerfile" <<< "$skills_list"; then
+    :
+  else
+    T116_EXIT=1
+    break
+  fi
+done
+
+assert_exit_code 0 "$T116_EXIT" "T116"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "────────────────────────────────────────"


### PR DESCRIPTION
## Summary
- add a new `docker-compose-local-setup` devops skill for local multi-service orchestration
- keep `write-dockerfile` focused on image/Dockerfile concerns and explicitly route compose orchestration to the new skill
- enable both Docker skills in service-oriented profiles (including `typescript-bff`, which now has a `skills:` block)
- extend tests and docs/index coverage for the new skill

## Changes
- Added:
  - `skills/devops/docker-compose-local-setup/SKILL.md`
  - `skills/devops/docker-compose-local-setup/compose-patterns-reference.md`
- Updated:
  - `skills/devops/write-dockerfile/SKILL.md`
  - `profiles/go-hexagonal-microservice.yaml`
  - `profiles/typescript-hexagonal-microservice.yaml`
  - `profiles/python-fastapi-microservice.yaml`
  - `profiles/php-hexagonal-ddd.yaml`
  - `profiles/typescript-bff.yaml`
  - `profiles/golang-hexagonal-vue-vite-ui.yaml`
  - `profiles/golang-hexagonal-nuxt-vite-ui.yaml`
  - `profiles/typescript-hexagonal-vue-vite-ui.yaml`
  - `profiles/typescript-hexagonal-nuxt-vite-ui.yaml`
  - `docs/skills.md`
  - `index/skills.json`
  - `tooling/lib/test.sh`

## Validation
- `just index` passed
- `just lint` passed
- `just test` passed (`388/388`)

## Scope notes
- Stayed local-dev focused (`docker compose` orchestration, health/readiness, env files, volumes, migrations/seeds).
- No LocalStack/Terraform deep workflows added.
- Added test guard coverage for changed profile skill references via compose assertions.

Closes #91
