### PR TITLE
feat(skills): add diagram-design skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -64,6 +64,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 - `vue-component-design` — Design robust Vue component APIs with clear contracts.
 - `vue-component-testing` — Apply layered Vue testing strategy for logic, components, and flows.
 - `wireframe-prototyping` — Produce low-fidelity wireframes with interaction and acceptance notes.
+- `diagram-design` — Design implementation-grounded diagrams and flag ADR/RFC/code mismatches.
 
 ## Using a skill outside a profile
 

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-28T22:41:42Z",
+  "generated_at": "2026-04-29T20:34:29Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -421,6 +421,19 @@
       "tags": [
         "documentation",
         "readme"
+      ]
+    },
+    {
+      "name": "diagram-design",
+      "group": "ui",
+      "path": "skills/ui/diagram-design/SKILL.md",
+      "description": "Designs implementation-grounded architecture, sequence, and flow diagrams from existing code and documentation. Ensures ",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "architecture",
+        "diagram",
+        "design"
       ]
     },
     {

--- a/profiles/typescript-hexagonal-next-ui.yaml
+++ b/profiles/typescript-hexagonal-next-ui.yaml
@@ -93,6 +93,7 @@ skills:
   - react-component-testing
   - internationalization-i18n
   - wireframe-prototyping
+  - diagram-design
   - static-code-analysis
   - pull-request-automation
   - github-actions-workflow

--- a/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
@@ -96,6 +96,7 @@ skills:
   - vue-component-testing
   - internationalization-i18n
   - wireframe-prototyping
+  - diagram-design
   - static-code-analysis
   - pull-request-automation
   - github-actions-workflow

--- a/profiles/typescript-hexagonal-react-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-react-vite-ui.yaml
@@ -80,6 +80,7 @@ skills:
   - react-component-testing
   - internationalization-i18n
   - wireframe-prototyping
+  - diagram-design
   - static-code-analysis
   - pull-request-automation
   - github-actions-workflow

--- a/profiles/typescript-hexagonal-vue-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-vue-vite-ui.yaml
@@ -83,6 +83,7 @@ skills:
   - vue-component-testing
   - internationalization-i18n
   - wireframe-prototyping
+  - diagram-design
   - static-code-analysis
   - pull-request-automation
   - github-actions-workflow

--- a/profiles/typescript-next-app.yaml
+++ b/profiles/typescript-next-app.yaml
@@ -51,6 +51,7 @@ skills:
   - react-component-design
   - react-component-testing
   - wireframe-prototyping
+  - diagram-design
   - internationalization-i18n
   - static-code-analysis
   - write-readme

--- a/profiles/typescript-nuxt-app.yaml
+++ b/profiles/typescript-nuxt-app.yaml
@@ -54,6 +54,7 @@ skills:
   - vue-component-design
   - vue-component-testing
   - wireframe-prototyping
+  - diagram-design
   - internationalization-i18n
   - static-code-analysis
   - write-readme

--- a/profiles/typescript-react-spa.yaml
+++ b/profiles/typescript-react-spa.yaml
@@ -48,6 +48,7 @@ skills:
   - react-component-design
   - react-component-testing
   - wireframe-prototyping
+  - diagram-design
   - internationalization-i18n
   - static-code-analysis
   - write-readme

--- a/profiles/typescript-vue-spa.yaml
+++ b/profiles/typescript-vue-spa.yaml
@@ -49,6 +49,7 @@ skills:
   - vue-component-design
   - vue-component-testing
   - wireframe-prototyping
+  - diagram-design
   - internationalization-i18n
   - static-code-analysis
   - write-readme

--- a/skills/ui/diagram-design/SKILL.md
+++ b/skills/ui/diagram-design/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: diagram-design
+description: >
+  Designs implementation-grounded architecture, sequence, and flow diagrams from
+  existing code and documentation. Ensures notation is chosen intentionally,
+  avoids invented components or flows, and explicitly flags mismatches across
+  ADRs, RFCs, and code.
+version: 1.0.0
+tags:
+  - ui
+  - architecture
+  - diagram
+  - design
+resources: []
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Diagram Design Skill
+
+### Step 1 — Inspect Source of Truth
+
+Inspect implementation artifacts before drawing:
+- Code structure and runtime boundaries (modules, routes, services, adapters).
+- Existing docs (`README`, ADRs, RFCs, architecture docs, API contracts).
+- Current terminology used by the codebase and product language.
+
+Capture what is explicitly evidenced. If evidence is missing, mark it as unknown.
+
+### Step 2 — Define Diagram Objective
+
+State the single primary question the diagram must answer, such as:
+- "How data moves from UI action to persistence."
+- "Which components own state vs orchestration."
+- "Where sync vs async boundaries are enforced."
+
+Limit scope to one context per diagram to keep it reviewable.
+
+### Step 3 — Choose Notation Intentionally
+
+Select notation based on the objective:
+- C4/container or component view for structural ownership and dependencies.
+- Sequence diagram for request/response timing and actor interactions.
+- Flow/state diagram for decision branches, retries, and error handling.
+
+Document why this notation was chosen and why alternatives were not.
+
+### Step 4 — Map Only Verified Components and Flows
+
+Build the diagram strictly from verified artifacts:
+- Use real component/service/module names from code/docs.
+- Include only flows that can be traced to handlers, functions, contracts, or tests.
+- Mark uncertain links as `Unknown` or `TBD (needs evidence)` instead of inventing paths.
+
+Do not add speculative systems, side effects, queues, or external actors without evidence.
+
+### Step 5 — Cross-Check ADR/RFC/Code Consistency
+
+Validate consistency across design intent and implementation:
+- ADR says X, code does Y.
+- RFC flow omits a runtime guard present in code.
+- Code introduces dependency or sync call not reflected in docs.
+
+List mismatches explicitly with:
+- Source reference (ADR/RFC filename or code path).
+- Observed conflict.
+- Impact (correctness, performance, operability, ownership).
+
+### Step 6 — Deliver Diagram + Review Notes
+
+Provide:
+- The diagram artifact (Mermaid/PlantUML/ASCII/Figma structure as requested).
+- A short legend for symbols and boundaries.
+- Assumptions and unknowns.
+- Mismatch log with recommended follow-up actions (doc update, ADR amendment, refactor).

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2503,6 +2503,62 @@ done
 
 assert_exit_code 0 "$T116_EXIT" "T116"
 
+# T117 — index: skills index includes diagram-design
+run_test "T117 — index: includes diagram-design"
+bash "$INDEX" \
+  --library "$LIBRARY" \
+  > /dev/null 2>&1
+
+assert_file_contains "$LIBRARY/index/skills.json" "\"name\": \"diagram-design\"" "T117"
+
+# T118 — profile rollout: all targeted TypeScript UI profiles include diagram-design
+run_test "T118 — profile rollout: target profiles include diagram-design"
+T118_EXIT=0
+for profile in \
+  typescript-react-spa \
+  typescript-next-app \
+  typescript-vue-spa \
+  typescript-nuxt-app \
+  typescript-hexagonal-react-vite-ui \
+  typescript-hexagonal-next-ui \
+  typescript-hexagonal-vue-vite-ui \
+  typescript-hexagonal-nuxt-vite-ui; do
+  profile_file="$LIBRARY/profiles/$profile.yaml"
+  skills_list="$(yq '.skills[]' "$profile_file" 2>/dev/null || true)"
+  if grep -qFx "diagram-design" <<< "$skills_list"; then
+    :
+  else
+    T118_EXIT=1
+    break
+  fi
+done
+
+assert_exit_code 0 "$T118_EXIT" "T118"
+
+# T119 — compose: full mode includes diagram-design skill content
+run_test "T119 — compose: full mode inlines diagram-design content"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-react-spa \
+  --target "$TMP/t119" \
+  --full \
+  > /dev/null 2>&1
+
+assert_file_contains "$TMP/t119/AGENTS.md" "## Diagram Design Skill" "T119"
+
+# T120 — deploy-skills: README includes diagram-design
+run_test "T120 — deploy-skills: README includes diagram-design"
+mkdir -p "$TMP/t120"
+bash "$DEPLOY_SKILLS" \
+  --library "$LIBRARY" \
+  --target "$TMP/t120" \
+  --skills all \
+  > /dev/null 2>&1
+
+assert_file_exists "$TMP/t120/.agentic/skills/diagram-design/SKILL.md" "T120"
+assert_file_exists "$TMP/t120/.agentic/skills/README.md" "T120"
+assert_file_contains "$TMP/t120/.agentic/skills/README.md" "diagram-design" "T120"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "────────────────────────────────────────"


### PR DESCRIPTION
## Summary
- add new `diagram-design` UI skill for implementation-grounded architecture and flow diagram authoring
- roll out `diagram-design` to the agreed TypeScript UI profile set
- update skills docs/index and add focused regression coverage

## Added
- `skills/ui/diagram-design/SKILL.md`

## Updated
- Profiles:
  - `profiles/typescript-react-spa.yaml`
  - `profiles/typescript-next-app.yaml`
  - `profiles/typescript-vue-spa.yaml`
  - `profiles/typescript-nuxt-app.yaml`
  - `profiles/typescript-hexagonal-react-vite-ui.yaml`
  - `profiles/typescript-hexagonal-next-ui.yaml`
  - `profiles/typescript-hexagonal-vue-vite-ui.yaml`
  - `profiles/typescript-hexagonal-nuxt-vite-ui.yaml`
- Docs/index:
  - `docs/skills.md`
  - `index/skills.json`
- Tests:
  - `tooling/lib/test.sh` (`T117`-`T120` for index/rollout/full-compose/deploy-readme+skill presence)

## Validation
- `just index` passed
- `just lint` passed
- `just test` passed

## Notes
- Kept scope content-focused (no tooling behavior changes).
- No new fragment added; skill-only implementation with explicit evidence-first diagram rules.

Closes #87
