### PR TITLE
feat(mcp): seed .cursor/mcp.json from .agentic/mcp.yaml

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -74,6 +74,7 @@ servers:
 - `.mcp.json` (Claude shape)
 - `opencode.json` (`mcp` block translation)
 - `.gemini/settings.json` (`mcpServers` translation)
+- `.cursor/mcp.json` (`mcpServers` translation)
 
 If `.agentic/mcp.yaml` is missing, legacy `mcp:` under `.agentic/profile.yaml`
 is still supported for backward compatibility, but deprecated.

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -78,6 +78,7 @@ Generated targets:
 - `.mcp.json` uses `mcpServers` (Claude-compatible shape)
 - `opencode.json` uses `mcp` with translated transport keys
 - `.gemini/settings.json` uses `mcpServers` with Gemini-specific field mapping
+- `.cursor/mcp.json` uses `mcpServers` (Cursor-compatible project shape)
 
 Precedence and compatibility:
 

--- a/tooling/lib/mcp.sh
+++ b/tooling/lib/mcp.sh
@@ -28,6 +28,7 @@ done
 MCP_FILE="$TARGET/.mcp.json"
 OPENCODE_FILE="$TARGET/opencode.json"
 GEMINI_SETTINGS="$TARGET/.gemini/settings.json"
+CURSOR_MCP_FILE="$TARGET/.cursor/mcp.json"
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -363,6 +364,55 @@ action_seed() {
     final_json=$(printf '{"mcpServers": %s}' "$updated_servers")
     write_json "$mcp_file" "$final_json"
     echo "  ✔  Seeded ${#server_names[@]} server(s) to .mcp.json (strategy: $strategy)"
+  fi
+
+  # ── Seed .cursor/mcp.json (Cursor) ───────────────────────────────────
+  local cursor_mcp_file="$CURSOR_MCP_FILE"
+  if [[ -f "$cursor_mcp_file" ]]; then
+    if ! jq -e '.mcpServers // {}' "$cursor_mcp_file" > /dev/null 2>&1; then
+      echo "Error: existing .cursor/mcp.json is invalid JSON; refusing to overwrite" >&2
+      exit 1
+    fi
+  fi
+  if [[ -f "$cursor_mcp_file" || "$strategy" == "replace" || "${#server_names[@]}" -gt 0 ]]; then
+    local existing_cursor updated_cursor
+    existing_cursor="{}"
+    if [[ -f "$cursor_mcp_file" ]]; then
+      existing_cursor=$(jq '.mcpServers // {}' "$cursor_mcp_file")
+    fi
+
+    if [[ "$strategy" == "replace" ]]; then
+      updated_cursor="{}"
+      local name
+      for name in "${server_names[@]}"; do
+        local server_yaml server_json
+        server_yaml=$(yq -r "${servers_expr}[\"$name\"]" "$source_file" 2>/dev/null || echo "")
+        if [[ -n "$server_yaml" && "$server_yaml" != "null" ]]; then
+          server_json=$(echo "$server_yaml" | yq -o json '.' 2>/dev/null || echo "{}")
+          updated_cursor=$(printf '%s' "$updated_cursor" | jq --arg n "$name" --argjson s "$server_json" '. + {($n): $s}')
+        fi
+      done
+    else
+      local name
+      for name in "${server_names[@]}"; do
+        local exists
+        exists=$(jq -r --arg n "$name" 'has($n)' "$existing_cursor" 2>/dev/null || echo "false")
+        if [[ "$exists" == "false" ]]; then
+          local server_yaml server_json
+          server_yaml=$(yq -r "${servers_expr}[\"$name\"]" "$source_file" 2>/dev/null || echo "")
+          if [[ -n "$server_yaml" && "$server_yaml" != "null" ]]; then
+            server_json=$(echo "$server_yaml" | yq -o json '.' 2>/dev/null || echo "{}")
+            existing_cursor=$(printf '%s' "$existing_cursor" | jq --arg n "$name" --argjson s "$server_json" '. + {($n): $s}')
+          fi
+        fi
+      done
+      updated_cursor="$existing_cursor"
+    fi
+
+    local final_cursor_json
+    final_cursor_json=$(printf '{"mcpServers": %s}' "$updated_cursor")
+    write_json "$cursor_mcp_file" "$final_cursor_json"
+    echo "  ✔  Seeded ${#server_names[@]} server(s) to .cursor/mcp.json (strategy: $strategy)"
   fi
 
   # ── Helper: translate a profile server entry to Opencode format ─────────

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -1442,6 +1442,8 @@ assert_file_contains "$TMP/t68/opencode.json" '"environment"' "T68"
 run_test "T69 — compose: MCP seed translates for .gemini/settings.json"
 mkdir -p "$TMP/t69/.gemini"
 echo '{"mcpServers":{}}' > "$TMP/t69/.gemini/settings.json"
+mkdir -p "$TMP/t69/.cursor"
+echo '{"mcpServers":{}}' > "$TMP/t69/.cursor/mcp.json"
 
 cat > "$TMP/t69-profile.yaml" <<'EOF'
 meta:
@@ -1475,6 +1477,9 @@ assert_file_contains "$TMP/t69/.gemini/settings.json" "http-server" "T69"
 assert_file_contains "$TMP/t69/.gemini/settings.json" "httpUrl" "T69"
 # Should NOT contain 'type' field
 assert_file_not_contains "$TMP/t69/.gemini/settings.json" '"type"' "T69"
+assert_file_exists "$TMP/t69/.cursor/mcp.json" "T69 cursor"
+assert_file_contains "$TMP/t69/.cursor/mcp.json" "http-server" "T69 cursor server"
+assert_file_contains "$TMP/t69/.cursor/mcp.json" '"mcpServers"' "T69 cursor shape"
 
 # T70 — compose: MCP merge strategy preserves existing servers
 run_test "T70 — compose: MCP merge preserves existing servers"
@@ -1518,6 +1523,8 @@ assert_file_contains "$TMP/t70/.mcp.json" "new-server" "T70"
 run_test "T71 — compose: MCP replace removes old servers"
 mkdir -p "$TMP/t71"
 echo '{"mcpServers":{"old-server":{"type":"stdio","command":"old","args":["old"]}}}' > "$TMP/t71/.mcp.json"
+mkdir -p "$TMP/t71/.cursor"
+echo '{"mcpServers":{"old-server":{"type":"stdio","command":"old","args":["old"]}}}' > "$TMP/t71/.cursor/mcp.json"
 
 cat > "$TMP/t71-profile.yaml" <<'EOF'
 meta:
@@ -1549,6 +1556,43 @@ bash "$COMPOSE" \
 
 assert_file_contains "$TMP/t71/.mcp.json" "brand-new" "T71"
 assert_file_not_contains "$TMP/t71/.mcp.json" "old-server" "T71"
+assert_file_contains "$TMP/t71/.cursor/mcp.json" "brand-new" "T71 cursor"
+assert_file_not_contains "$TMP/t71/.cursor/mcp.json" "old-server" "T71 cursor replace"
+
+# T71B — compose: invalid existing .cursor/mcp.json fails safely
+run_test "T71B — compose: invalid .cursor/mcp.json fails"
+mkdir -p "$TMP/t71b/.cursor"
+cat > "$TMP/t71b-profile.yaml" <<'EOF'
+meta:
+  name: Test Cursor MCP Invalid
+  description: Test invalid existing cursor mcp json
+  version: "1.0.0"
+fragments:
+  base:
+    - git-conventions
+output:
+  build_command: ""
+  test_command: ""
+  lint_command: ""
+vendors:
+  enabled: []
+mcp:
+  strategy: merge
+  servers:
+    server-a:
+      type: stdio
+      command: npx
+      args: ["-y", "foo"]
+EOF
+printf '%s\n' '{invalid' > "$TMP/t71b/.cursor/mcp.json"
+T71B_EXIT=0
+T71B_OUTPUT=$(bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile-file "$TMP/t71b-profile.yaml" \
+  --target "$TMP/t71b" \
+  2>&1) || T71B_EXIT=$?
+assert_exit_code 1 "$T71B_EXIT" "T71B"
+assert_stdout_contains "$T71B_OUTPUT" "existing .cursor/mcp.json is invalid JSON" "T71B error"
 
 # T72 — compose: profile without mcp key produces no MCP files
 run_test "T72 — compose: profile without mcp key is no-op"

--- a/vendors/cursor/README.md
+++ b/vendors/cursor/README.md
@@ -14,5 +14,4 @@ Cursor vendor adapter for `.cursor/rules/*.mdc` output.
 Not in scope for this adapter:
 
 - `.agentic/providers.yaml` integration
-- `.agentic/mcp.yaml` to `.cursor/mcp.json` translation
 - nested `.cursor/rules` support


### PR DESCRIPTION
Closes #121

Summary
- extend MCP seeding to generate/update .cursor/mcp.json from canonical .agentic/mcp.yaml (and legacy profile fallback path)
- keep .cursor/mcp.json out of vendor-switch symlink management
- preserve existing merge/replace semantics used by other seeded targets
- fail safely when existing .cursor/mcp.json is invalid JSON

Implementation
- tooling/lib/mcp.sh: add Cursor seeding path using mcpServers shape
- tests added/updated in tooling/lib/test.sh:
  - T69: cursor seeding in merge flow
  - T71: cursor replace flow removes old server keys
  - T71B: invalid existing .cursor/mcp.json causes clear failure
- docs updates:
  - docs/customization.md MCP generated targets includes .cursor/mcp.json
  - docs/vendors.md MCP pivot model includes .cursor/mcp.json target
  - vendors/cursor/README.md removes outdated 'out-of-scope' note for MCP translation

Validation
- just lint
- just test (452/452)

Guardrails
- no .cursor/mcp.json symlink behavior added
- no change to AGENTS.md canonical instruction model