### PR TITLE
feat(vendors): generate nested Cursor tier rules

### DIFF
--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -59,6 +59,8 @@ Opencode reads `AGENTS.md` natively. Skills are deployed to `.opencode/skills/`.
 Cursor uses `.cursor/rules/*.mdc`. The adapter generates files into
 `.agentic/vendor-files/cursor/rules/`, then `agentic switch cursor` symlinks only
 `.cursor/rules`. This preserves unrelated `.cursor/*` files such as `.cursor/mcp.json`.
+For nested profiles, vendor-gen also emits tier-specific rule trees under
+`.agentic/vendor-files/cursor/rules/<tier>/`.
 If a real `.cursor/rules` directory already exists, switch migrates it to
 `.cursor/rules.backup` (or `.cursor/rules.backup.N`) before linking.
 If a multi-vendor switch fails after mutation begins, agentic rolls back prior

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2962,6 +2962,23 @@ bash "$VENDOR_SWITCH" \
 assert_file_exists "$TMP/t133/.cursor/rules.backup/first.mdc" "T133 first backup"
 assert_file_exists "$TMP/t133/.cursor/rules.backup.1/second.mdc" "T133 second backup"
 
+# T134 — vendor-gen: nested profile generates tier-specific cursor rules
+run_test "T134 — vendor-gen: nested cursor rules generation"
+mkdir -p "$TMP/t134"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-next-ui \
+  --target "$TMP/t134" \
+  > /dev/null 2>&1
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t134" \
+  --vendors cursor \
+  > /dev/null 2>&1
+assert_file_exists "$TMP/t134/.agentic/vendor-files/cursor/rules/00-core.mdc" "T134 root core"
+assert_file_exists "$TMP/t134/.agentic/vendor-files/cursor/rules/backend/00-core.mdc" "T134 backend core"
+assert_file_exists "$TMP/t134/.agentic/vendor-files/cursor/rules/ui/00-core.mdc" "T134 ui core"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "────────────────────────────────────────"

--- a/tooling/lib/vendors/cursor.sh
+++ b/tooling/lib/vendors/cursor.sh
@@ -6,10 +6,41 @@ gen_cursor() {
   local vendor_dir="$VENDOR_FILES_DIR/cursor"
   local rules_dir="$vendor_dir/rules"
   local adapter="$LIBRARY/vendors/cursor/adapter.json"
+  local lock_file="$TARGET/.agentic/config.yaml"
+  local structure="flat"
 
   mkdir -p "$rules_dir"
+  if [[ -f "$lock_file" ]]; then
+    structure=$(yq '.structure // "flat"' "$lock_file" 2>/dev/null || echo "flat")
+    [[ "$structure" == "null" ]] && structure="flat"
+  fi
 
-  local core_file="$rules_dir/00-core.mdc"
+  generate_cursor_ruleset "$rules_dir" "root"
+  echo "  Created: .agentic/vendor-files/cursor/rules/00-core.mdc"
+
+  if [[ "$structure" == "nested" ]]; then
+    local tiers=()
+    while IFS= read -r _tier; do
+      [[ -n "$_tier" && "$_tier" != "null" ]] && tiers+=("$_tier")
+    done < <(yq '.tiers[]' "$lock_file" 2>/dev/null || true)
+
+    local tier
+    for tier in "${tiers[@]}"; do
+      local tier_agents="$TARGET/$tier/AGENTS.md"
+      [[ -f "$tier_agents" ]] || continue
+      local tier_rules_dir="$rules_dir/$tier"
+      mkdir -p "$tier_rules_dir"
+      generate_cursor_ruleset "$tier_rules_dir" "$tier_agents"
+      echo "  Created: .agentic/vendor-files/cursor/rules/$tier/00-core.mdc"
+    done
+  fi
+}
+
+generate_cursor_ruleset() {
+  local out_dir="$1"
+  local source="$2" # "root" or path to AGENTS.md
+  local adapter="$LIBRARY/vendors/cursor/adapter.json"
+  local core_file="$out_dir/00-core.mdc"
   {
     echo "---"
     echo "description: Global engineering conventions"
@@ -20,20 +51,19 @@ gen_cursor() {
 
     jq -r '.section_mappings[] | select(.activation_mode == "always-on") | .agents_md_heading' "$adapter" | \
     sed 's/^## //' | while read -r heading; do
-      content=$(get_section_content "$heading")
+      content=$(get_cursor_section_content "$heading" "$source")
       [[ -n "$content" ]] && printf '\n## %s\n\n%s\n' "$heading" "$content"
-    done
+    done || true
   } > "$core_file"
   format_markdown "$core_file"
-  echo "  Created: .agentic/vendor-files/cursor/rules/00-core.mdc"
 
   jq -r '.section_mappings[] | select(.activation_mode == "glob-scoped") | [.agents_md_heading, .output_file, (.frontmatter.globs // [] | join(","))] | @tsv' "$adapter" | \
   while IFS=$'\t' read -r heading out_file globs_csv; do
     heading_text="${heading#\## }"
-    content=$(get_section_content "$heading_text")
+    content=$(get_cursor_section_content "$heading_text" "$source")
     [[ -z "$content" ]] && continue
 
-    local out_path="$rules_dir/$out_file"
+    local out_path="$out_dir/$out_file"
     IFS=',' read -ra glob_list <<< "$globs_csv"
 
     {
@@ -50,6 +80,21 @@ gen_cursor() {
     } > "$out_path"
 
     format_markdown "$out_path"
-    echo "  Created: .agentic/vendor-files/cursor/rules/$out_file"
-  done
+    if [[ "$source" == "root" ]]; then
+      echo "  Created: .agentic/vendor-files/cursor/rules/$out_file"
+    else
+      echo "  Created: .agentic/vendor-files/cursor/rules/$(basename "$out_dir")/$out_file"
+    fi
+  done || true
+}
+
+get_cursor_section_content() {
+  local heading="$1"
+  local source="$2"
+
+  if [[ "$source" == "root" ]]; then
+    get_section_content "$heading"
+  else
+    extract_section "$heading" "$source"
+  fi
 }

--- a/vendors/cursor/README.md
+++ b/vendors/cursor/README.md
@@ -3,6 +3,8 @@
 Cursor vendor adapter for `.cursor/rules/*.mdc` output.
 
 - Generated source files live in `.agentic/vendor-files/cursor/rules/`.
+- In nested profiles, additional tier rules are generated under
+  `.agentic/vendor-files/cursor/rules/<tier>/`.
 - `agentic switch cursor` only manages the `.cursor/rules` symlink.
 - Unrelated `.cursor/*` files (for example `.cursor/mcp.json`) are preserved.
 - If a real `.cursor/rules` directory already exists, `agentic switch cursor` migrates it


### PR DESCRIPTION
## Summary
Implements issue #122 by extending the Cursor adapter to generate nested tier-specific rule outputs when composing nested profiles.

Closes #122.

## Changes
- Added nested profile support in `tooling/lib/vendors/cursor.sh`:
  - Detects `structure: nested` from `.agentic/config.yaml`.
  - Reads configured tiers and generates per-tier rules under:
    - `.agentic/vendor-files/cursor/rules/<tier>/`
  - Reuses common rule generation via `generate_cursor_ruleset` for root and tier sources.
- Added regression coverage in `tooling/lib/test.sh`:
  - `T134` verifies root + backend + ui `00-core.mdc` generation for `typescript-hexagonal-next-ui`.
- Updated docs:
  - `docs/vendors.md`
  - `vendors/cursor/README.md`
  - Documents nested tier rule output path.

## Important fix detail
While adding nested generation, `vendor-gen` could exit early under `set -euo pipefail` when a tier had no matching rule sections in a pipeline loop. This PR hardens both section loops with non-fatal handling (`done || true`) so nested generation completes across all tiers.

## Validation
- `just lint` ✅
- `just test` ✅ (`461/461`)
