### PR TITLE
chore(ci): set codecov coverage badge range

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 coverage:
+  range: 50..75
+
   status:
     project:
       default:


### PR DESCRIPTION
## Summary
Adjusts Codecov badge color range so coverage maps in the requested band and avoids orange.

## Changes
- Update `codecov.yml`:
  - `coverage.range: 50..75`
- Keep status gates unchanged:
  - project target `75%`, threshold `0%`, `if_ci_failed: error`
  - patch target `75%`, threshold `0%`, `if_ci_failed: error`

## Validation
- `just lint` ✅
- `just test` ✅ (`474/474`)
