### PR TITLE
feat(vendors): add Cursor adapter and deterministic vendor switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ agentic list profiles|skills|vendors          # list available resources
 
 ## Supported AI Tools
 
-Claude, GitHub Copilot, Gemini CLI, OpenAI Codex, Opencode — all from one `AGENTS.md`.
+Claude, GitHub Copilot, Gemini CLI, OpenAI Codex, Opencode, Cursor (rules-only) — all from one `AGENTS.md`.
 
 → [Vendor details](https://agentic.soulcodex.link/vendors)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -158,6 +158,12 @@ agentic switch claude,copilot      # Activate multiple vendors
 agentic switch list                # Show available vendors
 ```
 
+Cursor-specific behavior:
+- `switch` manages only `.cursor/rules` (no `.cursor/skills` behavior).
+- If `.cursor/rules` is a real directory, it is migrated to deterministic backups:
+  `.cursor/rules.backup`, then `.cursor/rules.backup.N`.
+- If activation fails mid-switch, agentic rolls back to the prior symlink/config state.
+
 ### sync
 
 Regenerate AGENTS.md and vendor files from the local `.agentic/profile.yaml`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -59,7 +59,7 @@ agentic deploy <profile> [target] <vendors> [options]
 |---|---|---|
 | `profile` | ✅ | Profile name — see `agentic list profiles` |
 | `target` | optional | Project directory, auto-detected from current dir if omitted |
-| `vendors` | ✅ | Comma-separated vendors to activate: `claude`, `copilot`, `gemini`, `codex`, `opencode` |
+| `vendors` | ✅ | Comma-separated vendors to activate: `claude`, `copilot`, `gemini`, `codex`, `opencode`, `cursor` |
 
 | Option | Description |
 |---|---|
@@ -153,6 +153,7 @@ agentic switch [target] list
 ```bash
 agentic switch claude              # Activate only Claude
 agentic switch gemini              # Activate only Gemini
+agentic switch cursor              # Activate only Cursor
 agentic switch claude,copilot      # Activate multiple vendors
 agentic switch list                # Show available vendors
 ```

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -221,7 +221,7 @@ are gitignored automatically.
 | `CLAUDE.md`, `GEMINI.md`, vendor symlinks | 🚫 ignore | 🚫 ignore | Always recreated by `agentic sync` / `agentic switch` |
 
 > **Note**: vendor entry-point files (`CLAUDE.md`, `.github/copilot-instructions.md`,
-> `.gemini/system.md`, etc.) are always gitignored in both modes — they are always
+> `.gemini/system.md`, `.cursor/rules`, etc.) are always gitignored in both modes — they are always
 > regenerated and have no standalone value in git history.
 
 ### Switching between modes

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -223,6 +223,11 @@ are gitignored automatically.
 > **Note**: vendor entry-point files (`CLAUDE.md`, `.github/copilot-instructions.md`,
 > `.gemini/system.md`, `.cursor/rules`, etc.) are always gitignored in both modes — they are always
 > regenerated and have no standalone value in git history.
+>
+> For Cursor specifically, `agentic switch cursor` only manages `.cursor/rules`. If a
+> real `.cursor/rules` directory exists, agentic migrates it to
+> `.cursor/rules.backup` (or `.backup.N`) before linking, and restores it if switch
+> activation later fails and triggers rollback.
 
 ### Switching between modes
 

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -11,6 +11,7 @@ agentic generates vendor-specific instruction files from a single `AGENTS.md` so
 | **OpenAI Codex** | `AGENTS.md` | `AGENTS.md` natively; hierarchical for monorepos (tier AGENTS.md files) |
 | **Gemini CLI** | `GEMINI.md`, `.gemini/system.md` | Root context file (auto-discovered) + system-prompt override |
 | **Opencode** | `AGENTS.md` | `AGENTS.md` natively; skills in `.opencode/skills/` |
+| **Cursor** | `.cursor/rules/*.mdc` | Rules model with one always-on core rule + auto-attached language rules |
 
 ## How Each Vendor Uses AGENTS.md
 
@@ -52,6 +53,12 @@ Skills are deployed natively to `.gemini/skills/` and activated lazily via the
 ### Opencode
 
 Opencode reads `AGENTS.md` natively. Skills are deployed to `.opencode/skills/`. Opencode also supports `.claude/skills/` and `.agents/skills/` as compatibility fallbacks.
+
+### Cursor
+
+Cursor uses `.cursor/rules/*.mdc`. The adapter generates files into
+`.agentic/vendor-files/cursor/rules/`, then `agentic switch cursor` symlinks only
+`.cursor/rules`. This preserves unrelated `.cursor/*` files such as `.cursor/mcp.json`.
 
 ## MCP Pivot Model
 
@@ -108,3 +115,4 @@ Multiple vendors can be active simultaneously since their symlink paths don't co
 | `codex` | `.agents/skills` (reads `AGENTS.md` natively) |
 | `gemini` | `GEMINI.md`, `.gemini/system.md`, `.gemini/skills` |
 | `opencode` | `.opencode/skills` |
+| `cursor` | `.cursor/rules` |

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -59,6 +59,10 @@ Opencode reads `AGENTS.md` natively. Skills are deployed to `.opencode/skills/`.
 Cursor uses `.cursor/rules/*.mdc`. The adapter generates files into
 `.agentic/vendor-files/cursor/rules/`, then `agentic switch cursor` symlinks only
 `.cursor/rules`. This preserves unrelated `.cursor/*` files such as `.cursor/mcp.json`.
+If a real `.cursor/rules` directory already exists, switch migrates it to
+`.cursor/rules.backup` (or `.cursor/rules.backup.N`) before linking.
+If a multi-vendor switch fails after mutation begins, agentic rolls back prior
+symlinks/config and restores migrated Cursor rules.
 
 ## MCP Pivot Model
 

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -49,7 +49,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["claude", "copilot", "codex", "gemini", "opencode"]
+        "enum": ["claude", "copilot", "codex", "gemini", "opencode", "cursor"]
       },
       "description": "Vendors currently activated via symlinks."
     },

--- a/tooling/lib/cli.sh
+++ b/tooling/lib/cli.sh
@@ -482,8 +482,9 @@ cmd_list() {
       echo "  claude     Claude Code (CLAUDE.md, .claude/)"
       echo "  copilot    GitHub Copilot (.github/copilot-instructions.md)"
       echo "  codex      OpenAI Codex (AGENTS.md, .agents/)"
-      echo "  gemini     Gemini CLI (.gemini/systemPrompt.md)"
-      echo "  opencode   Opencode (opencode.json, .opencode/)"
+      echo "  gemini     Gemini CLI (GEMINI.md, .gemini/system.md)"
+      echo "  opencode   Opencode (AGENTS.md, .opencode/)"
+      echo "  cursor     Cursor (.cursor/rules/*.mdc)"
       ;;
     *)
       die "Unknown resource: $resource. Use: profiles, skills, fragments, vendors"

--- a/tooling/lib/common.sh
+++ b/tooling/lib/common.sh
@@ -111,7 +111,7 @@ require_arg() {
 # ══════════════════════════════════════════════════════════════════════════════
 
 # All supported vendors (single source of truth)
-export AGENTIC_VENDORS=(claude copilot codex gemini opencode)
+export AGENTIC_VENDORS=(claude copilot codex gemini opencode cursor)
 
 # Get vendor skill directory path
 # Usage: get_vendor_skill_dir <vendor>
@@ -122,6 +122,7 @@ get_vendor_skill_dir() {
     opencode) echo ".opencode/skills" ;;
     codex)    echo ".agents/skills" ;;
     gemini)   echo ".gemini/skills" ;;
+    cursor)   echo "" ;;           # Cursor rules-only adapter; no native skills path
     copilot)  echo "" ;;           # Copilot uses prompt-injected skills
     *)        echo "" ;;
   esac

--- a/tooling/lib/common.sh
+++ b/tooling/lib/common.sh
@@ -106,6 +106,21 @@ require_arg() {
   fi
 }
 
+# Returns a deterministic backup path for a filesystem entry.
+# Example: /x/.cursor/rules -> /x/.cursor/rules.backup, then .backup.1, .backup.2...
+next_backup_path() {
+  local original="$1"
+  local candidate="${original}.backup"
+  local index=1
+
+  while [[ -e "$candidate" || -L "$candidate" ]]; do
+    candidate="${original}.backup.${index}"
+    index=$((index + 1))
+  done
+
+  echo "$candidate"
+}
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Vendor registry
 # ══════════════════════════════════════════════════════════════════════════════

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -927,6 +927,7 @@ opencode.json
 .claude/skills
 .opencode/skills
 .agents/skills
+.cursor/rules
 
 $MARKER_END
 BLOCK
@@ -947,6 +948,7 @@ opencode.json
 .claude/skills
 .opencode/skills
 .agents/skills
+.cursor/rules
 
 # Agentic runtime directories — symlinks to library, recreated by \`agentic sync\`
 .agentic/skills/

--- a/tooling/lib/deploy-skills.sh
+++ b/tooling/lib/deploy-skills.sh
@@ -109,6 +109,7 @@ This directory contains reusable agent skills deployed by the agentic library.
 | Codex | `.agents/skills/` (symlinked here) | Native |
 | Copilot | Injected into copilot-instructions.md | Prompt-injected |
 | Gemini | `.gemini/skills/` (symlinked here) | Native (lazy via activate_skill) |
+| Cursor | Rules-only (`.cursor/rules/*.mdc`) | No native skills path |
 
 ## How It Works
 
@@ -202,6 +203,9 @@ create_skill_symlinks() {
       rm -f "$TARGET/.gemini/skills"
       ln -s "../.agentic/skills" "$TARGET/.gemini/skills"
       echo "  Linked: .gemini/skills → ../.agentic/skills"
+      ;;
+    cursor)
+      echo "  cursor uses .cursor/rules only — no skill symlink needed"
       ;;
     *)
       echo "  Unknown vendor '$vendor' — skipping skill symlinks"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -141,7 +141,7 @@ run_test() {
   num=$((10#$num))
   
   local tag="compose"
-  if (( num >= 8 && num <= 13 )) || (( num >= 28 && num <= 43 )) || (( num >= 42 && num <= 43 )) || (( num >= 124 && num <= 130 )); then
+  if (( num >= 8 && num <= 13 )) || (( num >= 28 && num <= 43 )) || (( num >= 42 && num <= 43 )) || (( num >= 124 && num <= 133 )); then
     tag="vendor"
   elif (( num == 14 )) || (( num == 73 )); then
     tag="lint"
@@ -2654,9 +2654,10 @@ bash "$VENDOR_SWITCH" \
 assert_file_exists "$TMP/t127/.cursor/mcp.json" "T127 mcp preserved"
 assert_not_symlink "$TMP/t127/.cursor/mcp.json" "T127 mcp not symlink"
 
-# T127B — vendor-switch: fail if .cursor/rules is a real directory
-run_test "T127B — vendor-switch: fails on real .cursor/rules dir"
+# T127B — vendor-switch: migrate real .cursor/rules directory to deterministic backup
+run_test "T127B — vendor-switch: migrates real .cursor/rules dir to backup"
 mkdir -p "$TMP/t127b/.cursor/rules"
+printf '%s\n' "legacy rules" > "$TMP/t127b/.cursor/rules/custom.mdc"
 bash "$COMPOSE" \
   --library "$LIBRARY" \
   --profile typescript-hexagonal-microservice \
@@ -2667,24 +2668,22 @@ bash "$VENDOR_GEN" \
   --target "$TMP/t127b" \
   --vendors cursor \
   > /dev/null 2>&1
-set +e
-T127B_OUTPUT=$(bash "$VENDOR_SWITCH" \
+bash "$VENDOR_SWITCH" \
   --library "$LIBRARY" \
   --target "$TMP/t127b" \
   cursor \
-  2>&1)
-T127B_CODE=$?
-set -e
-if [[ "$T127B_CODE" -ne 0 ]]; then
-  pass "T127B — vendor-switch failed as expected"
-else
-  fail "T127B — vendor-switch should fail when .cursor/rules is a real directory"
-fi
-assert_stdout_contains "$T127B_OUTPUT" ".cursor/rules exists and is not a symlink" "T127B error message"
+  > /dev/null 2>&1
+assert_symlink_exists "$TMP/t127b/.cursor/rules" "T127B rules symlink created"
+assert_file_exists "$TMP/t127b/.cursor/rules.backup/custom.mdc" "T127B backup created"
+assert_file_contains "$TMP/t127b/.agentic/config.yaml" "  - cursor" "T127B active vendor updated"
 
-# T127C — vendor-switch: conflict must not remove currently active vendor symlinks
-run_test "T127C — vendor-switch: conflict keeps existing vendor state"
+# T127C — vendor-switch: migration chooses .backup.N when .backup exists
+run_test "T127C — vendor-switch: uses incremental backup suffix"
 mkdir -p "$TMP/t127c"
+mkdir -p "$TMP/t127c/.cursor/rules"
+mkdir -p "$TMP/t127c/.cursor/rules.backup"
+printf '%s\n' "old backup" > "$TMP/t127c/.cursor/rules.backup/existing.txt"
+printf '%s\n' "legacy rules" > "$TMP/t127c/.cursor/rules/custom.mdc"
 bash "$COMPOSE" \
   --library "$LIBRARY" \
   --profile typescript-hexagonal-microservice \
@@ -2693,34 +2692,19 @@ bash "$COMPOSE" \
 bash "$VENDOR_GEN" \
   --library "$LIBRARY" \
   --target "$TMP/t127c" \
-  --vendors claude,cursor \
+  --vendors cursor \
   > /dev/null 2>&1
 bash "$VENDOR_SWITCH" \
   --library "$LIBRARY" \
   --target "$TMP/t127c" \
-  claude \
-  > /dev/null 2>&1
-mkdir -p "$TMP/t127c/.cursor/rules"
-set +e
-T127C_OUTPUT=$(bash "$VENDOR_SWITCH" \
-  --library "$LIBRARY" \
-  --target "$TMP/t127c" \
   cursor \
-  2>&1)
-T127C_CODE=$?
-set -e
-if [[ "$T127C_CODE" -ne 0 ]]; then
-  pass "T127C — vendor-switch failed as expected"
-else
-  fail "T127C — vendor-switch should fail when .cursor/rules is a real directory"
-fi
-assert_stdout_contains "$T127C_OUTPUT" ".cursor/rules exists and is not a symlink" "T127C error message"
-assert_symlink_exists "$TMP/t127c/CLAUDE.md" "T127C claude symlink preserved"
-assert_file_contains "$TMP/t127c/.agentic/config.yaml" "  - claude" "T127C active vendor unchanged"
-assert_file_not_contains "$TMP/t127c/.agentic/config.yaml" "  - cursor" "T127C cursor not activated"
+  > /dev/null 2>&1
+assert_symlink_exists "$TMP/t127c/.cursor/rules" "T127C rules symlink created"
+assert_file_exists "$TMP/t127c/.cursor/rules.backup.1/custom.mdc" "T127C incremental backup created"
+assert_file_exists "$TMP/t127c/.cursor/rules.backup/existing.txt" "T127C existing backup retained"
 
-# T127D — vendor-switch: multi-vendor conflict does not leave partial activation
-run_test "T127D — vendor-switch: no partial activation on cursor conflict"
+# T127D — vendor-switch: rollback restores prior vendor state on post-mutation failure
+run_test "T127D — vendor-switch: rollback restores prior state on failure"
 mkdir -p "$TMP/t127d"
 bash "$COMPOSE" \
   --library "$LIBRARY" \
@@ -2730,26 +2714,38 @@ bash "$COMPOSE" \
 bash "$VENDOR_GEN" \
   --library "$LIBRARY" \
   --target "$TMP/t127d" \
-  --vendors claude,cursor \
+  --vendors claude,cursor,gemini \
   > /dev/null 2>&1
 mkdir -p "$TMP/t127d/.cursor/rules"
+printf '%s\n' "legacy rules" > "$TMP/t127d/.cursor/rules/custom.mdc"
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127d" \
+  claude \
+  > /dev/null 2>&1
+printf '%s\n' "block gemini dir" > "$TMP/t127d/.gemini"
 set +e
 T127D_OUTPUT=$(bash "$VENDOR_SWITCH" \
   --library "$LIBRARY" \
   --target "$TMP/t127d" \
-  claude cursor \
+  cursor gemini \
   2>&1)
 T127D_CODE=$?
 set -e
 if [[ "$T127D_CODE" -ne 0 ]]; then
   pass "T127D — vendor-switch failed as expected"
 else
-  fail "T127D — vendor-switch should fail when .cursor/rules is a real directory"
+  fail "T127D — vendor-switch should fail when gemini path is blocked"
 fi
-assert_stdout_contains "$T127D_OUTPUT" ".cursor/rules exists and is not a symlink" "T127D error message"
-assert_file_not_exists "$TMP/t127d/CLAUDE.md" "T127D no partial claude activation"
-assert_file_not_contains "$TMP/t127d/.agentic/config.yaml" "  - claude" "T127D config unchanged on failure"
-assert_file_not_contains "$TMP/t127d/.agentic/config.yaml" "  - cursor" "T127D config unchanged on failure"
+assert_stdout_contains "$T127D_OUTPUT" "rolling back state" "T127D rollback message"
+assert_symlink_exists "$TMP/t127d/CLAUDE.md" "T127D claude symlink restored"
+assert_not_symlink "$TMP/t127d/.cursor/rules" "T127D cursor rules restored as directory"
+assert_file_exists "$TMP/t127d/.cursor/rules/custom.mdc" "T127D cursor rules content restored"
+assert_file_not_exists "$TMP/t127d/GEMINI.md" "T127D gemini root link removed on rollback"
+assert_file_not_exists "$TMP/t127d/.gemini/system.md" "T127D gemini system link removed on rollback"
+assert_file_not_exists "$TMP/t127d/.gemini/skills" "T127D gemini skills link removed on rollback"
+assert_file_contains "$TMP/t127d/.agentic/config.yaml" "  - claude" "T127D active vendor unchanged"
+assert_file_not_contains "$TMP/t127d/.agentic/config.yaml" "  - cursor" "T127D cursor not activated"
 
 # T128 — config schema: active_vendors enum includes cursor
 run_test "T128 — config schema: enum includes cursor"
@@ -2765,6 +2761,107 @@ bash "$DEPLOY_SKILLS" \
   --vendor cursor \
   > /dev/null 2>&1
 assert_file_not_exists "$TMP/t129/.cursor/skills" "T129 no cursor skills symlink"
+
+# T130 — vendor-switch: rollback restores single-vendor state on gemini failure
+run_test "T130 — vendor-switch: rollback with existing cursor-only state"
+mkdir -p "$TMP/t130"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t130" \
+  > /dev/null 2>&1
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t130" \
+  --vendors cursor,gemini \
+  > /dev/null 2>&1
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t130" \
+  cursor \
+  > /dev/null 2>&1
+printf '%s\n' "block gemini dir" > "$TMP/t130/.gemini"
+set +e
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t130" \
+  cursor gemini \
+  > /dev/null 2>&1
+T130_CODE=$?
+set -e
+assert_exit_code 1 "$T130_CODE" "T130"
+assert_symlink_exists "$TMP/t130/.cursor/rules" "T130 cursor symlink preserved"
+assert_file_not_exists "$TMP/t130/GEMINI.md" "T130 gemini root link removed on rollback"
+assert_file_not_exists "$TMP/t130/.gemini/system.md" "T130 gemini system link removed on rollback"
+assert_file_not_exists "$TMP/t130/.gemini/skills" "T130 gemini skills link removed on rollback"
+assert_file_contains "$TMP/t130/.agentic/config.yaml" "  - cursor" "T130 active vendor unchanged"
+assert_file_not_contains "$TMP/t130/.agentic/config.yaml" "  - gemini" "T130 gemini not activated"
+
+# T131 — vendor-switch: cursor remains rules-only (no .cursor/skills)
+run_test "T131 — vendor-switch: no .cursor/skills on activation"
+mkdir -p "$TMP/t131"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t131" \
+  > /dev/null 2>&1
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t131" \
+  cursor \
+  > /dev/null 2>&1
+assert_file_not_exists "$TMP/t131/.cursor/skills" "T131 no cursor skills symlink"
+
+# T132 — vendor-switch: cursor backup migration preserves unrelated .cursor files
+run_test "T132 — vendor-switch: migration preserves .cursor/mcp.json"
+mkdir -p "$TMP/t132/.cursor/rules"
+printf '%s\n' "legacy rules" > "$TMP/t132/.cursor/rules/custom.mdc"
+printf '%s\n' '{"mcpServers":{"demo":{"command":"node"}}}' > "$TMP/t132/.cursor/mcp.json"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t132" \
+  > /dev/null 2>&1
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t132" \
+  cursor \
+  > /dev/null 2>&1
+assert_file_exists "$TMP/t132/.cursor/mcp.json" "T132 mcp preserved"
+assert_file_exists "$TMP/t132/.cursor/rules.backup/custom.mdc" "T132 backup created"
+assert_symlink_exists "$TMP/t132/.cursor/rules" "T132 rules symlink created"
+
+# T133 — vendor-switch: backup naming increments across repeated migrations
+run_test "T133 — vendor-switch: deterministic incremental backup naming"
+mkdir -p "$TMP/t133"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t133" \
+  > /dev/null 2>&1
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t133" \
+  cursor \
+  > /dev/null 2>&1
+rm "$TMP/t133/.cursor/rules"
+mkdir -p "$TMP/t133/.cursor/rules"
+printf '%s\n' "first legacy" > "$TMP/t133/.cursor/rules/first.mdc"
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t133" \
+  cursor \
+  > /dev/null 2>&1
+rm "$TMP/t133/.cursor/rules"
+mkdir -p "$TMP/t133/.cursor/rules"
+printf '%s\n' "second legacy" > "$TMP/t133/.cursor/rules/second.mdc"
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t133" \
+  cursor \
+  > /dev/null 2>&1
+assert_file_exists "$TMP/t133/.cursor/rules.backup/first.mdc" "T133 first backup"
+assert_file_exists "$TMP/t133/.cursor/rules.backup.1/second.mdc" "T133 second backup"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -141,7 +141,7 @@ run_test() {
   num=$((10#$num))
   
   local tag="compose"
-  if (( num >= 8 && num <= 13 )) || (( num >= 28 && num <= 43 )) || (( num >= 42 && num <= 43 )); then
+  if (( num >= 8 && num <= 13 )) || (( num >= 28 && num <= 43 )) || (( num >= 42 && num <= 43 )) || (( num >= 124 && num <= 130 )); then
     tag="vendor"
   elif (( num == 14 )) || (( num == 73 )); then
     tag="lint"
@@ -621,6 +621,7 @@ assert_file_contains "$T29_TMPFILE" "copilot"  "T29"
 assert_file_contains "$T29_TMPFILE" "codex"    "T29"
 assert_file_contains "$T29_TMPFILE" "gemini"   "T29"
 assert_file_contains "$T29_TMPFILE" "opencode" "T29"
+assert_file_contains "$T29_TMPFILE" "cursor"   "T29"
 
 # T30 — deploy-skills: creates vendor skill symlinks when --vendor is specified
 run_test "T30 — deploy-skills: creates vendor skill symlinks"
@@ -890,6 +891,7 @@ assert_file_contains "$TMP/t41/.gitignore" "# agentic:end" "T41"
 assert_file_contains "$TMP/t41/.gitignore" ".claude/skills" "T41"
 assert_file_contains "$TMP/t41/.gitignore" ".opencode/skills" "T41"
 assert_file_contains "$TMP/t41/.gitignore" ".agents/skills" "T41"
+assert_file_contains "$TMP/t41/.gitignore" ".cursor/rules" "T41"
 # Project-owned files must NOT be ignored
 assert_file_not_contains "$TMP/t41/.gitignore" "AGENTS.md" "T41"
 assert_file_not_contains "$TMP/t41/.gitignore" "config.yaml" "T41"
@@ -912,6 +914,7 @@ bash "$COMPOSE" \
 assert_file_contains "$TMP/t_gl/.gitignore" ".agentic/skills/" "T_GITIGNORE_LINK_MODE"
 assert_file_contains "$TMP/t_gl/.gitignore" ".agentic/fragments/" "T_GITIGNORE_LINK_MODE"
 assert_file_contains "$TMP/t_gl/.gitignore" ".agentic/vendor-files/" "T_GITIGNORE_LINK_MODE"
+assert_file_contains "$TMP/t_gl/.gitignore" ".cursor/rules" "T_GITIGNORE_LINK_MODE"
 assert_file_contains "$TMP/t_gl/.gitignore" "# agentic:start" "T_GITIGNORE_LINK_MODE"
 
 # T_GITIGNORE_IDEMPOTENT — block not duplicated on re-run
@@ -1131,6 +1134,7 @@ assert_stdout_contains "$T47_OUTPUT" "Supported vendors:" "T47"
 assert_stdout_contains "$T47_OUTPUT" "claude" "T47"
 assert_stdout_contains "$T47_OUTPUT" "copilot" "T47"
 assert_stdout_contains "$T47_OUTPUT" "gemini" "T47"
+assert_stdout_contains "$T47_OUTPUT" "cursor" "T47"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # LIBRARY DISCOVERY TESTS
@@ -2590,6 +2594,108 @@ bash "$DEPLOY_SKILLS" \
 
 assert_file_exists "$TMP/t123/.agentic/skills/README.md" "T123"
 assert_file_contains "$TMP/t123/.agentic/skills/README.md" "github-issue-planning" "T123"
+
+# T124 — vendor-gen: cursor creates expected .mdc files
+run_test "T124 — vendor-gen: cursor creates expected .mdc files"
+mkdir -p "$TMP/t124"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t124" \
+  > /dev/null 2>&1
+
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t124" \
+  --vendors cursor \
+  > /dev/null 2>&1
+
+assert_file_exists "$TMP/t124/.agentic/vendor-files/cursor/rules/00-core.mdc" "T124 core"
+assert_file_exists "$TMP/t124/.agentic/vendor-files/cursor/rules/10-typescript.mdc" "T124 typescript"
+assert_file_not_exists "$TMP/t124/.cursorrules" "T124 no cursorrules"
+
+# T125 — vendor-gen: cursor frontmatter for always-on vs auto-attached rules
+run_test "T125 — vendor-gen: cursor frontmatter correctness"
+assert_file_contains "$TMP/t124/.agentic/vendor-files/cursor/rules/00-core.mdc" "alwaysApply: true" "T125 core always-on"
+assert_file_not_contains "$TMP/t124/.agentic/vendor-files/cursor/rules/10-typescript.mdc" "alwaysApply: true" "T125 ts not always-on"
+assert_file_contains "$TMP/t124/.agentic/vendor-files/cursor/rules/10-typescript.mdc" "globs:" "T125 ts globs"
+assert_file_contains "$TMP/t124/.agentic/vendor-files/cursor/rules/10-typescript.mdc" "**/*.ts" "T125 ts globs value"
+
+# T126 — vendor-switch: cursor manages only .cursor/rules symlink
+run_test "T126 — vendor-switch: cursor symlink behavior"
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t124" \
+  cursor \
+  > /dev/null 2>&1
+
+assert_symlink_exists "$TMP/t124/.cursor/rules" "T126 cursor rules symlink"
+assert_file_contains "$TMP/t124/.agentic/config.yaml" "  - cursor" "T126 active vendor"
+
+# T127 — vendor-switch: preserve unrelated .cursor/mcp.json
+run_test "T127 — vendor-switch: preserves .cursor/mcp.json"
+mkdir -p "$TMP/t127/.cursor"
+printf '%s\n' '{"mcpServers":{"demo":{"command":"node"}}}' > "$TMP/t127/.cursor/mcp.json"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t127" \
+  > /dev/null 2>&1
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127" \
+  --vendors cursor \
+  > /dev/null 2>&1
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127" \
+  cursor \
+  > /dev/null 2>&1
+assert_file_exists "$TMP/t127/.cursor/mcp.json" "T127 mcp preserved"
+assert_not_symlink "$TMP/t127/.cursor/mcp.json" "T127 mcp not symlink"
+
+# T127B — vendor-switch: fail if .cursor/rules is a real directory
+run_test "T127B — vendor-switch: fails on real .cursor/rules dir"
+mkdir -p "$TMP/t127b/.cursor/rules"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t127b" \
+  > /dev/null 2>&1
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127b" \
+  --vendors cursor \
+  > /dev/null 2>&1
+set +e
+T127B_OUTPUT=$(bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127b" \
+  cursor \
+  2>&1)
+T127B_CODE=$?
+set -e
+if [[ "$T127B_CODE" -ne 0 ]]; then
+  pass "T127B — vendor-switch failed as expected"
+else
+  fail "T127B — vendor-switch should fail when .cursor/rules is a real directory"
+fi
+assert_stdout_contains "$T127B_OUTPUT" ".cursor/rules exists and is not a symlink" "T127B error message"
+
+# T128 — config schema: active_vendors enum includes cursor
+run_test "T128 — config schema: enum includes cursor"
+assert_file_contains "$LIBRARY/schemas/config.schema.json" "\"cursor\"" "T128"
+
+# T129 — deploy-skills: cursor vendor is rules-only (no native skill symlink)
+run_test "T129 — deploy-skills: cursor rules-only behavior"
+mkdir -p "$TMP/t129"
+bash "$DEPLOY_SKILLS" \
+  --library "$LIBRARY" \
+  --target "$TMP/t129" \
+  --skills code-review \
+  --vendor cursor \
+  > /dev/null 2>&1
+assert_file_not_exists "$TMP/t129/.cursor/skills" "T129 no cursor skills symlink"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2682,6 +2682,75 @@ else
 fi
 assert_stdout_contains "$T127B_OUTPUT" ".cursor/rules exists and is not a symlink" "T127B error message"
 
+# T127C — vendor-switch: conflict must not remove currently active vendor symlinks
+run_test "T127C — vendor-switch: conflict keeps existing vendor state"
+mkdir -p "$TMP/t127c"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t127c" \
+  > /dev/null 2>&1
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127c" \
+  --vendors claude,cursor \
+  > /dev/null 2>&1
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127c" \
+  claude \
+  > /dev/null 2>&1
+mkdir -p "$TMP/t127c/.cursor/rules"
+set +e
+T127C_OUTPUT=$(bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127c" \
+  cursor \
+  2>&1)
+T127C_CODE=$?
+set -e
+if [[ "$T127C_CODE" -ne 0 ]]; then
+  pass "T127C — vendor-switch failed as expected"
+else
+  fail "T127C — vendor-switch should fail when .cursor/rules is a real directory"
+fi
+assert_stdout_contains "$T127C_OUTPUT" ".cursor/rules exists and is not a symlink" "T127C error message"
+assert_symlink_exists "$TMP/t127c/CLAUDE.md" "T127C claude symlink preserved"
+assert_file_contains "$TMP/t127c/.agentic/config.yaml" "  - claude" "T127C active vendor unchanged"
+assert_file_not_contains "$TMP/t127c/.agentic/config.yaml" "  - cursor" "T127C cursor not activated"
+
+# T127D — vendor-switch: multi-vendor conflict does not leave partial activation
+run_test "T127D — vendor-switch: no partial activation on cursor conflict"
+mkdir -p "$TMP/t127d"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t127d" \
+  > /dev/null 2>&1
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127d" \
+  --vendors claude,cursor \
+  > /dev/null 2>&1
+mkdir -p "$TMP/t127d/.cursor/rules"
+set +e
+T127D_OUTPUT=$(bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127d" \
+  claude cursor \
+  2>&1)
+T127D_CODE=$?
+set -e
+if [[ "$T127D_CODE" -ne 0 ]]; then
+  pass "T127D — vendor-switch failed as expected"
+else
+  fail "T127D — vendor-switch should fail when .cursor/rules is a real directory"
+fi
+assert_stdout_contains "$T127D_OUTPUT" ".cursor/rules exists and is not a symlink" "T127D error message"
+assert_file_not_exists "$TMP/t127d/CLAUDE.md" "T127D no partial claude activation"
+assert_file_not_contains "$TMP/t127d/.agentic/config.yaml" "  - claude" "T127D config unchanged on failure"
+assert_file_not_contains "$TMP/t127d/.agentic/config.yaml" "  - cursor" "T127D config unchanged on failure"
+
 # T128 — config schema: active_vendors enum includes cursor
 run_test "T128 — config schema: enum includes cursor"
 assert_file_contains "$LIBRARY/schemas/config.schema.json" "\"cursor\"" "T128"

--- a/tooling/lib/vendor-gen.sh
+++ b/tooling/lib/vendor-gen.sh
@@ -141,6 +141,8 @@ source "$SCRIPT_DIR/vendors/codex.sh"
 source "$SCRIPT_DIR/vendors/gemini.sh"
 # shellcheck source=tooling/lib/vendors/opencode.sh
 source "$SCRIPT_DIR/vendors/opencode.sh"
+# shellcheck source=tooling/lib/vendors/cursor.sh
+source "$SCRIPT_DIR/vendors/cursor.sh"
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 mkdir -p "$VENDOR_FILES_DIR"
@@ -153,6 +155,7 @@ for vendor in $(resolve_vendors); do
     codex)    gen_codex    ;;
     gemini)   gen_gemini   ;;
     opencode) gen_opencode ;;
+    cursor)   gen_cursor   ;;
     *) echo "Warning: unknown vendor '$vendor' — skipping" >&2 ;;
   esac
 done

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -225,6 +225,19 @@ create_vendor_symlinks() {
   esac
 }
 
+# ── Preflight vendor activation conflicts (must run before mutations) ─────────
+preflight_vendor_conflicts() {
+  local vendor="$1"
+  case "$vendor" in
+    cursor)
+      if [[ -e "$TARGET/.cursor/rules" && ! -L "$TARGET/.cursor/rules" ]]; then
+        echo "Error: .cursor/rules exists and is not a symlink. Move or remove it, then rerun vendor switch." >&2
+        exit 1
+      fi
+      ;;
+  esac
+}
+
 # ── Check if vendor files exist ────────────────────────────────────────────────
 vendor_files_exist() {
   local vendor="$1"
@@ -262,6 +275,11 @@ for vendor in "${VENDORS[@]}"; do
     echo "Generating $vendor files..."
     bash "$VENDOR_GEN" --library "$LIBRARY" --target "$TARGET" --vendors "$vendor"
   fi
+done
+
+# Preflight conflicts before mutating symlinks, to keep switches atomic on failure
+for vendor in "${VENDORS[@]}"; do
+  preflight_vendor_conflicts "$vendor"
 done
 
 # Remove existing symlinks

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -130,6 +130,7 @@ remove_all_vendor_symlinks() {
   [[ -L "$TARGET/.claude/skills" ]] && rm "$TARGET/.claude/skills"
   [[ -L "$TARGET/.opencode/skills" ]] && rm "$TARGET/.opencode/skills"
   [[ -L "$TARGET/.agents/skills" ]] && rm "$TARGET/.agents/skills"
+  [[ -L "$TARGET/.cursor/rules" ]] && rm "$TARGET/.cursor/rules"
   
   # Clean up empty directories (only if they exist and are empty)
   [[ -d "$TARGET/.github/instructions" ]] && rmdir "$TARGET/.github/instructions" 2>/dev/null || true
@@ -138,6 +139,7 @@ remove_all_vendor_symlinks() {
   [[ -d "$TARGET/.claude" ]] && rmdir "$TARGET/.claude" 2>/dev/null || true
   [[ -d "$TARGET/.opencode" ]] && rmdir "$TARGET/.opencode" 2>/dev/null || true
   [[ -d "$TARGET/.agents" ]] && rmdir "$TARGET/.agents" 2>/dev/null || true
+  [[ -d "$TARGET/.cursor" ]] && rmdir "$TARGET/.cursor" 2>/dev/null || true
 }
 
 # ── Create vendor-specific symlinks ────────────────────────────────────────────
@@ -209,6 +211,17 @@ create_vendor_symlinks() {
         echo "    Linked: .opencode/skills → ../.agentic/skills"
       fi
       ;;
+    cursor)
+      if [[ -d "$VENDOR_FILES_DIR/cursor/rules" ]]; then
+        mkdir -p "$TARGET/.cursor"
+        if [[ -e "$TARGET/.cursor/rules" && ! -L "$TARGET/.cursor/rules" ]]; then
+          echo "Error: .cursor/rules exists and is not a symlink. Move or remove it, then rerun vendor switch." >&2
+          exit 1
+        fi
+        ln -sfn "../.agentic/vendor-files/cursor/rules" "$TARGET/.cursor/rules"
+        echo "    Linked: .cursor/rules → ../.agentic/vendor-files/cursor/rules"
+      fi
+      ;;
   esac
 }
 
@@ -221,6 +234,7 @@ vendor_files_exist() {
     codex)    [[ -d "$VENDOR_FILES_DIR/codex" ]] ;;
     gemini)   [[ -f "$VENDOR_FILES_DIR/gemini/GEMINI.md" ]] ;;
     opencode) [[ -d "$VENDOR_FILES_DIR/opencode" ]] ;;
+    cursor)   [[ -d "$VENDOR_FILES_DIR/cursor/rules" ]] ;;
     *)        return 1 ;;
   esac
 }

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -40,6 +40,11 @@ VENDOR_GEN="$LIBRARY/tooling/lib/vendor-gen.sh"
 SYNC_SCRIPT="$LIBRARY/tooling/lib/sync.sh"
 CONFIG="$TARGET/.agentic/config.yaml"
 VENDOR_FILES_DIR="$TARGET/.agentic/vendor-files"
+ROLLBACK_DIR="$TARGET/.agentic/.switch-rollback"
+ROLLBACK_LINKS_FILE="$ROLLBACK_DIR/links.tsv"
+ROLLBACK_CONFIG_FILE="$ROLLBACK_DIR/config.yaml"
+ROLLBACK_CURSOR_MOVES_FILE="$ROLLBACK_DIR/cursor-moves.tsv"
+SWITCH_COMMITTED=0
 
 # Use AGENTIC_VENDORS from common.sh (single source of truth)
 
@@ -115,6 +120,106 @@ migrate_active_vendor_format() {
   fi
 }
 
+record_cursor_backup_move() {
+  local original="$1"
+  local backup="$2"
+  mkdir -p "$ROLLBACK_DIR"
+  printf '%s\t%s\n' "$original" "$backup" >> "$ROLLBACK_CURSOR_MOVES_FILE"
+}
+
+prepare_cursor_rules_path() {
+  local cursor_rules="$TARGET/.cursor/rules"
+  if [[ -e "$cursor_rules" && ! -L "$cursor_rules" ]]; then
+    local backup_path
+    backup_path="$(next_backup_path "$cursor_rules")"
+    mv "$cursor_rules" "$backup_path"
+    record_cursor_backup_move "$cursor_rules" "$backup_path"
+    echo "  Migrated: .cursor/rules → ${backup_path#$TARGET/}"
+  fi
+}
+
+snapshot_current_switch_state() {
+  local managed_paths=(
+    "$TARGET/CLAUDE.md"
+    "$TARGET/.github/copilot-instructions.md"
+    "$TARGET/.github/instructions"
+    "$TARGET/GEMINI.md"
+    "$TARGET/.gemini/system.md"
+    "$TARGET/.gemini/skills"
+    "$TARGET/.claude/skills"
+    "$TARGET/.opencode/skills"
+    "$TARGET/.agents/skills"
+    "$TARGET/.cursor/rules"
+  )
+
+  rm -rf "$ROLLBACK_DIR"
+  mkdir -p "$ROLLBACK_DIR"
+  : > "$ROLLBACK_LINKS_FILE"
+  : > "$ROLLBACK_CURSOR_MOVES_FILE"
+
+  if [[ -f "$CONFIG" ]]; then
+    cp "$CONFIG" "$ROLLBACK_CONFIG_FILE"
+  fi
+
+  local path
+  for path in "${managed_paths[@]}"; do
+    if [[ -L "$path" ]]; then
+      printf '%s\t%s\n' "$path" "$(readlink "$path")" >> "$ROLLBACK_LINKS_FILE"
+    fi
+  done
+}
+
+rollback_switch_state() {
+  local original backup link_path link_target
+
+  remove_all_vendor_symlinks
+
+  if [[ -f "$ROLLBACK_LINKS_FILE" ]]; then
+    while IFS=$'\t' read -r link_path link_target; do
+      [[ -z "$link_path" || -z "$link_target" ]] && continue
+      mkdir -p "$(dirname "$link_path")"
+      ln -sfn "$link_target" "$link_path"
+    done < "$ROLLBACK_LINKS_FILE"
+  fi
+
+  if [[ -f "$ROLLBACK_CONFIG_FILE" ]]; then
+    cp "$ROLLBACK_CONFIG_FILE" "$CONFIG"
+  fi
+
+  if [[ -f "$ROLLBACK_CURSOR_MOVES_FILE" ]]; then
+    while IFS=$'\t' read -r original backup; do
+      [[ -z "$original" || -z "$backup" ]] && continue
+      if [[ -L "$original" ]]; then
+        rm "$original"
+      fi
+      if [[ ! -e "$original" && -e "$backup" ]]; then
+        mv "$backup" "$original"
+      fi
+    done < "$ROLLBACK_CURSOR_MOVES_FILE"
+  fi
+}
+
+cleanup_rollback_artifacts() {
+  rm -rf "$ROLLBACK_DIR"
+}
+
+on_switch_error() {
+  local exit_code="$1"
+  set +e
+  if [[ "$exit_code" -ne 0 && "$SWITCH_COMMITTED" -eq 0 ]]; then
+    echo "Switch failed; rolling back state..." >&2
+    rollback_switch_state
+  fi
+  cleanup_rollback_artifacts
+  set -e
+}
+
+on_switch_exit() {
+  local exit_code=$?
+  on_switch_error "$exit_code"
+  exit "$exit_code"
+}
+
 # ── Remove all vendor symlinks ─────────────────────────────────────────────────
 remove_all_vendor_symlinks() {
   # Remove vendor entrypoint symlinks (check if symlink before removing)
@@ -122,7 +227,7 @@ remove_all_vendor_symlinks() {
 
   [[ -L "$TARGET/.github/copilot-instructions.md" ]] && rm "$TARGET/.github/copilot-instructions.md"
   [[ -L "$TARGET/.github/instructions" ]] && rm "$TARGET/.github/instructions"
-  [[ -L "$TARGET/.gemini/GEMINI.md" ]] && rm "$TARGET/GEMINI.md"
+  [[ -L "$TARGET/GEMINI.md" ]] && rm "$TARGET/GEMINI.md"
   [[ -L "$TARGET/.gemini/system.md" ]] && rm "$TARGET/.gemini/system.md"
   [[ -L "$TARGET/.gemini/skills" ]] && rm "$TARGET/.gemini/skills"
   
@@ -214,10 +319,6 @@ create_vendor_symlinks() {
     cursor)
       if [[ -d "$VENDOR_FILES_DIR/cursor/rules" ]]; then
         mkdir -p "$TARGET/.cursor"
-        if [[ -e "$TARGET/.cursor/rules" && ! -L "$TARGET/.cursor/rules" ]]; then
-          echo "Error: .cursor/rules exists and is not a symlink. Move or remove it, then rerun vendor switch." >&2
-          exit 1
-        fi
         ln -sfn "../.agentic/vendor-files/cursor/rules" "$TARGET/.cursor/rules"
         echo "    Linked: .cursor/rules → ../.agentic/vendor-files/cursor/rules"
       fi
@@ -230,10 +331,7 @@ preflight_vendor_conflicts() {
   local vendor="$1"
   case "$vendor" in
     cursor)
-      if [[ -e "$TARGET/.cursor/rules" && ! -L "$TARGET/.cursor/rules" ]]; then
-        echo "Error: .cursor/rules exists and is not a symlink. Move or remove it, then rerun vendor switch." >&2
-        exit 1
-      fi
+      prepare_cursor_rules_path
       ;;
   esac
 }
@@ -277,6 +375,9 @@ for vendor in "${VENDORS[@]}"; do
   fi
 done
 
+snapshot_current_switch_state
+trap on_switch_exit EXIT
+
 # Preflight conflicts before mutating symlinks, to keep switches atomic on failure
 for vendor in "${VENDORS[@]}"; do
   preflight_vendor_conflicts "$vendor"
@@ -305,6 +406,9 @@ if [[ -f "$CONFIG" ]]; then
   # Remove old active_vendor if present, set active_vendors array
   yq -i "del(.active_vendor) | .active_vendors = $yaml_array" "$CONFIG"
 fi
+
+SWITCH_COMMITTED=1
+cleanup_rollback_artifacts
 
 echo ""
 echo "Activated vendors: ${VENDORS[*]}"

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -134,7 +134,7 @@ prepare_cursor_rules_path() {
     backup_path="$(next_backup_path "$cursor_rules")"
     mv "$cursor_rules" "$backup_path"
     record_cursor_backup_move "$cursor_rules" "$backup_path"
-    echo "  Migrated: .cursor/rules → ${backup_path#$TARGET/}"
+    echo "  Migrated: .cursor/rules → ${backup_path#"$TARGET"/}"
   fi
 }
 

--- a/tooling/lib/vendors/cursor.sh
+++ b/tooling/lib/vendors/cursor.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# cursor.sh — Vendor generation for Cursor
+
+gen_cursor() {
+  echo "  Generating Cursor adapter..."
+  local vendor_dir="$VENDOR_FILES_DIR/cursor"
+  local rules_dir="$vendor_dir/rules"
+  local adapter="$LIBRARY/vendors/cursor/adapter.json"
+
+  mkdir -p "$rules_dir"
+
+  local core_file="$rules_dir/00-core.mdc"
+  {
+    echo "---"
+    echo "description: Global engineering conventions"
+    echo "alwaysApply: true"
+    echo "---"
+    echo ""
+    autogen_header
+
+    jq -r '.section_mappings[] | select(.activation_mode == "always-on") | .agents_md_heading' "$adapter" | \
+    sed 's/^## //' | while read -r heading; do
+      content=$(get_section_content "$heading")
+      [[ -n "$content" ]] && printf '\n## %s\n\n%s\n' "$heading" "$content"
+    done
+  } > "$core_file"
+  format_markdown "$core_file"
+  echo "  Created: .agentic/vendor-files/cursor/rules/00-core.mdc"
+
+  jq -r '.section_mappings[] | select(.activation_mode == "glob-scoped") | [.agents_md_heading, .output_file, (.frontmatter.globs // [] | join(","))] | @tsv' "$adapter" | \
+  while IFS=$'\t' read -r heading out_file globs_csv; do
+    heading_text="${heading#\## }"
+    content=$(get_section_content "$heading_text")
+    [[ -z "$content" ]] && continue
+
+    local out_path="$rules_dir/$out_file"
+    IFS=',' read -ra glob_list <<< "$globs_csv"
+
+    {
+      echo "---"
+      echo "description: ${heading_text} language rules"
+      echo "globs:"
+      for glob in "${glob_list[@]}"; do
+        [[ -n "$glob" ]] && printf '  - "%s"\n' "$glob"
+      done
+      echo "---"
+      echo ""
+      autogen_header
+      printf '## %s\n\n%s\n' "$heading_text" "$content"
+    } > "$out_path"
+
+    format_markdown "$out_path"
+    echo "  Created: .agentic/vendor-files/cursor/rules/$out_file"
+  done
+}

--- a/vendors/_schema/adapter.schema.json
+++ b/vendors/_schema/adapter.schema.json
@@ -9,7 +9,7 @@
   "properties": {
     "vendor": {
       "type": "string",
-      "enum": ["claude", "copilot", "codex", "gemini", "opencode"],
+      "enum": ["claude", "copilot", "codex", "gemini", "opencode", "cursor"],
       "description": "The vendor this adapter targets"
     },
     "version": {

--- a/vendors/_schema/capability-matrix.md
+++ b/vendors/_schema/capability-matrix.md
@@ -75,6 +75,11 @@ The agentic library uses a symlink-based vendor switching system:
 4. **Switching**: Only symlinks change — no file movement or copying
 5. **Git**: Symlinks are gitignored; recreate locally via `agentic switch <vendor>`
 
+Cursor-specific switch behavior:
+- Only `.cursor/rules` is managed (rules-only; no `.cursor/skills` support).
+- Existing real `.cursor/rules` directories are migrated to `.cursor/rules.backup`, then `.backup.N`.
+- If switch activation fails mid-run, agentic rolls back prior symlinks/config and restores migrated Cursor rules.
+
 ## Update Log
 
 | Date | Change |
@@ -82,3 +87,4 @@ The agentic library uses a symlink-based vendor switching system:
 | 2026-03-01 | Initial capability matrix created |
 | 2026-03-02 | Added Opencode column; added Gemini awk note |
 | 2026-03-03 | Updated for symlink-based vendor switching; added Codex skills support; documented canonical .agentic/ paths |
+| 2026-05-02 | Documented Cursor rules-only backup migration and rollback-safe switch behavior |

--- a/vendors/cursor/README.md
+++ b/vendors/cursor/README.md
@@ -1,0 +1,13 @@
+# Cursor Adapter
+
+Cursor vendor adapter for `.cursor/rules/*.mdc` output.
+
+- Generated source files live in `.agentic/vendor-files/cursor/rules/`.
+- `agentic switch cursor` only manages the `.cursor/rules` symlink.
+- Unrelated `.cursor/*` files (for example `.cursor/mcp.json`) are preserved.
+
+Not in scope for this adapter:
+
+- `.agentic/providers.yaml` integration
+- `.agentic/mcp.yaml` to `.cursor/mcp.json` translation
+- nested `.cursor/rules` support

--- a/vendors/cursor/README.md
+++ b/vendors/cursor/README.md
@@ -5,6 +5,11 @@ Cursor vendor adapter for `.cursor/rules/*.mdc` output.
 - Generated source files live in `.agentic/vendor-files/cursor/rules/`.
 - `agentic switch cursor` only manages the `.cursor/rules` symlink.
 - Unrelated `.cursor/*` files (for example `.cursor/mcp.json`) are preserved.
+- If a real `.cursor/rules` directory already exists, `agentic switch cursor` migrates it
+  to a deterministic backup path (`.cursor/rules.backup`, then `.cursor/rules.backup.N`)
+  before creating the symlink.
+- Cursor switching is rollback-safe: if a later step fails during multi-vendor activation,
+  prior symlinks, config, and migrated `.cursor/rules` state are restored.
 
 Not in scope for this adapter:
 

--- a/vendors/cursor/adapter.json
+++ b/vendors/cursor/adapter.json
@@ -82,5 +82,5 @@
   "unsupported_sections": [],
   "character_limit_per_file": null,
   "total_character_limit": null,
-  "notes": "Cursor adapter targets .cursor/rules/*.mdc. One always-on core rule is generated and language rules are generated only when matching language sections exist."
+  "notes": "Cursor adapter targets .cursor/rules/*.mdc. One always-on core rule is generated and language rules are generated only when matching language sections exist. Vendor switching manages only .cursor/rules and migrates pre-existing real directories to deterministic backups (.backup, .backup.N) before symlink activation."
 }

--- a/vendors/cursor/adapter.json
+++ b/vendors/cursor/adapter.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "../_schema/adapter.schema.json",
+  "vendor": "cursor",
+  "version": "1.0.0",
+  "output_paths": {
+    "base": ".cursor/rules"
+  },
+  "section_mappings": [
+    {
+      "agents_md_heading": "## Git Conventions",
+      "output_file": "00-core.mdc",
+      "activation_mode": "always-on",
+      "frontmatter": {
+        "alwaysApply": true
+      }
+    },
+    {
+      "agents_md_heading": "## Security",
+      "output_file": "00-core.mdc",
+      "activation_mode": "always-on",
+      "frontmatter": {
+        "alwaysApply": true
+      }
+    },
+    {
+      "agents_md_heading": "## Code Review",
+      "output_file": "00-core.mdc",
+      "activation_mode": "always-on",
+      "frontmatter": {
+        "alwaysApply": true
+      }
+    },
+    {
+      "agents_md_heading": "## Testing Philosophy",
+      "output_file": "00-core.mdc",
+      "activation_mode": "always-on",
+      "frontmatter": {
+        "alwaysApply": true
+      }
+    },
+    {
+      "agents_md_heading": "## Documentation",
+      "output_file": "00-core.mdc",
+      "activation_mode": "always-on",
+      "frontmatter": {
+        "alwaysApply": true
+      }
+    },
+    {
+      "agents_md_heading": "## TypeScript",
+      "output_file": "10-typescript.mdc",
+      "activation_mode": "glob-scoped",
+      "frontmatter": {
+        "globs": ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"]
+      }
+    },
+    {
+      "agents_md_heading": "## Go",
+      "output_file": "20-go.mdc",
+      "activation_mode": "glob-scoped",
+      "frontmatter": {
+        "globs": ["**/*.go"]
+      }
+    },
+    {
+      "agents_md_heading": "## Python",
+      "output_file": "30-python.mdc",
+      "activation_mode": "glob-scoped",
+      "frontmatter": {
+        "globs": ["**/*.py"]
+      }
+    },
+    {
+      "agents_md_heading": "## PHP",
+      "output_file": "40-php.mdc",
+      "activation_mode": "glob-scoped",
+      "frontmatter": {
+        "globs": ["**/*.php"]
+      }
+    }
+  ],
+  "unsupported_sections": [],
+  "character_limit_per_file": null,
+  "total_character_limit": null,
+  "notes": "Cursor adapter targets .cursor/rules/*.mdc. One always-on core rule is generated and language rules are generated only when matching language sections exist."
+}


### PR DESCRIPTION
## Why
Issue #103 adds Cursor as a first-class vendor in Agentic. This follow-up finalizes safe switching behavior when projects already have local Cursor rules.

## What Changed
- Added Cursor backup migration semantics in vendor switch:
  - if `.cursor/rules` is a real file/dir, it is migrated to `.cursor/rules.backup`, then `.cursor/rules.backup.N`.
  - managed symlink is then created to `.agentic/vendor-files/cursor/rules`.
- Added rollback-safe switching:
  - switch snapshots prior managed symlinks/config
  - on failure after mutation begins, it restores prior vendor symlinks and config
  - migrated Cursor rules are restored when needed
- Preserved rules-only Cursor contract:
  - no `.cursor/skills` management introduced

## Reviewer-Gate Fixes Included
- Fixed rollback cleanup bug where partial `GEMINI.md` could remain after failed activation.
- Extended rollback tests to assert Gemini artifacts are fully removed on rollback when not previously active.

## Tests
- `just lint` passed
- `just test` passed (`445/445`)

### Coverage highlights
- Cursor migration and backup naming: `T127B`, `T127C`, `T133`
- Cursor rollback restoration: `T127D`, `T130`
- Rules-only invariant: `T129`, `T131`
- Preservation of unrelated Cursor files: `T127`, `T132`

## Docs/Metadata Updated
- `vendors/cursor/README.md`
- `vendors/cursor/adapter.json`
- `vendors/_schema/capability-matrix.md`
- `docs/vendors.md`
- `docs/commands.md`
- `docs/customization.md`

## Impact
- Backward-compatible for existing vendors.
- Cursor remains additive and rules-only.
- Existing user Cursor rules are preserved via deterministic backups rather than hard-fail.
