### PR TITLE
feat(vendors): manifest-driven Cursor multi-path switch and rollback

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -160,9 +160,10 @@ agentic switch list                # Show available vendors
 ```
 
 Cursor-specific behavior:
-- `switch` manages only `.cursor/rules` (no `.cursor/skills` behavior).
-- If `.cursor/rules` is a real directory, it is migrated to deterministic backups:
-  `.cursor/rules.backup`, then `.cursor/rules.backup.N`.
+- `switch` uses `.agentic/vendor-files/cursor/switch-manifest.json` to manage one or more
+  Cursor rule paths (for example `.cursor/rules`, `backend/.cursor/rules`, `ui/.cursor/rules`).
+- If a managed Cursor rules path is a real directory, it is migrated to deterministic backups:
+  `<path>.backup`, then `<path>.backup.N`.
 - If activation fails mid-switch, agentic rolls back to the prior symlink/config state.
 
 ### sync

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -246,10 +246,12 @@ are gitignored automatically.
 > `.gemini/system.md`, `.cursor/rules`, etc.) are always gitignored in both modes — they are always
 > regenerated and have no standalone value in git history.
 >
-> For Cursor specifically, `agentic switch cursor` only manages `.cursor/rules`. If a
-> real `.cursor/rules` directory exists, agentic migrates it to
-> `.cursor/rules.backup` (or `.backup.N`) before linking, and restores it if switch
-> activation later fails and triggers rollback.
+> For Cursor specifically, `agentic switch cursor` reads
+> `.agentic/vendor-files/cursor/switch-manifest.json` and manages all declared Cursor rule
+> paths (for example `.cursor/rules`, `backend/.cursor/rules`, `ui/.cursor/rules`).
+> If any managed path already exists as a real directory, agentic migrates it to
+> `<path>.backup` (or `.backup.N`) before linking, and restores prior state if activation
+> later fails and triggers rollback.
 
 ### Switching between modes
 

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2979,6 +2979,60 @@ assert_file_exists "$TMP/t134/.agentic/vendor-files/cursor/rules/00-core.mdc" "T
 assert_file_exists "$TMP/t134/.agentic/vendor-files/cursor/rules/backend/00-core.mdc" "T134 backend core"
 assert_file_exists "$TMP/t134/.agentic/vendor-files/cursor/rules/ui/00-core.mdc" "T134 ui core"
 
+# T135 — vendor-switch: cursor uses manifest-driven multi-path symlinks
+run_test "T135 — vendor-switch: cursor manifest multi-path activation"
+mkdir -p "$TMP/t135"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-next-ui \
+  --target "$TMP/t135" \
+  > /dev/null 2>&1
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t135" \
+  --vendors cursor \
+  > /dev/null 2>&1
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t135" \
+  cursor \
+  > /dev/null 2>&1
+assert_file_exists "$TMP/t135/.agentic/vendor-files/cursor/switch-manifest.json" "T135 manifest"
+assert_symlink_exists "$TMP/t135/.cursor/rules" "T135 root symlink"
+assert_symlink_exists "$TMP/t135/backend/.cursor/rules" "T135 backend symlink"
+assert_symlink_exists "$TMP/t135/ui/.cursor/rules" "T135 ui symlink"
+
+# T136 — vendor-switch: cursor multi-path failure rolls back cleanly
+run_test "T136 — vendor-switch: cursor multi-path rollback on partial failure"
+mkdir -p "$TMP/t136"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-next-ui \
+  --target "$TMP/t136" \
+  > /dev/null 2>&1
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t136" \
+  --vendors claude,cursor \
+  > /dev/null 2>&1
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t136" \
+  claude \
+  > /dev/null 2>&1
+printf '%s\n' "blocker" > "$TMP/t136/ui/.cursor"
+T136_OUTPUT=$(bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t136" \
+  cursor 2>&1) || T136_EXIT=$?
+T136_EXIT=${T136_EXIT:-0}
+assert_exit_code 1 "$T136_EXIT" "T136"
+assert_stdout_contains "$T136_OUTPUT" "rolling back state" "T136 rollback message"
+assert_symlink_exists "$TMP/t136/CLAUDE.md" "T136 claude restored"
+assert_file_not_exists "$TMP/t136/.cursor/rules" "T136 root cursor link removed"
+assert_file_not_exists "$TMP/t136/backend/.cursor/rules" "T136 backend cursor link removed"
+assert_file_contains "$TMP/t136/ui/.cursor" "blocker" "T136 blocker file preserved"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "────────────────────────────────────────"

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -44,7 +44,9 @@ ROLLBACK_DIR="$TARGET/.agentic/.switch-rollback"
 ROLLBACK_LINKS_FILE="$ROLLBACK_DIR/links.tsv"
 ROLLBACK_CONFIG_FILE="$ROLLBACK_DIR/config.yaml"
 ROLLBACK_CURSOR_MOVES_FILE="$ROLLBACK_DIR/cursor-moves.tsv"
+CURSOR_SWITCH_MANIFEST="$VENDOR_FILES_DIR/cursor/switch-manifest.json"
 SWITCH_COMMITTED=0
+CURSOR_MANAGED_PATHS=()
 
 # Use AGENTIC_VENDORS from common.sh (single source of truth)
 
@@ -120,6 +122,34 @@ migrate_active_vendor_format() {
   fi
 }
 
+add_cursor_managed_path() {
+  local rel_path="$1"
+  [[ -z "$rel_path" || "$rel_path" == "null" ]] && return
+  local existing
+  for existing in "${CURSOR_MANAGED_PATHS[@]}"; do
+    [[ "$existing" == "$rel_path" ]] && return
+  done
+  CURSOR_MANAGED_PATHS+=("$rel_path")
+}
+
+load_cursor_managed_paths() {
+  CURSOR_MANAGED_PATHS=()
+  add_cursor_managed_path ".cursor/rules"
+
+  if [[ -f "$CURSOR_SWITCH_MANIFEST" ]] && jq -e '.managed_paths | type == "array"' "$CURSOR_SWITCH_MANIFEST" > /dev/null 2>&1; then
+    local rel_path
+    while IFS= read -r rel_path; do
+      add_cursor_managed_path "$rel_path"
+    done < <(jq -r '.managed_paths[]?.target // empty' "$CURSOR_SWITCH_MANIFEST")
+  fi
+
+  local existing_cursor_symlink
+  while IFS= read -r existing_cursor_symlink; do
+    existing_cursor_symlink="${existing_cursor_symlink#"$TARGET"/}"
+    add_cursor_managed_path "$existing_cursor_symlink"
+  done < <(find "$TARGET" -type l -path '*/.cursor/rules' 2>/dev/null || true)
+}
+
 record_cursor_backup_move() {
   local original="$1"
   local backup="$2"
@@ -128,13 +158,14 @@ record_cursor_backup_move() {
 }
 
 prepare_cursor_rules_path() {
-  local cursor_rules="$TARGET/.cursor/rules"
+  local rel_path="$1"
+  local cursor_rules="$TARGET/$rel_path"
   if [[ -e "$cursor_rules" && ! -L "$cursor_rules" ]]; then
     local backup_path
     backup_path="$(next_backup_path "$cursor_rules")"
     mv "$cursor_rules" "$backup_path"
     record_cursor_backup_move "$cursor_rules" "$backup_path"
-    echo "  Migrated: .cursor/rules → ${backup_path#"$TARGET"/}"
+    echo "  Migrated: $rel_path → ${backup_path#"$TARGET"/}"
   fi
 }
 
@@ -149,8 +180,12 @@ snapshot_current_switch_state() {
     "$TARGET/.claude/skills"
     "$TARGET/.opencode/skills"
     "$TARGET/.agents/skills"
-    "$TARGET/.cursor/rules"
   )
+
+  local cursor_rel_path
+  for cursor_rel_path in "${CURSOR_MANAGED_PATHS[@]}"; do
+    managed_paths+=("$TARGET/$cursor_rel_path")
+  done
 
   rm -rf "$ROLLBACK_DIR"
   mkdir -p "$ROLLBACK_DIR"
@@ -235,7 +270,11 @@ remove_all_vendor_symlinks() {
   [[ -L "$TARGET/.claude/skills" ]] && rm "$TARGET/.claude/skills"
   [[ -L "$TARGET/.opencode/skills" ]] && rm "$TARGET/.opencode/skills"
   [[ -L "$TARGET/.agents/skills" ]] && rm "$TARGET/.agents/skills"
-  [[ -L "$TARGET/.cursor/rules" ]] && rm "$TARGET/.cursor/rules"
+  local cursor_rel_path cursor_abs_path
+  for cursor_rel_path in "${CURSOR_MANAGED_PATHS[@]}"; do
+    cursor_abs_path="$TARGET/$cursor_rel_path"
+    [[ -L "$cursor_abs_path" ]] && rm "$cursor_abs_path"
+  done
   
   # Clean up empty directories (only if they exist and are empty)
   [[ -d "$TARGET/.github/instructions" ]] && rmdir "$TARGET/.github/instructions" 2>/dev/null || true
@@ -317,7 +356,17 @@ create_vendor_symlinks() {
       fi
       ;;
     cursor)
-      if [[ -d "$VENDOR_FILES_DIR/cursor/rules" ]]; then
+      if [[ -f "$CURSOR_SWITCH_MANIFEST" ]] && jq -e '.managed_paths | type == "array"' "$CURSOR_SWITCH_MANIFEST" > /dev/null 2>&1; then
+        local rel_target rel_source abs_target abs_source
+        while IFS=$'\t' read -r rel_target rel_source; do
+          [[ -z "$rel_target" || -z "$rel_source" ]] && continue
+          abs_target="$TARGET/$rel_target"
+          abs_source="$TARGET/$rel_source"
+          mkdir -p "$(dirname "$abs_target")"
+          ln -sfn "$abs_source" "$abs_target"
+          echo "    Linked: $rel_target → $rel_source"
+        done < <(jq -r '.managed_paths[]? | [.target, .source] | @tsv' "$CURSOR_SWITCH_MANIFEST")
+      elif [[ -d "$VENDOR_FILES_DIR/cursor/rules" ]]; then
         mkdir -p "$TARGET/.cursor"
         ln -sfn "../.agentic/vendor-files/cursor/rules" "$TARGET/.cursor/rules"
         echo "    Linked: .cursor/rules → ../.agentic/vendor-files/cursor/rules"
@@ -331,7 +380,10 @@ preflight_vendor_conflicts() {
   local vendor="$1"
   case "$vendor" in
     cursor)
-      prepare_cursor_rules_path
+      local rel_path
+      for rel_path in "${CURSOR_MANAGED_PATHS[@]}"; do
+        prepare_cursor_rules_path "$rel_path"
+      done
       ;;
   esac
 }
@@ -375,6 +427,7 @@ for vendor in "${VENDORS[@]}"; do
   fi
 done
 
+load_cursor_managed_paths
 snapshot_current_switch_state
 trap on_switch_exit EXIT
 

--- a/tooling/lib/vendors/cursor.sh
+++ b/tooling/lib/vendors/cursor.sh
@@ -5,9 +5,10 @@ gen_cursor() {
   echo "  Generating Cursor adapter..."
   local vendor_dir="$VENDOR_FILES_DIR/cursor"
   local rules_dir="$vendor_dir/rules"
-  local adapter="$LIBRARY/vendors/cursor/adapter.json"
   local lock_file="$TARGET/.agentic/config.yaml"
+  local manifest_file="$vendor_dir/switch-manifest.json"
   local structure="flat"
+  local manifest_entries='[{"target":".cursor/rules","source":".agentic/vendor-files/cursor/rules"}]'
 
   mkdir -p "$rules_dir"
   if [[ -f "$lock_file" ]]; then
@@ -31,9 +32,13 @@ gen_cursor() {
       local tier_rules_dir="$rules_dir/$tier"
       mkdir -p "$tier_rules_dir"
       generate_cursor_ruleset "$tier_rules_dir" "$tier_agents"
+      manifest_entries=$(printf '%s' "$manifest_entries" | jq --arg t "$tier" '. + [{"target":($t + "/.cursor/rules"),"source":(".agentic/vendor-files/cursor/rules/" + $t)}]')
       echo "  Created: .agentic/vendor-files/cursor/rules/$tier/00-core.mdc"
     done
   fi
+
+  jq -n --argjson managed "$manifest_entries" '{version: 1, managed_paths: $managed}' > "$manifest_file"
+  echo "  Created: .agentic/vendor-files/cursor/switch-manifest.json"
 }
 
 generate_cursor_ruleset() {

--- a/vendors/cursor/README.md
+++ b/vendors/cursor/README.md
@@ -5,15 +5,15 @@ Cursor vendor adapter for `.cursor/rules/*.mdc` output.
 - Generated source files live in `.agentic/vendor-files/cursor/rules/`.
 - In nested profiles, additional tier rules are generated under
   `.agentic/vendor-files/cursor/rules/<tier>/`.
-- `agentic switch cursor` only manages the `.cursor/rules` symlink.
+- `agentic switch cursor` uses `.agentic/vendor-files/cursor/switch-manifest.json`
+  to manage Cursor rule symlinks (root and tier-local paths).
 - Unrelated `.cursor/*` files (for example `.cursor/mcp.json`) are preserved.
-- If a real `.cursor/rules` directory already exists, `agentic switch cursor` migrates it
-  to a deterministic backup path (`.cursor/rules.backup`, then `.cursor/rules.backup.N`)
-  before creating the symlink.
+- If a managed Cursor rules path already exists as a real directory, `agentic switch cursor`
+  migrates it to a deterministic backup path (`<path>.backup`, then `<path>.backup.N`)
+  before creating symlinks.
 - Cursor switching is rollback-safe: if a later step fails during multi-vendor activation,
-  prior symlinks, config, and migrated `.cursor/rules` state are restored.
+  prior symlinks, config, and migrated Cursor rules paths are restored.
 
 Not in scope for this adapter:
 
 - `.agentic/providers.yaml` integration
-- nested `.cursor/rules` support


### PR DESCRIPTION
## Summary
Implements #123 by generalizing Cursor vendor switching from a single hardcoded path to a manifest-driven multi-path model with deterministic backup and rollback.

Closes #123.

## What changed
- Added Cursor switch manifest generation in vendor-gen:
  - `tooling/lib/vendors/cursor.sh` now emits
    - `.agentic/vendor-files/cursor/switch-manifest.json`
  - Manifest includes managed target/source path mappings for root and nested tiers.
- Updated Cursor switching to consume manifest paths:
  - `tooling/lib/vendor-switch.sh`
  - Loads managed Cursor paths from manifest with backward-compatible fallback to `.cursor/rules`.
  - Preflight migrates existing real directories for each managed path to deterministic backups (`.backup`, `.backup.N`).
  - Activates all managed Cursor symlinks from manifest mappings.
  - Snapshot/rollback now includes all managed Cursor paths, preventing partial symlink leaks on failure.
- Added regression and behavior tests:
  - `T135`: manifest-driven multi-path activation (`.cursor/rules`, `backend/.cursor/rules`, `ui/.cursor/rules`).
  - `T136`: forced mid-activation failure verifies rollback restores prior state and removes partial Cursor links.
- Updated docs:
  - `docs/commands.md`
  - `docs/customization.md`
  - `vendors/cursor/README.md`

## Backward compatibility
- Existing single-path behavior remains supported when no manifest exists.
- Unrelated `.cursor/*` files are preserved.
- Config writes remain last, and rollback restores previous config/symlink state on failure.

## Validation
- `just lint` ✅
- `just test` ✅ (`471/471`)
