### PR TITLE
docs(vendors): add cursor provider-model guardrail

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -165,6 +165,8 @@ Cursor-specific behavior:
 - If a managed Cursor rules path is a real directory, it is migrated to deterministic backups:
   `<path>.backup`, then `<path>.backup.N`.
 - If activation fails mid-switch, agentic rolls back to the prior symlink/config state.
+- Cursor provider/model mapping from `.agentic/providers.yaml` is intentionally unsupported
+  until Cursor publishes an official project-local contract.
 
 ### sync
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -165,8 +165,6 @@ Cursor-specific behavior:
 - If a managed Cursor rules path is a real directory, it is migrated to deterministic backups:
   `<path>.backup`, then `<path>.backup.N`.
 - If activation fails mid-switch, agentic rolls back to the prior symlink/config state.
-- Cursor provider/model mapping from `.agentic/providers.yaml` is intentionally unsupported
-  until Cursor publishes an official project-local contract.
 
 ### sync
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -54,6 +54,8 @@ Behavior:
 - If `.agentic/providers.yaml` is missing, behavior is unchanged (backward compatible).
 - If present but invalid, `agentic compose` and `agentic sync` fail with a clear error.
 - This file influences runtime pivot preferences only; `AGENTS.md` remains canonical.
+- Cursor provider/model mapping is intentionally unsupported until Cursor publishes
+  an official project-local contract for that configuration surface.
 
 ## MCP Configuration (Pivot Model)
 

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -65,6 +65,8 @@ If a real `.cursor/rules` directory already exists, switch migrates it to
 `.cursor/rules.backup` (or `.cursor/rules.backup.N`) before linking.
 If a multi-vendor switch fails after mutation begins, agentic rolls back prior
 symlinks/config and restores migrated Cursor rules.
+Cursor provider/model mapping is intentionally unsupported until Cursor publishes
+an official project-local contract for that configuration surface.
 
 ## MCP Pivot Model
 

--- a/vendors/cursor/README.md
+++ b/vendors/cursor/README.md
@@ -17,3 +17,4 @@ Cursor vendor adapter for `.cursor/rules/*.mdc` output.
 Not in scope for this adapter:
 
 - `.agentic/providers.yaml` integration
+- Cursor provider/model mapping from `.agentic/providers.yaml` (intentionally unsupported until Cursor publishes an official project-local contract)


### PR DESCRIPTION
## Summary
Add a clear guardrail that Cursor provider/model mapping from `.agentic/providers.yaml` is intentionally unsupported until Cursor publishes an official project-local contract.

Refs #127.

## Changes
- `docs/vendors.md`
  - Added explicit guardrail in Cursor vendor section.
- `vendors/cursor/README.md`
  - Added explicit out-of-scope guardrail line.
- `docs/customization.md`
  - Added the same guardrail in providers behavior.

## Notes
- Per request, this guardrail was removed from `docs/commands.md` and is documented only in vendor-focused docs.

## Validation
- `just lint` ✅
