### PR TITLE
feat(config): add .agentic/providers.yaml contract scaffold

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -125,6 +125,7 @@ Creates:
 - `.agentic/config.yaml`
 - `.agentic/profile.yaml`
 - `.agentic/mcp.yaml`
+- `.agentic/providers.yaml`
 - `.agentic/project-skills/`
 
 **Examples:**

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -14,7 +14,7 @@ agentic init
 ```
 
 This creates `.agentic/config.yaml`, `.agentic/profile.yaml`,
-`.agentic/mcp.yaml`, and `.agentic/project-skills/`.
+`.agentic/mcp.yaml`, `.agentic/providers.yaml`, and `.agentic/project-skills/`.
 
 ### What You Can Customize
 
@@ -33,6 +33,27 @@ agentic sync
 ```
 
 This re-runs compose with your local profile, regenerates vendor files, and preserves your active vendors.
+
+## Providers Configuration
+
+Optional provider preferences live in `.agentic/providers.yaml`:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/providers.schema.json
+version: "1"
+default_provider: "claude"
+providers:
+  claude:
+    enabled: true
+  cursor:
+    enabled: true
+```
+
+Behavior:
+
+- If `.agentic/providers.yaml` is missing, behavior is unchanged (backward compatible).
+- If present but invalid, `agentic compose` and `agentic sync` fail with a clear error.
+- This file influences runtime pivot preferences only; `AGENTS.md` remains canonical.
 
 ## MCP Configuration (Pivot Model)
 

--- a/schemas/providers.schema.json
+++ b/schemas/providers.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/soulcodex/agentic/schemas/providers.schema.json",
+  "title": "Agentic Providers Config",
+  "description": "Optional project-local provider preferences used for deterministic runtime pivots.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Providers config schema version identifier."
+    },
+    "default_provider": {
+      "type": "string",
+      "enum": ["claude", "copilot", "codex", "gemini", "opencode", "cursor"],
+      "description": "Default provider preference for this project."
+    },
+    "providers": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "claude": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "copilot": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "codex": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "gemini": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "opencode": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "cursor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        }
+      },
+      "description": "Per-provider enablement preferences."
+    }
+  }
+}

--- a/tooling/lib/cli.sh
+++ b/tooling/lib/cli.sh
@@ -145,6 +145,7 @@ Description:
   - .agentic/config.yaml
   - .agentic/profile.yaml
   - .agentic/mcp.yaml
+  - .agentic/providers.yaml
   - .agentic/project-skills/
 
 Examples:

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=tooling/lib/common.sh
 source "$SCRIPT_DIR/common.sh"
+# shellcheck source=tooling/lib/providers.sh
+source "$SCRIPT_DIR/providers.sh"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 LIBRARY=""
@@ -45,6 +47,8 @@ done
 [[ -z "$LIBRARY" ]] && { echo "Error: --library required" >&2; exit 1; }
 [[ -z "$PROFILE" && -z "$PROFILE_FILE" ]] && { echo "Error: --profile or --profile-file required" >&2; exit 1; }
 [[ -z "$TARGET"  ]] && { echo "Error: --target required" >&2; exit 1; }
+
+validate_providers_config "$TARGET"
 
 # ── Profile resolution ────────────────────────────────────────────────────────
 # If --profile-file is provided, use it directly; otherwise lookup by name

--- a/tooling/lib/init.sh
+++ b/tooling/lib/init.sh
@@ -38,10 +38,11 @@ PROJECT_SKILLS_DIR="$AGENTIC_DIR/project-skills"
 CONFIG_FILE="$AGENTIC_DIR/config.yaml"
 PROFILE_FILE="$AGENTIC_DIR/profile.yaml"
 MCP_FILE="$AGENTIC_DIR/mcp.yaml"
+PROVIDERS_FILE="$AGENTIC_DIR/providers.yaml"
 
 mkdir -p "$PROJECT_SKILLS_DIR"
 
-if [[ -e "$CONFIG_FILE" || -e "$PROFILE_FILE" || -e "$MCP_FILE" ]]; then
+if [[ -e "$CONFIG_FILE" || -e "$PROFILE_FILE" || -e "$MCP_FILE" || -e "$PROVIDERS_FILE" ]]; then
   echo "Error: .agentic skeleton already exists in $TARGET" >&2
   echo "Refusing to overwrite existing files. Remove them manually if needed." >&2
   exit 1
@@ -114,10 +115,18 @@ strategy: merge
 servers: {}
 EOF
 
+cat > "$PROVIDERS_FILE" <<'EOF'
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/providers.schema.json
+version: "1"
+default_provider: ""
+providers: {}
+EOF
+
 echo "Initialized .agentic skeleton in: $TARGET/.agentic"
 echo "  - config.yaml"
 echo "  - profile.yaml"
 echo "  - mcp.yaml"
+echo "  - providers.yaml"
 echo "  - project-skills/"
 
 run_sync=false

--- a/tooling/lib/providers.sh
+++ b/tooling/lib/providers.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# providers.sh — Optional providers.yaml validation helpers
+# Sourced by: compose.sh, sync.sh
+
+# shellcheck source=tooling/lib/common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+validate_providers_config() {
+  local target="$1"
+  local providers_file="$target/.agentic/providers.yaml"
+
+  [[ ! -f "$providers_file" ]] && return 0
+
+  if ! yq -e '.' "$providers_file" > /dev/null 2>&1; then
+    echo "Error: Invalid YAML in $providers_file" >&2
+    return 1
+  fi
+
+  local default_provider
+  default_provider=$(yq '.default_provider // ""' "$providers_file" 2>/dev/null || echo "")
+  if [[ -n "$default_provider" && "$default_provider" != "null" && "$default_provider" != "\"\"" ]]; then
+    local is_valid=false
+    local vendor
+    for vendor in "${AGENTIC_VENDORS[@]}"; do
+      if [[ "$default_provider" == "$vendor" ]]; then
+        is_valid=true
+        break
+      fi
+    done
+    if [[ "$is_valid" != "true" ]]; then
+      echo "Error: Invalid default_provider '$default_provider' in $providers_file" >&2
+      return 1
+    fi
+  fi
+
+  local provider_keys=()
+  while IFS= read -r provider; do
+    [[ -z "$provider" || "$provider" == "null" ]] && continue
+    provider_keys+=("$provider")
+  done < <(yq '.providers | keys | .[]' "$providers_file" 2>/dev/null || true)
+
+  local key
+  for key in "${provider_keys[@]}"; do
+    local valid_key=false
+    local vendor
+    for vendor in "${AGENTIC_VENDORS[@]}"; do
+      if [[ "$key" == "$vendor" ]]; then
+        valid_key=true
+        break
+      fi
+    done
+    if [[ "$valid_key" != "true" ]]; then
+      echo "Error: Invalid provider key '$key' in $providers_file" >&2
+      return 1
+    fi
+
+    local enabled_type
+    enabled_type=$(yq ".providers.\"$key\".enabled | type" "$providers_file" 2>/dev/null || echo "!!null")
+    if [[ "$enabled_type" != "!!null" && "$enabled_type" != "!!bool" ]]; then
+      echo "Error: providers.$key.enabled must be boolean in $providers_file" >&2
+      return 1
+    fi
+  done
+
+  return 0
+}

--- a/tooling/lib/sync.sh
+++ b/tooling/lib/sync.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=tooling/lib/common.sh
 source "$SCRIPT_DIR/common.sh"
+# shellcheck source=tooling/lib/providers.sh
+source "$SCRIPT_DIR/providers.sh"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 TARGET=""
@@ -35,6 +37,8 @@ LOCAL_PROFILE="$TARGET/.agentic/profile.yaml"
   echo "Error: $LOCAL_PROFILE not found. Run 'just compose' first to copy the profile." >&2
   exit 1
 }
+
+validate_providers_config "$TARGET"
 
 # ── Resolve library path ────────────────────────────────────────────────────────
 # Use discover_library_from_target function which reads from target's config

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2214,6 +2214,7 @@ AGENTIC_REPO_ROOT="$LIBRARY" "$CLI" init "$TMP/t99" --no-sync > /dev/null 2>&1
 assert_file_exists "$TMP/t99/.agentic/config.yaml" "T99 config"
 assert_file_exists "$TMP/t99/.agentic/profile.yaml" "T99 profile"
 assert_file_exists "$TMP/t99/.agentic/mcp.yaml" "T99 mcp"
+assert_file_exists "$TMP/t99/.agentic/providers.yaml" "T99 providers"
 if [[ -d "$TMP/t99/.agentic/project-skills" ]]; then
   pass "T99 project-skills directory exists"
 else
@@ -2225,6 +2226,7 @@ run_test "T100 — init: YAML schema headers are present"
 assert_file_contains "$TMP/t99/.agentic/config.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/config.schema.json" "T100 config schema"
 assert_file_contains "$TMP/t99/.agentic/profile.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json" "T100 profile schema"
 assert_file_contains "$TMP/t99/.agentic/mcp.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/mcp.schema.json" "T100 mcp schema"
+assert_file_contains "$TMP/t99/.agentic/providers.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/providers.schema.json" "T100 providers schema"
 
 # T101 — init --sync: scaffolds and composes immediately
 run_test "T101 — init --sync composes project"
@@ -2314,6 +2316,59 @@ assert_exit_code 0 "$T103_EXIT" "T103"
 assert_stdout_contains "$T103_OUTPUT" "Deprecated MCP declaration in profile detected" "T103 warning"
 assert_file_exists "$TMP/t103/.mcp.json" "T103 mcp json"
 assert_file_contains "$TMP/t103/.mcp.json" "legacy-only" "T103 legacy server seeded"
+
+# T103B — compose: invalid providers.yaml fails clearly
+run_test "T103B — compose: invalid providers config fails"
+mkdir -p "$TMP/t103b/.agentic"
+cat > "$TMP/t103b/.agentic/providers.yaml" <<'EOF'
+version: "1"
+default_provider: "not-a-vendor"
+providers: {}
+EOF
+cat > "$TMP/t103b-profile.yaml" <<'EOF'
+meta:
+  name: Test Providers Validation
+  description: Test providers validation
+  version: "1.0.0"
+fragments:
+  base:
+    - git-conventions
+output:
+  build_command: ""
+  test_command: ""
+  lint_command: ""
+vendors:
+  enabled: []
+EOF
+T103B_EXIT=0
+T103B_OUTPUT=$(bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile-file "$TMP/t103b-profile.yaml" \
+  --target "$TMP/t103b" \
+  2>&1) || T103B_EXIT=$?
+assert_exit_code 1 "$T103B_EXIT" "T103B"
+assert_stdout_contains "$T103B_OUTPUT" "Invalid default_provider" "T103B"
+
+# T103C — sync: invalid providers.yaml fails clearly
+run_test "T103C — sync: invalid providers config fails"
+mkdir -p "$TMP/t103c"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103c" \
+  > /dev/null 2>&1
+cat > "$TMP/t103c/.agentic/providers.yaml" <<'EOF'
+version: "1"
+providers:
+  claude:
+    enabled: "yes"
+EOF
+T103C_EXIT=0
+T103C_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103c" \
+  2>&1) || T103C_EXIT=$?
+assert_exit_code 1 "$T103C_EXIT" "T103C"
+assert_stdout_contains "$T103C_OUTPUT" "must be boolean" "T103C"
 
 # T104 — compose: standalone typescript-react-spa profile
 run_test "T104 — compose: standalone typescript-react-spa profile"


### PR DESCRIPTION
Closes #120

Summary
- add optional .agentic/providers.yaml project config scaffolded by agentic init
- add schemas/providers.schema.json and schema header in scaffolded file
- add tooling/lib/providers.sh validation helper
- validate providers config in compose and sync (no-op when file is absent)
- update CLI/docs to include providers file in init/customization docs

Backward compatibility
- if .agentic/providers.yaml is missing, behavior is unchanged
- only invalid provider config now fails fast with actionable errors

Validation
- just lint
- just test (451/451)

Tests added
- T99/T100 extended to assert providers scaffold + schema header
- T103B: compose fails on invalid default_provider
- T103C: sync fails when providers.<vendor>.enabled is non-boolean
