### PR TITLE
chore(ci): add codecov coverage status gates

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 75%
+        threshold: 0%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 75%
+        threshold: 0%
+        if_ci_failed: error


### PR DESCRIPTION
## Summary
Adds `codecov.yml` coverage status gates for both overall project and patch coverage.

## Changes
- Add `codecov.yml` with:
  - `project.default.target: 75%`
  - `project.default.threshold: 0%`
  - `project.default.if_ci_failed: error`
  - `patch.default.target: 75%`
  - `patch.default.threshold: 0%`
  - `patch.default.if_ci_failed: error`

## Validation
- `just lint` ✅
- `just test` ✅ (`474/474`)
