### PR TITLE
fix(typescript): enforce alias imports and esm guidance

### DIFF
--- a/agents/frameworks/react-testing.md
+++ b/agents/frameworks/react-testing.md
@@ -26,7 +26,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect } from 'vitest'
-import { SearchForm } from './SearchForm'
+import { SearchForm } from '<alias>/components/SearchForm'
 
 it('submits query from form', async () => {
   const user = userEvent.setup()

--- a/agents/frameworks/vue-component-design.md
+++ b/agents/frameworks/vue-component-design.md
@@ -31,7 +31,7 @@ const modelValue = defineModel<string>({ default: '' })
 
 ### Compound Components with `provide`/`inject`
 
-Export injection keys as typed Symbols from a dedicated `keys.ts` file. This prevents typos and gives TypeScript accurate type inference.
+Export injection keys as typed Symbols from a dedicated `keys.ts` file. This prevents typos and gives TypeScript accurate type inference. Same-folder relative imports like `./keys.ts` are acceptable; use aliases for cross-directory imports.
 
 ```ts
 // keys.ts

--- a/agents/frameworks/vue-testing.md
+++ b/agents/frameworks/vue-testing.md
@@ -15,7 +15,7 @@ Import the composable and call it directly — no component wrapper needed for p
 ```ts
 import { setActivePinia, createPinia } from 'pinia'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { useCounter } from './useCounter'
+import { useCounter } from '<alias>/composables/useCounter'
 
 beforeEach(() => { setActivePinia(createPinia()) })
 
@@ -38,7 +38,7 @@ Use `setActivePinia(createPinia())` in `beforeEach` — always reset between tes
 ```ts
 import { setActivePinia, createPinia } from 'pinestest'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { useCartStore } from './cart.store'
+import { useCartStore } from '<alias>/stores/cart.store'
 
 let store: ReturnType<typeof useCartStore>
 
@@ -68,10 +68,10 @@ Mount the real component (not shallow) unless the child is a heavy external libr
 import { render, screen, fireEvent } from '@testing-library/vue'
 import { createTestingPinia } from '@pinia/testing'
 import { describe, it, expect, vi } from 'vitest'
-import BaseButton from './BaseButton.vue'
+import BaseButton from '<alias>/components/BaseButton.vue'
 
 const mockTrack = vi.fn()
-vi.mock('./analytics', () => ({ track: mockTrack }))
+vi.mock('<alias>/lib/analytics', () => ({ track: mockTrack }))
 
 it('emits click and tracks analytics', async () => {
   render(BaseButton, {

--- a/agents/languages/typescript.md
+++ b/agents/languages/typescript.md
@@ -42,11 +42,14 @@ Always enable strict mode in `tsconfig.json`:
 
 ### Module System
 
+- Use ES module syntax everywhere in TS/JS (`import` / `export` only).
+- Never introduce CommonJS syntax (`require`, `module.exports`, `exports.foo`) in TS/JS code.
 - Use ESModules (`"module": "ESNext"` or `"NodeNext"`). Avoid CommonJS for new code.
 - Avoid barrel files (`index.ts` re-exporting everything). They hurt tree-shaking and create
   circular dependency risks.
-- Use absolute imports configured via `paths` in tsconfig; avoid deeply nested relative imports
-  (`../../..`).
+- Use absolute alias imports configured via `paths` in tsconfig for cross-directory references.
+- Relative imports are only allowed for files in the same folder (`./foo`); avoid parent traversal
+  (`../`, `../../..`) and other cross-directory relative imports.
 
 ### Error Handling
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -2,8 +2,6 @@
 
 A profile is a named YAML preset that selects which fragments, tech stack details, and skills to include. Pick one, run `agentic deploy`, done.
 
-TypeScript profiles enforce alias imports for cross-directory modules and ESM `import`/`export` syntax in TS/JS code.
-
 ## Available Profiles
 
 | Profile | What it's for | Language(s) |

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -2,6 +2,8 @@
 
 A profile is a named YAML preset that selects which fragments, tech stack details, and skills to include. Pick one, run `agentic deploy`, done.
 
+TypeScript profiles enforce alias imports for cross-directory modules and ESM `import`/`export` syntax in TS/JS code.
+
 ## Available Profiles
 
 | Profile | What it's for | Language(s) |

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-28T20:18:29Z",
+  "generated_at": "2026-04-29T21:00:58Z",
   "fragments": [
     {
       "name": "bff",
@@ -161,7 +161,7 @@
       "group": "frameworks",
       "path": "agents/frameworks/vue-component-design.md",
       "heading": "Vue 3 Component Design",
-      "words": 591
+      "words": 603
     },
     {
       "name": "vue-styling",
@@ -210,7 +210,7 @@
       "group": "languages",
       "path": "agents/languages/typescript.md",
       "heading": "TypeScript",
-      "words": 353
+      "words": 397
     },
     {
       "name": "api-design",

--- a/profiles/golang-hexagonal-next-ui.yaml
+++ b/profiles/golang-hexagonal-next-ui.yaml
@@ -91,6 +91,7 @@ output:
     Full-stack project: Go hexagonal backend + Next.js frontend.
     Backend domain package must have zero external dependencies.
     Frontend uses strict TypeScript with functional components and hooks.
+    Frontend TS convention: alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/golang-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/golang-hexagonal-nuxt-vite-ui.yaml
@@ -94,6 +94,7 @@ output:
     Full-stack project: Go hexagonal backend + Nuxt 3 frontend.
     Backend domain package must have zero external dependencies.
     Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    Frontend TS convention: alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/golang-hexagonal-react-vite-ui.yaml
+++ b/profiles/golang-hexagonal-react-vite-ui.yaml
@@ -95,6 +95,7 @@ output:
     Full-stack project: Go hexagonal backend + React SPA frontend (no SSR).
     Backend domain package must have zero external dependencies.
     Frontend uses strict TypeScript with functional components and hooks.
+    Frontend TS convention: alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/golang-hexagonal-vue-vite-ui.yaml
+++ b/profiles/golang-hexagonal-vue-vite-ui.yaml
@@ -98,6 +98,7 @@ output:
     Full-stack project: Go hexagonal backend + Vue 3 SPA frontend (no SSR).
     Backend domain package must have zero external dependencies.
     Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    Frontend TS convention: alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/typescript-bff.yaml
+++ b/profiles/typescript-bff.yaml
@@ -40,6 +40,7 @@ output:
   lint_command: "pnpm lint"
   project_header: |
     This is a TypeScript BFF (Backend for Frontend).
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     It aggregates data from downstream microservices and shapes it for a specific client.
     No business logic here — only aggregation, transformation, and caching.
     No database writes — state changes are delegated to downstream services.

--- a/profiles/typescript-hexagonal-microservice.yaml
+++ b/profiles/typescript-hexagonal-microservice.yaml
@@ -44,6 +44,7 @@ output:
   lint_command: "pnpm lint"
   project_header: |
     This is a TypeScript microservice built with hexagonal architecture and DDD.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     The domain layer must remain free of framework dependencies.
     All external dependencies (HTTP, database, messaging) are adapters behind ports.
 

--- a/profiles/typescript-hexagonal-next-ui.yaml
+++ b/profiles/typescript-hexagonal-next-ui.yaml
@@ -107,6 +107,7 @@ output:
     Full-stack TypeScript project: Hono hexagonal backend + Next.js frontend.
     Backend domain layer must have zero framework dependencies.
     Frontend uses strict TypeScript with functional components and hooks.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
@@ -110,6 +110,7 @@ output:
     Full-stack TypeScript project: Hono hexagonal backend + Nuxt 3 frontend.
     Backend domain layer must have zero framework dependencies.
     Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/typescript-hexagonal-react-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-react-vite-ui.yaml
@@ -94,6 +94,7 @@ output:
     Full-stack TypeScript project: Hono hexagonal backend + React SPA frontend (no SSR).
     Backend domain layer must have zero framework dependencies.
     Frontend uses strict TypeScript with functional components and hooks.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/typescript-hexagonal-vue-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-vue-vite-ui.yaml
@@ -97,6 +97,7 @@ output:
     Full-stack TypeScript project: Hono hexagonal backend + Vue 3 SPA frontend (no SSR).
     Backend domain layer must have zero framework dependencies.
     Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 
 vendors:

--- a/profiles/typescript-library.yaml
+++ b/profiles/typescript-library.yaml
@@ -45,6 +45,7 @@ output:
   project_header: |
     This is a TypeScript reusable library. The public API (everything exported
     from the package entry points declared in package.json#exports) is a contract.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     Breaking changes require a major semver bump.
     Target ESM-first. Do not introduce runtime framework dependencies —
     the consumer chooses the framework.

--- a/profiles/typescript-next-app.yaml
+++ b/profiles/typescript-next-app.yaml
@@ -64,6 +64,7 @@ output:
   project_header: |
     Standalone Next.js application with SSR via App Router.
     Components and hooks use TypeScript strictly, with functional components only.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     Server/client boundaries must be explicit and intentional.
     Styling via Tailwind CSS v4; shadcn/ui for UI primitives.
     API endpoints via route handlers. SSR safety rules apply everywhere.

--- a/profiles/typescript-nuxt-app.yaml
+++ b/profiles/typescript-nuxt-app.yaml
@@ -67,6 +67,7 @@ output:
   project_header: |
     Standalone Nuxt 3 application with SSR.
     All components use <script setup lang="ts"> exclusively — no Options API.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     State management via Pinia setup stores. File-based routing via Nuxt.
     Styling via Tailwind CSS v4; shadcn/vue for UI primitives.
     Server routes under server/api/ via Nitro. SSR safety rules apply everywhere.

--- a/profiles/typescript-react-spa.yaml
+++ b/profiles/typescript-react-spa.yaml
@@ -60,6 +60,7 @@ output:
   project_header: |
     Standalone React SPA — no server-side rendering.
     Components and hooks use TypeScript strictly, with functional components only.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     Routing via React Router with explicit route ownership and boundaries.
     Styling via Tailwind CSS v4 utility classes; shadcn/ui for UI primitives.
     Three-tier testing: Vitest unit tests for hooks/utils, @testing-library/react

--- a/profiles/typescript-vue-spa.yaml
+++ b/profiles/typescript-vue-spa.yaml
@@ -61,6 +61,7 @@ output:
   project_header: |
     Standalone Vue 3 SPA — no server-side rendering.
     All components use <script setup lang="ts"> exclusively — no Options API.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
     State management via Pinia setup stores. Routing via Vue Router 4 with typed routes.
     Styling via Tailwind CSS v4 utility classes; shadcn/vue for UI primitives.
     Three-tier testing: Vitest unit tests for composables/stores, @testing-library/vue

--- a/skills/development/static-code-analysis/SKILL.md
+++ b/skills/development/static-code-analysis/SKILL.md
@@ -25,7 +25,7 @@ vendor_support:
 
 | Language | Recommended tool | Config file |
 |----------|-----------------|-------------|
-| TypeScript / JavaScript | ESLint + typescript-eslint | `eslint.config.ts` |
+| TypeScript / JavaScript | ESLint + typescript-eslint (+ eslint-plugin-import if using `import/*` rules) | `eslint.config.ts` |
 | Go | golangci-lint | `.golangci.yml` |
 | Python | Ruff | `ruff.toml` or `pyproject.toml` |
 | PHP | PHPStan | `phpstan.neon` |
@@ -35,7 +35,8 @@ If a tool is already present, audit its configuration before making changes.
 
 ### Step 2 — Configure Rules
 
-Apply a strict baseline:
+Apply a strict baseline.
+If you use `import/*` rules, ensure `eslint-plugin-import` is installed and configured.
 
 **TypeScript (ESLint)**
 ```json
@@ -43,6 +44,7 @@ Apply a strict baseline:
   "rules": {
     "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-unused-vars": "error",
+    "import/no-commonjs": "error",
     "no-console": "warn",
     "eqeqeq": ["error", "always"]
   }

--- a/skills/ui/next-application-structure/SKILL.md
+++ b/skills/ui/next-application-structure/SKILL.md
@@ -61,6 +61,7 @@ src/
 - Keep data fetching and secrets in server modules/route handlers.
 - Pass serialized data to client components via props.
 - Avoid importing server-only modules into client components.
+- Use alias imports for cross-directory modules and ESM `import`/`export` syntax only.
 
 ### Step 3 — Data Fetching and Mutations
 

--- a/skills/ui/react-application-structure/SKILL.md
+++ b/skills/ui/react-application-structure/SKILL.md
@@ -64,6 +64,7 @@ src/
 - Keep components thin; move reusable logic to custom hooks.
 - Name hooks with the `use` prefix and keep single responsibility.
 - Keep side effects in hooks/components where they are consumed; avoid hidden global effects.
+- Use alias imports for cross-directory modules and ESM `import`/`export` syntax only.
 
 ```tsx
 interface Props {

--- a/skills/ui/react-component-testing/SKILL.md
+++ b/skills/ui/react-component-testing/SKILL.md
@@ -53,6 +53,7 @@ it('sets user on login success', () => {
 - Use `userEvent` for interactions, not low-level DOM event simulation unless necessary.
 - Wrap with providers used in production (router, query client, store) via a shared test render utility.
 - Assert user-visible output and callback side effects.
+- In TypeScript projects, keep TS/JS imports ESM-only and use aliases for cross-directory imports.
 
 ```tsx
 import { render, screen } from '@testing-library/react'

--- a/skills/ui/vue-application-structure/SKILL.md
+++ b/skills/ui/vue-application-structure/SKILL.md
@@ -56,6 +56,7 @@ src/
 - Use `<script setup lang="ts">` exclusively — no Options API, no `defineComponent`.
 - Declare `defineProps` and `defineEmits` with TypeScript interfaces, not runtime validators.
 - Keep template logic minimal — extract complex expressions into `computed` refs or composables.
+- Use alias imports for cross-directory modules and ESM `import`/`export` syntax only.
 
 ```vue
 <script setup lang="ts">

--- a/skills/ui/vue-component-testing/SKILL.md
+++ b/skills/ui/vue-component-testing/SKILL.md
@@ -61,15 +61,16 @@ it('login sets user', async () => {
 - Mount the real component (not shallow) unless the child is a heavy external library.
 - Assert: what the user sees (text, roles, visibility), which events are emitted, which store actions are called.
 - Do NOT assert: internal refs, CSS classes, snapshot blobs.
+- In TypeScript projects, keep TS/JS imports ESM-only and use aliases for cross-directory imports.
 
 ```ts
 import { render, screen, fireEvent } from '@testing-library/vue'
 import { createTestingPinia } from '@pinia/testing'
 import { describe, expect, it, vi } from 'vitest'
-import BaseButton from './BaseButton.vue'
+import BaseButton from '<alias>/components/BaseButton.vue'
 
 const mockTrack = vi.fn()
-vi.mock('./analytics', () => ({ trackEvent: mockTrack }))
+vi.mock('<alias>/lib/analytics', () => ({ trackEvent: mockTrack }))
 
 it('tracks click event on button press', async () => {
   render(BaseButton, {


### PR DESCRIPTION
## Summary
- enforce TypeScript/JavaScript guidance to prefer alias imports for cross-directory references
- enforce ESM import/export syntax and explicitly disallow CommonJS patterns in TS/JS guidance
- propagate the convention across impacted framework fragments, TS-oriented skills, and profile summaries

## Changes
- Core guidance:
  - `agents/languages/typescript.md`
- Framework fragments:
  - `agents/frameworks/react-testing.md`
  - `agents/frameworks/vue-testing.md`
  - `agents/frameworks/vue-component-design.md`
- Profiles (TS and Go+TS summaries updated for convention clarity):
  - `profiles/typescript-*.yaml` and relevant `profiles/golang-hexagonal-*-ui.yaml`
- Skills:
  - `skills/ui/react-component-testing/SKILL.md`
  - `skills/ui/vue-component-testing/SKILL.md`
  - `skills/ui/react-application-structure/SKILL.md`
  - `skills/ui/vue-application-structure/SKILL.md`
  - `skills/ui/next-application-structure/SKILL.md`
  - `skills/development/static-code-analysis/SKILL.md`
- Docs/index:
  - `docs/profiles.md`
  - `index/fragments.json`

## Policy Clarification
- Cross-directory TS/JS imports should use configured aliases.
- Same-folder relative imports (`./...`) remain allowed.
- TS/JS guidance is ESM-first: `import`/`export`; avoid `require`/`module.exports`.

## Validation
- `just index` passed
- `just lint` passed

Closes #113
