### PR TITLE
feat(skills): add github issue planning workflow skill

### DIFF
--- a/bin/agentic
+++ b/bin/agentic
@@ -27,7 +27,7 @@ if [[ ! -f "$CLI_LIB" ]]; then
   exit 1
 fi
 
-# shellcheck source=../tooling/lib/cli.sh
+# shellcheck source=tooling/lib/cli.sh
 source "$CLI_LIB"
 
 # Run the CLI

--- a/bin/agentic
+++ b/bin/agentic
@@ -27,6 +27,7 @@ if [[ ! -f "$CLI_LIB" ]]; then
   exit 1
 fi
 
+# shellcheck source=../tooling/lib/cli.sh
 source "$CLI_LIB"
 
 # Run the CLI

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -57,6 +57,25 @@ servers:
 If `.agentic/mcp.yaml` is missing, legacy `mcp:` under `.agentic/profile.yaml`
 is still supported for backward compatibility, but deprecated.
 
+### Local vs Issue-Backed Planning
+
+Plan persistence supports two modes:
+
+- Local-file mode: `write-plan` / `persist-plan` store plans in `.agentic/plans/`.
+- Issue-backed mode: `github-issue-planning` stores and updates a managed comment on a GitHub issue.
+
+For issue-backed planning, use this decision order:
+
+1. GitHub MCP (preferred) when available/configured.
+2. `gh` CLI fallback when MCP is unavailable or misconfigured.
+3. Local-file fallback only when GitHub persistence is unavailable (or not desired).
+
+Prerequisites for issue-backed mode:
+
+- Issue URL or issue number with repository context.
+- MCP configured with GitHub access, or authenticated `gh` (`gh auth status`).
+- Permissions to read/write issue comments in the target repository.
+
 ## Project-Local Skills
 
 For skills specific to a single project that shouldn't live in the shared library,

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -7,6 +7,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 - `compose-agents-md` — Create project-specific `AGENTS.md` instructions from the agentic library.
 - `configure-mcp` — Set up and configure MCP servers for agent tool access.
 - `deploy-config` — Deploy composed config, vendor files, and skills to a target project.
+- `github-issue-planning` — Persist implementation plans on GitHub issues with MCP-first and `gh` fallback.
 - `persist-plan` — Save the current plan as a structured file under `.agentic/plans/`.
 - `write-plan` — Auto-persist generated plans and keep a local plans index updated.
 

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-29T20:34:29Z",
+  "generated_at": "2026-04-29T21:45:39Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -36,6 +36,19 @@
         "agentic",
         "meta",
         "deployment"
+      ]
+    },
+    {
+      "name": "github-issue-planning",
+      "group": "agentic",
+      "path": "skills/agentic/github-issue-planning/SKILL.md",
+      "description": "Builds and persists implementation plans directly on a GitHub issue comment with an idempotent managed marker. Prefers G",
+      "version": "1.0.0",
+      "tags": [
+        "agentic",
+        "planning",
+        "github",
+        "issues"
       ]
     },
     {

--- a/skills/agentic/configure-mcp/SKILL.md
+++ b/skills/agentic/configure-mcp/SKILL.md
@@ -22,6 +22,8 @@ vendor_support:
 ## Configure MCP Skill
 
 Guide the user through selecting and configuring an MCP server for their project.
+For GitHub issue planning workflows, MCP is the preferred persistence path; if MCP
+is unavailable or misconfigured, use `gh` CLI as the primary fallback.
 
 ### Step 1 — Understand the Stack
 

--- a/skills/agentic/github-issue-planning/SKILL.md
+++ b/skills/agentic/github-issue-planning/SKILL.md
@@ -98,15 +98,6 @@ gh api repos/{owner}/{repo}/issues/comments/$COMMENT_ID \
   or explicitly not desired by the user.
 - Report that the plan was saved locally and not persisted to the issue.
 
-### Agent Orchestration Rules
-
-- Wait for delegated agents to complete before advancing to dependent steps.
-  - Do not continue to commit/push/PR steps while required reviewer/worker tasks are still running.
-  - If an agent is still running, keep polling until completion or explicit timeout/escalation.
-- If work is parallelizable, spawn more than one agent.
-  - Use multiple agents only for independent subtasks with non-overlapping outputs.
-  - Avoid parallelizing tightly coupled or blocking subtasks where sequencing is required.
-
 ### Output Requirements
 
 Always report:

--- a/skills/agentic/github-issue-planning/SKILL.md
+++ b/skills/agentic/github-issue-planning/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: github-issue-planning
+description: >
+  Builds and persists implementation plans directly on a GitHub issue comment
+  with an idempotent managed marker. Prefers GitHub MCP when available and
+  falls back to gh CLI for persistence when MCP is unavailable or misconfigured.
+  Uses local plan persistence only when issue persistence is unavailable or not
+  desired.
+version: 1.0.0
+tags:
+  - agentic
+  - planning
+  - github
+  - issues
+resources:
+  - issue-comment-template.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## GitHub Issue Planning Skill
+
+Use this skill when planning work tied to a GitHub issue and the plan should be
+persisted on that issue for team visibility.
+
+### Required Input
+
+Do not proceed without one of:
+- Full issue URL (`https://github.com/{owner}/{repo}/issues/{number}`), or
+- Owner/repo plus issue number (`{owner}/{repo}#{number}`)
+
+If neither is available, ask for it first.
+
+### Persistence Contract (Managed Comment)
+
+Persist the plan in one managed issue comment with a stable marker:
+
+```html
+<!-- agentic:github-issue-plan -->
+```
+
+Rules:
+- Exactly one managed comment per issue per planning thread.
+- Update that managed comment in place on subsequent runs (idempotent).
+- Keep the marker at the top of the comment body so it is discoverable.
+- Use `issue-comment-template.md` as the body scaffold.
+
+### Decision Tree
+
+1. MCP path (preferred):
+- If GitHub MCP is available and configured, use MCP issue/comment tools to find
+  existing comments containing `<!-- agentic:github-issue-plan -->` and update.
+- Enforce deterministic managed-comment handling:
+  - 0 matching comments: create one managed comment with marker + plan body.
+  - 1 matching comment: update that exact managed comment.
+  - More than 1 matching comment: stop and request manual cleanup before updating.
+
+2. `gh` CLI fallback (primary fallback, not hard-block):
+- If MCP is unavailable or misconfigured, continue using `gh` CLI.
+- Check auth first:
+
+```bash
+gh auth status
+```
+
+- Create a managed comment:
+
+```bash
+gh issue comment {issue_number} --repo {owner}/{repo} --body-file /tmp/issue-plan.md
+```
+
+- Update existing managed comment (find exactly one comment id, then edit):
+
+```bash
+MATCHED_IDS=$(gh api repos/{owner}/{repo}/issues/{issue_number}/comments --paginate \
+  --jq '.[] | select(.body | contains("<!-- agentic:github-issue-plan -->")) | .id')
+
+MATCH_COUNT=$(printf "%s\n" "$MATCHED_IDS" | sed '/^$/d' | wc -l | tr -d ' ')
+if [ "$MATCH_COUNT" -gt 1 ]; then
+  echo "Multiple managed plan comments found; stop and ask for manual cleanup."
+  exit 1
+fi
+
+COMMENT_ID=$(printf "%s\n" "$MATCHED_IDS" | sed '/^$/d' | head -n 1)
+
+gh api repos/{owner}/{repo}/issues/comments/$COMMENT_ID \
+  --method PATCH \
+  --field body="$(cat /tmp/issue-plan.md)"
+```
+
+3. Local plan fallback (last resort):
+- Use `write-plan` or `persist-plan` local file flow only when GitHub issue
+  persistence is unavailable (no MCP, no working `gh`, or permission denied)
+  or explicitly not desired by the user.
+- Report that the plan was saved locally and not persisted to the issue.
+
+### Agent Orchestration Rules
+
+- Wait for delegated agents to complete before advancing to dependent steps.
+  - Do not continue to commit/push/PR steps while required reviewer/worker tasks are still running.
+  - If an agent is still running, keep polling until completion or explicit timeout/escalation.
+- If work is parallelizable, spawn more than one agent.
+  - Use multiple agents only for independent subtasks with non-overlapping outputs.
+  - Avoid parallelizing tightly coupled or blocking subtasks where sequencing is required.
+
+### Output Requirements
+
+Always report:
+- Issue reference used.
+- Persistence path used (`MCP`, `gh`, or `local`).
+- Whether managed comment was created or updated.
+- If fallback happened, include the concrete reason.

--- a/skills/agentic/github-issue-planning/issue-comment-template.md
+++ b/skills/agentic/github-issue-planning/issue-comment-template.md
@@ -1,0 +1,17 @@
+<!-- agentic:github-issue-plan -->
+## Implementation Plan
+
+### Context
+- {context}
+
+### Goals
+- {goal_1}
+
+### Steps
+1. {step_1}
+
+### Risks / Open Questions
+- {risk_1}
+
+### Status
+- Last updated: {updated_at}

--- a/skills/agentic/persist-plan/SKILL.md
+++ b/skills/agentic/persist-plan/SKILL.md
@@ -28,6 +28,10 @@ vendor_support:
 Capture a plan or architectural decision as a discoverable, structured file so that
 any agent or team member can find it later without re-deriving the context.
 
+When planning directly against a GitHub issue, use `github-issue-planning` for
+issue-comment persistence (MCP preferred, `gh` fallback). Use this skill for
+local `.agentic/plans/` persistence.
+
 ### Step 1 — Gather Plan Metadata
 
 Collect (or confirm) the following before writing:

--- a/skills/agentic/write-plan/SKILL.md
+++ b/skills/agentic/write-plan/SKILL.md
@@ -28,6 +28,10 @@ vendor_support:
 Automatically capture every agent-produced plan as a discoverable file in
 `.agentic/plans/` — so plans are preserved locally but never pollute the git tree.
 
+When a plan is tied to a GitHub issue and issue persistence is desired, prefer
+`github-issue-planning` to persist/update a managed issue comment first. Keep this
+skill as the local-file persistence path.
+
 > **This skill is agent-invoked, not user-invoked.** Do not prompt the user for
 > metadata. Derive everything from context and write silently.
 

--- a/skills/development/new-gh-issue-orchestration/SKILL.md
+++ b/skills/development/new-gh-issue-orchestration/SKILL.md
@@ -104,6 +104,15 @@ Loop policy:
   - after worker fixes, run reviewer again
 - If still unresolved after 3 automatic iterations, stop and ask developer for clear next instructions.
 
+### Agent Orchestration Rules
+
+- Wait for delegated agents to complete before advancing to dependent steps.
+  - Do not continue to commit/push/PR steps while required reviewer/worker tasks are still running.
+  - If an agent is still running, keep polling until completion or explicit timeout/escalation.
+- If work is parallelizable, spawn more than one agent.
+  - Use multiple agents only for independent subtasks with non-overlapping outputs.
+  - Avoid parallelizing tightly coupled or blocking subtasks where sequencing is required.
+
 ### Step 7 - Validation Gates
 
 Run the repository's required quality gates before commit/push.

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2559,6 +2559,38 @@ assert_file_exists "$TMP/t120/.agentic/skills/diagram-design/SKILL.md" "T120"
 assert_file_exists "$TMP/t120/.agentic/skills/README.md" "T120"
 assert_file_contains "$TMP/t120/.agentic/skills/README.md" "diagram-design" "T120"
 
+# T121 — deploy-skills: all-skills includes github-issue-planning
+run_test "T121 — deploy-skills: all-skills includes github-issue-planning"
+mkdir -p "$TMP/t121"
+bash "$DEPLOY_SKILLS" \
+  --library "$LIBRARY" \
+  --target "$TMP/t121" \
+  --skills all \
+  > /dev/null 2>&1
+
+assert_file_exists "$TMP/t121/.agentic/skills/github-issue-planning/SKILL.md" "T121"
+assert_file_exists "$TMP/t121/.agentic/skills/github-issue-planning/issue-comment-template.md" "T121"
+
+# T122 — index: skills index includes github-issue-planning
+run_test "T122 — index: includes github-issue-planning"
+bash "$INDEX" \
+  --library "$LIBRARY" \
+  > /dev/null 2>&1
+
+assert_file_contains "$LIBRARY/index/skills.json" "\"name\": \"github-issue-planning\"" "T122"
+
+# T123 — deploy-skills: README includes github-issue-planning
+run_test "T123 — deploy-skills: README includes github-issue-planning"
+mkdir -p "$TMP/t123"
+bash "$DEPLOY_SKILLS" \
+  --library "$LIBRARY" \
+  --target "$TMP/t123" \
+  --skills all \
+  > /dev/null 2>&1
+
+assert_file_exists "$TMP/t123/.agentic/skills/README.md" "T123"
+assert_file_contains "$TMP/t123/.agentic/skills/README.md" "github-issue-planning" "T123"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "────────────────────────────────────────"


### PR DESCRIPTION
## Summary
- add new `github-issue-planning` skill for issue-backed planning persistence
- keep local planning skills backward-compatible while cross-linking to the new issue-backed path
- enforce persistence decision tree: MCP preferred, `gh` fallback, local fallback only when GitHub persistence is unavailable/not desired
- add deterministic managed-comment handling for both MCP and `gh` paths

## Added
- `skills/agentic/github-issue-planning/SKILL.md`
- `skills/agentic/github-issue-planning/issue-comment-template.md`

## Updated
- `skills/agentic/write-plan/SKILL.md`
- `skills/agentic/persist-plan/SKILL.md`
- `skills/agentic/configure-mcp/SKILL.md`
- `docs/customization.md`
- `docs/skills.md`
- `tooling/lib/test.sh`
- `index/skills.json`
- `bin/agentic`

## Out Of Scope But Needed
- Added ShellCheck source directives in `bin/agentic` to satisfy CI:
  - initial directive addition for dynamic `source`
  - follow-up path correction to match CI resolution behavior
- Tightened duplicate managed-comment handling semantics in `github-issue-planning` to avoid non-deterministic updates when more than one marker comment exists.
- Added deploy assertion for `issue-comment-template.md` to ensure skill resources are actually shipped with `deploy-skills`.

## Validation
- `just index` passed
- `just lint` passed
- `just test` passed

Closes #101
