### PR TITLE
feat(tooling): add opt-in portable agents sync

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agents Orchestration Switching
 
-Use `.agentic/agents.yaml` to define project-local agent orchestration and generate provider-local agent files.
+Use `.agentic/agents.yaml` to define project-local agent orchestration and generate canonical provider outputs under `.agentic/agents/`.
 This feature is additive and optional: if the file is missing, or `enabled: false`, sync behavior is unchanged.
 
 ## Default behavior
@@ -42,9 +42,13 @@ Notes:
 - Agent names are lowercase letters only (`architect`, `reviewer`, `worker`).
 - `prompt` is inline multiline instruction text in YAML.
 - If `enabled: true` and `agents` is empty, sync warns and performs no mutations.
-- Provider outputs are generated to local project paths:
-  - Codex: `.agents/orchestration/<agent>.md`
-  - OpenCode: `.opencode/agents/<agent>.md`
+- Provider outputs are generated to canonical local paths:
+  - Codex: `.agentic/agents/codex/<agent>.md`
+  - OpenCode: `.agentic/agents/opencode/<agent>.md`
+- `agentic switch` activates provider-local symlinks:
+  - `.agents/orchestration` → `.agentic/agents/codex`
+  - `.opencode/agents` → `.agentic/agents/opencode`
 - `model` must match the provider's valid model reference/name.
-- All outputs are preflighted before writing; unmanaged destination conflicts fail before mutation.
+- `.agentic/agents/` is generated from `agents.yaml` and should be gitignored.
+- `agents.yaml` remains the source of truth and should be tracked in git.
 - Provider behavior stays isolated in vendor adapters.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -26,7 +26,9 @@ enabled: true
 agents:
   architect:
     description: "Plans and scopes implementation."
-    prompt: ".agentic/portable/architect.md"
+    prompt: |
+      You are the architect agent.
+      Scope tasks, identify risks, and propose execution steps.
     providers:
       codex:
         enabled: true
@@ -38,10 +40,11 @@ agents:
 
 Notes:
 - Agent names are lowercase letters only (`architect`, `reviewer`, `worker`).
-- `prompt` paths are project-relative and must stay local (no absolute paths, no parent traversal).
+- `prompt` is inline multiline instruction text in YAML.
 - If `enabled: true` and `agents` is empty, sync warns and performs no mutations.
 - Provider outputs are generated to local project paths:
   - Codex: `.agents/orchestration/<agent>.md`
   - OpenCode: `.opencode/agents/<agent>.md`
+- `model` must match the provider's valid model reference/name.
 - All outputs are preflighted before writing; unmanaged destination conflicts fail before mutation.
 - Provider behavior stays isolated in vendor adapters.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,41 @@
+# Portable Agents
+
+Use `.agentic/agents.yaml` to keep provider-specific agent prompt files in sync from project-local source files.
+
+## Default behavior
+
+`agentic init` scaffolds `.agentic/agents.yaml` in explicit no-op mode:
+
+```yaml
+version: "1"
+enabled: false
+providers: {}
+```
+
+When `enabled: false` (or when the file is missing), `agentic sync` skips portable agents sync.
+
+## Opt in
+
+Set `enabled: true` and add provider mappings.
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
+version: "1"
+enabled: true
+providers:
+  codex:
+    enabled: true
+    mappings:
+      - source: ".agentic/portable/codex.md"
+        target: ".agents/AGENTS.md"
+  opencode:
+    enabled: true
+    mappings:
+      - source: ".agentic/portable/opencode.md"
+        target: ".opencode/AGENTS.md"
+```
+
+Notes:
+- `source` and `target` paths are project-relative.
+- Missing `source` files are skipped with a warning.
+- Mapping behavior stays provider-specific in vendor adapters.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -39,16 +39,18 @@ agents:
 ```
 
 Notes:
-- Agent names are lowercase letters only (`architect`, `reviewer`, `worker`).
+- `agents` are orchestration roles declared in `.agentic/agents.yaml` (`architect`, `reviewer`, `worker`).
+- Agent names are lowercase letters only.
 - `prompt` is inline multiline instruction text in YAML.
 - If `enabled: true` and `agents` is empty, sync warns and performs no mutations.
-- Provider outputs are generated to canonical local paths:
+- Provider outputs are generated as artifacts under `.agentic/agents/`:
   - Codex: `.agentic/agents/codex/<agent>.md`
   - OpenCode: `.agentic/agents/opencode/<agent>.md`
-- `agentic switch` activates provider-local symlinks:
-  - `.agents/orchestration` → `.agentic/agents/codex`
-  - `.opencode/agents` → `.agentic/agents/opencode`
+- `agentic switch` activates provider-local agent paths:
+  - Codex: `.codex/agents` → `.agentic/agents/codex`
+  - OpenCode: `.opencode/agents` → `.agentic/agents/opencode`
 - `model` must match the provider's valid model reference/name.
 - `.agentic/agents/` is generated from `agents.yaml` and should be gitignored.
 - `agents.yaml` remains the source of truth and should be tracked in git.
+- `subagents` are provider-local runtime directories (`.codex/agents`, `.opencode/agents`) that point to generated artifacts.
 - Provider behavior stays isolated in vendor adapters.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,7 @@
-# Portable Agents
+# Agents Orchestration Switching
 
-Use `.agentic/agents.yaml` to keep provider-specific agent prompt files in sync from project-local source files.
+Use `.agentic/agents.yaml` to define project-local agent orchestration and generate provider-local agent files.
+This feature is additive and optional: if the file is missing, or `enabled: false`, sync behavior is unchanged.
 
 ## Default behavior
 
@@ -9,33 +10,38 @@ Use `.agentic/agents.yaml` to keep provider-specific agent prompt files in sync 
 ```yaml
 version: "1"
 enabled: false
-providers: {}
+agents: {}
 ```
 
-When `enabled: false` (or when the file is missing), `agentic sync` skips portable agents sync.
+When `enabled: false` (or when the file is missing), `agentic sync` skips agents orchestration switching.
 
 ## Opt in
 
-Set `enabled: true` and add provider mappings.
+Set `enabled: true` and define agents.
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
 version: "1"
 enabled: true
-providers:
-  codex:
-    enabled: true
-    mappings:
-      - source: ".agentic/portable/codex.md"
-        target: ".agents/AGENTS.md"
-  opencode:
-    enabled: true
-    mappings:
-      - source: ".agentic/portable/opencode.md"
-        target: ".opencode/AGENTS.md"
+agents:
+  architect:
+    description: "Plans and scopes implementation."
+    prompt: ".agentic/portable/architect.md"
+    providers:
+      codex:
+        enabled: true
+        model: "gpt-5.3-codex"
+      opencode:
+        enabled: true
+        model: "openai/gpt-5"
 ```
 
 Notes:
-- `source` and `target` paths are project-relative.
-- Missing `source` files are skipped with a warning.
-- Mapping behavior stays provider-specific in vendor adapters.
+- Agent names are lowercase letters only (`architect`, `reviewer`, `worker`).
+- `prompt` paths are project-relative and must stay local (no absolute paths, no parent traversal).
+- If `enabled: true` and `agents` is empty, sync warns and performs no mutations.
+- Provider outputs are generated to local project paths:
+  - Codex: `.agents/orchestration/<agent>.md`
+  - OpenCode: `.opencode/agents/<agent>.md`
+- All outputs are preflighted before writing; unmanaged destination conflicts fail before mutation.
+- Provider behavior stays isolated in vendor adapters.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -188,8 +188,7 @@ agentic sync                # Auto-detect target from current directory
 agentic sync ./my-project   # Explicit target
 ```
 
-During sync, MCP seeding uses `.agentic/mcp.yaml` first. If absent, a legacy
-`mcp:` block inside `.agentic/profile.yaml` is still supported (deprecated).
+During sync, MCP seeding uses `.agentic/mcp.yaml`.
 If `.agentic/agents.yaml` is enabled, sync also regenerates `.agentic/agents/` from that file.
 
 ### list

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -168,7 +168,8 @@ Cursor-specific behavior:
 
 Agents orchestration switching behavior:
 - Canonical generated outputs live under `.agentic/agents/{provider}/`.
-- Switching `codex` creates `.agents/orchestration -> ../.agentic/agents/codex` when available.
+- `agents` are defined in `.agentic/agents.yaml`; provider-local `subagents` paths are created by switch.
+- Switching `codex` creates `.codex/agents -> ../.agentic/agents/codex` when available.
 - Switching `opencode` creates `.opencode/agents -> ../.agentic/agents/opencode` when available.
 
 ### sync

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -166,6 +166,11 @@ Cursor-specific behavior:
   `<path>.backup`, then `<path>.backup.N`.
 - If activation fails mid-switch, agentic rolls back to the prior symlink/config state.
 
+Agents orchestration switching behavior:
+- Canonical generated outputs live under `.agentic/agents/{provider}/`.
+- Switching `codex` creates `.agents/orchestration -> ../.agentic/agents/codex` when available.
+- Switching `opencode` creates `.opencode/agents -> ../.agentic/agents/opencode` when available.
+
 ### sync
 
 Regenerate AGENTS.md and vendor files from the local `.agentic/profile.yaml`.
@@ -184,6 +189,7 @@ agentic sync ./my-project   # Explicit target
 
 During sync, MCP seeding uses `.agentic/mcp.yaml` first. If absent, a legacy
 `mcp:` block inside `.agentic/profile.yaml` is still supported (deprecated).
+If `.agentic/agents.yaml` is enabled, sync also regenerates `.agentic/agents/` from that file.
 
 ### list
 

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -127,10 +127,9 @@ Tier-level overrides follow the same placement rules but apply only to their tie
 
 ## Validation
 
-Validation runs automatically as part of `agentic sync`. It checks:
+Validation runs automatically during `agentic sync`.
 
-- AGENTS.local.md exists → "[ OK ] Custom rules file present"
-- custom_rules in profile but no AGENTS.local.md → "[WARN]"
-- Duplicate H2 sections (also in AGENTS.md) → "[WARN]"
-
-Regenerate doesn't touch AGENTS.local.md — your custom rules persist across updates.
+- ✅ If `AGENTS.local.md` exists, your custom rules are recognized and included.
+- ⚠️ If `custom_rules` is configured in the profile but `AGENTS.local.md` is missing, you get a warning.
+- ⚠️ If an H2 section is duplicated between `AGENTS.local.md` and generated `AGENTS.md`, you get a warning.
+- 🔒 Regeneration never overwrites `AGENTS.local.md`, so your custom rules persist across updates.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -51,7 +51,7 @@ providers:
 
 Behavior:
 
-- If `.agentic/providers.yaml` is missing, behavior is unchanged (backward compatible).
+- If `.agentic/providers.yaml` is missing, default provider behavior applies.
 - If present but invalid, `agentic compose` and `agentic sync` fail with a clear error.
 - This file influences runtime pivot preferences only; `AGENTS.md` remains canonical.
 - Cursor provider/model mapping is intentionally unsupported until Cursor publishes
@@ -78,8 +78,7 @@ servers:
 - `.gemini/settings.json` (`mcpServers` translation)
 - `.cursor/mcp.json` (`mcpServers` translation)
 
-If `.agentic/mcp.yaml` is missing, legacy `mcp:` under `.agentic/profile.yaml`
-is still supported for backward compatibility, but deprecated.
+If `.agentic/mcp.yaml` is missing, MCP outputs are not seeded.
 
 ### Local vs Issue-Backed Planning
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,18 @@ Installs the `agentic` CLI to `~/.local/bin`. The installer checks prerequisites
 
     Reusable agent task definitions. Deploy shared skills from the library or add project-local ones in `.agentic/project-skills/`.
 
+-   :material-file-document-edit:{ .lg .middle } **Agents Orchestration Switching**
+
+    ---
+
+    Keep `agents.yaml` optional. Opt in per project to define agents orchestration with preflighted, local-only sync.
+
+-   :material-shield-check:{ .lg .middle } **Safe by default**
+
+    ---
+
+    Preflight checks run before writes. Conflict and validation failures stop early so unmanaged files are never mutated.
+
 </div>
 
 ---
@@ -70,7 +82,7 @@ agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
 
 ---
 
-> **Portable agents:** optional provider-specific agent prompt mapping is documented in [Portable Agents](agents.md).
+> **Agents orchestration switching:** optional, project-local agent orchestration is documented in [Agents Orchestration Switching](agents.md).
 
 ## Sections
 
@@ -80,6 +92,6 @@ agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
 - [**Profiles**](profiles.md) — all available profiles and their fragments
 - [**Skills**](skills.md) — shared skill catalog plus persistent and ad hoc (selective) skill usage paths
 - [**Vendors**](vendors.md) — supported AI tools and their output files
-- [**Portable Agents**](agents.md) — opt-in provider-specific agents mapping via `.agentic/agents.yaml`
+- [**Agents Orchestration Switching**](agents.md) — opt-in, project-local agent orchestration via `.agentic/agents.yaml`
 - [**Customization**](customization.md) — per-project overrides, project skills, proprietary libraries, link mode vs copy mode
 - [**Custom Rules**](custom-rules.md) — `AGENTS.local.md` injection

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,8 @@ agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
 
 ---
 
+> **Portable agents:** optional provider-specific agent prompt mapping is documented in [Portable Agents](agents.md).
+
 ## Sections
 
 - [**Installation**](getting-started/installation.md) — one-line install, manual install, prerequisites
@@ -78,5 +80,6 @@ agentic deploy typescript-hexagonal-microservice ~/code/my-api claude
 - [**Profiles**](profiles.md) — all available profiles and their fragments
 - [**Skills**](skills.md) — shared skill catalog plus persistent and ad hoc (selective) skill usage paths
 - [**Vendors**](vendors.md) — supported AI tools and their output files
+- [**Portable Agents**](agents.md) — opt-in provider-specific agents mapping via `.agentic/agents.yaml`
 - [**Customization**](customization.md) — per-project overrides, project skills, proprietary libraries, link mode vs copy mode
 - [**Custom Rules**](custom-rules.md) — `AGENTS.local.md` injection

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -121,7 +121,7 @@ Multiple vendors can be active simultaneously since their symlink paths don't co
 |--------|-------------------|
 | `claude` | `CLAUDE.md`, `.claude/skills` |
 | `copilot` | `.github/copilot-instructions.md`, `.github/instructions/` |
-| `codex` | `.agents/skills` (reads `AGENTS.md` natively) |
+| `codex` | `.agents/skills`, `.agents/orchestration` (reads `AGENTS.md` natively) |
 | `gemini` | `GEMINI.md`, `.gemini/system.md`, `.gemini/skills` |
-| `opencode` | `.opencode/skills` |
+| `opencode` | `.opencode/skills`, `.opencode/agents` |
 | `cursor` | `.cursor/rules` |

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -52,7 +52,7 @@ Skills are deployed natively to `.gemini/skills/` and activated lazily via the
 
 ### Opencode
 
-Opencode reads `AGENTS.md` natively. Skills are deployed to `.opencode/skills/`. Opencode also supports `.claude/skills/` and `.agents/skills/` as compatibility fallbacks.
+Opencode reads `AGENTS.md` natively. Skills are deployed to `.opencode/skills/`.
 
 ### Cursor
 
@@ -84,10 +84,9 @@ Generated targets:
 - `.gemini/settings.json` uses `mcpServers` with Gemini-specific field mapping
 - `.cursor/mcp.json` uses `mcpServers` (Cursor-compatible project shape)
 
-Precedence and compatibility:
+Source of truth:
 
 1. `.agentic/mcp.yaml` (authoritative)
-2. Legacy `.agentic/profile.yaml` `mcp:` key (deprecated fallback with warning)
 
 ## Vendor Commands
 

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -121,7 +121,9 @@ Multiple vendors can be active simultaneously since their symlink paths don't co
 |--------|-------------------|
 | `claude` | `CLAUDE.md`, `.claude/skills` |
 | `copilot` | `.github/copilot-instructions.md`, `.github/instructions/` |
-| `codex` | `.agents/skills`, `.agents/orchestration` (reads `AGENTS.md` natively) |
+| `codex` | `.agents/skills`, `.codex/agents` (reads `AGENTS.md` natively) |
 | `gemini` | `GEMINI.md`, `.gemini/system.md`, `.gemini/skills` |
 | `opencode` | `.opencode/skills`, `.opencode/agents` |
 | `cursor` | `.cursor/rules` |
+
+For orchestration switching, `agents` are declared in `.agentic/agents.yaml`, and provider-local `subagents` paths (`.codex/agents`, `.opencode/agents`) are symlinks to generated artifacts under `.agentic/agents/{provider}/`.

--- a/schemas/agents.schema.json
+++ b/schemas/agents.schema.json
@@ -25,7 +25,11 @@
           "required": ["description", "prompt"],
           "properties": {
             "description": { "type": "string", "minLength": 1 },
-            "prompt": { "type": "string", "minLength": 1 },
+            "prompt": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Agent instructions as inline multiline text."
+            },
             "providers": {
               "type": "object",
               "additionalProperties": false,
@@ -35,7 +39,10 @@
                   "additionalProperties": false,
                   "properties": {
                     "enabled": { "type": "boolean" },
-                    "model": { "type": "string" },
+                    "model": {
+                      "type": "string",
+                      "description": "Must match the provider's valid model reference/name."
+                    },
                     "reasoning_effort": { "type": "string" }
                   }
                 },
@@ -44,7 +51,10 @@
                   "additionalProperties": false,
                   "properties": {
                     "enabled": { "type": "boolean" },
-                    "model": { "type": "string" },
+                    "model": {
+                      "type": "string",
+                      "description": "Must match the provider's valid model reference/name."
+                    },
                     "reasoning_effort": { "type": "string" }
                   }
                 }

--- a/schemas/agents.schema.json
+++ b/schemas/agents.schema.json
@@ -1,63 +1,60 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/soulcodex/agentic/schemas/agents.schema.json",
-  "title": "Agentic Portable Agents Config",
-  "description": "Optional project-local mappings for syncing portable agent prompts to provider-specific paths.",
+  "title": "Agentic Agents Orchestration Switching Config",
+  "description": "Optional project-local agent orchestration switching definitions for provider-specific local outputs.",
   "type": "object",
   "additionalProperties": false,
   "properties": {
     "version": {
       "type": "string",
-      "description": "Portable agents config schema version identifier."
+      "const": "1",
+      "description": "Agents orchestration switching schema version identifier."
     },
     "enabled": {
       "type": "boolean",
-      "description": "Global opt-in gate for portable agents sync."
+      "description": "Global opt-in gate for agents orchestration switching."
     },
-    "providers": {
+    "agents": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "codex": {
+      "description": "Agent definitions keyed by lowercase name.",
+      "patternProperties": {
+        "^[a-z]+$": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["description", "prompt"],
           "properties": {
-            "enabled": { "type": "boolean" },
-            "mappings": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["source", "target"],
-                "properties": {
-                  "source": { "type": "string" },
-                  "target": { "type": "string" }
-                }
-              }
-            }
-          }
-        },
-        "opencode": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "enabled": { "type": "boolean" },
-            "mappings": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "required": ["source", "target"],
-                "properties": {
-                  "source": { "type": "string" },
-                  "target": { "type": "string" }
+            "description": { "type": "string", "minLength": 1 },
+            "prompt": { "type": "string", "minLength": 1 },
+            "providers": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "codex": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "model": { "type": "string" },
+                    "reasoning_effort": { "type": "string" }
+                  }
+                },
+                "opencode": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "model": { "type": "string" },
+                    "reasoning_effort": { "type": "string" }
+                  }
                 }
               }
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
-  "required": ["enabled"]
+  "required": ["version", "enabled"]
 }

--- a/schemas/agents.schema.json
+++ b/schemas/agents.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/soulcodex/agentic/schemas/agents.schema.json",
+  "title": "Agentic Portable Agents Config",
+  "description": "Optional project-local mappings for syncing portable agent prompts to provider-specific paths.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Portable agents config schema version identifier."
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Global opt-in gate for portable agents sync."
+    },
+    "providers": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "codex": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "mappings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["source", "target"],
+                "properties": {
+                  "source": { "type": "string" },
+                  "target": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "opencode": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "mappings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["source", "target"],
+                "properties": {
+                  "source": { "type": "string" },
+                  "target": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": ["enabled"]
+}

--- a/schemas/agents.schema.json
+++ b/schemas/agents.schema.json
@@ -42,7 +42,10 @@
                       "type": "string",
                       "description": "Must match the provider's valid model reference/name."
                     },
-                    "reasoning_effort": { "type": "string" }
+                    "reasoning_effort": {
+                      "type": "string",
+                      "enum": ["low", "medium", "high", "extra_high"]
+                    }
                   }
                 },
                 "opencode": {
@@ -54,7 +57,10 @@
                       "type": "string",
                       "description": "Must match the provider's valid model reference/name."
                     },
-                    "reasoning_effort": { "type": "string" }
+                    "reasoning_effort": {
+                      "type": "string",
+                      "enum": ["low", "medium", "high", "extra_high"]
+                    }
                   }
                 }
               }

--- a/schemas/agents.schema.json
+++ b/schemas/agents.schema.json
@@ -5,6 +5,64 @@
   "description": "Optional project-local agent orchestration switching definitions for provider-specific local outputs.",
   "type": "object",
   "additionalProperties": false,
+  "definitions": {
+    "providerConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "model": {
+          "type": "string",
+          "description": "Must match the provider's valid model reference/name."
+        },
+        "reasoning_effort": {
+          "type": "string",
+          "enum": ["low", "medium", "high", "extra_high"]
+        }
+      }
+    },
+    "providers": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "codex": { "$ref": "#/definitions/providerConfig" },
+        "opencode": { "$ref": "#/definitions/providerConfig" }
+      }
+    },
+    "agentDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": { "type": "string", "minLength": 1 },
+        "prompt": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Agent instructions as inline multiline text."
+        },
+        "providers": { "$ref": "#/definitions/providers" }
+      },
+      "required": ["description", "prompt"]
+    },
+    "subagentDefinition": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "parent": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Parent agent key this subagent attaches to."
+        },
+        "description": { "type": "string", "minLength": 1 },
+        "prompt": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Subagent instructions as inline multiline text."
+        },
+        "providers": { "$ref": "#/definitions/providers" }
+      },
+      "required": ["parent", "description", "prompt"]
+    }
+  },
   "properties": {
     "version": {
       "type": "string",
@@ -19,54 +77,15 @@
       "type": "object",
       "description": "Agent definitions keyed by lowercase name.",
       "patternProperties": {
-        "^[a-z]+$": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "description": { "type": "string", "minLength": 1 },
-            "prompt": {
-              "type": "string",
-              "minLength": 1,
-              "description": "Agent instructions as inline multiline text."
-            },
-            "providers": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "codex": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "enabled": { "type": "boolean" },
-                    "model": {
-                      "type": "string",
-                      "description": "Must match the provider's valid model reference/name."
-                    },
-                    "reasoning_effort": {
-                      "type": "string",
-                      "enum": ["low", "medium", "high", "extra_high"]
-                    }
-                  }
-                },
-                "opencode": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "enabled": { "type": "boolean" },
-                    "model": {
-                      "type": "string",
-                      "description": "Must match the provider's valid model reference/name."
-                    },
-                    "reasoning_effort": {
-                      "type": "string",
-                      "enum": ["low", "medium", "high", "extra_high"]
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+        "^[a-z]+$": { "$ref": "#/definitions/agentDefinition" }
+      },
+      "additionalProperties": false
+    },
+    "subagents": {
+      "type": "object",
+      "description": "Subagent definitions keyed by lowercase name.",
+      "patternProperties": {
+        "^[a-z]+$": { "$ref": "#/definitions/subagentDefinition" }
       },
       "additionalProperties": false
     }

--- a/schemas/agents.schema.json
+++ b/schemas/agents.schema.json
@@ -22,7 +22,6 @@
         "^[a-z]+$": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["description", "prompt"],
           "properties": {
             "description": { "type": "string", "minLength": 1 },
             "prompt": {

--- a/tooling/lib/agents.sh
+++ b/tooling/lib/agents.sh
@@ -113,11 +113,25 @@ preflight_portable_agents_mappings() {
   return 0
 }
 
+is_agent_provider_active() {
+  local provider="$1"
+  local active_vendors_csv="$2"
+
+  # Backward compatibility: missing active_vendors means no provider filter.
+  [[ -z "$active_vendors_csv" ]] && return 0
+
+  [[ ",$active_vendors_csv," == *",$provider,"* ]]
+}
+
 sync_portable_agents() {
   local target="$1"
   local agents_file="$target/.agentic/agents.yaml"
+  local config_file="$target/.agentic/config.yaml"
   local enabled
   local agent_count
+  local active_vendors_csv=""
+  local codex_active="true"
+  local opencode_active="true"
   local codex_mappings=()
   local opencode_mappings=()
   local all_mappings=()
@@ -141,10 +155,26 @@ sync_portable_agents() {
     return 0
   fi
 
-  collect_codex_agent_mappings "$target" "$agents_file" codex_mappings
-  collect_opencode_agent_mappings "$target" "$agents_file" opencode_mappings
+  if [[ -f "$config_file" ]]; then
+    active_vendors_csv=$(read_active_vendors "$config_file")
+  fi
+  if ! is_agent_provider_active "codex" "$active_vendors_csv"; then
+    codex_active="false"
+  fi
+  if ! is_agent_provider_active "opencode" "$active_vendors_csv"; then
+    opencode_active="false"
+  fi
+
+  if [[ "$codex_active" == "true" ]]; then
+    collect_codex_agent_mappings "$target" "$agents_file" codex_mappings
+  fi
+  if [[ "$opencode_active" == "true" ]]; then
+    collect_opencode_agent_mappings "$target" "$agents_file" opencode_mappings
+  fi
 
   if [[ "${#codex_mappings[@]}" -eq 0 && "${#opencode_mappings[@]}" -eq 0 ]]; then
+    cleanup_codex_agent_outputs "$target" "$codex_active"
+    cleanup_opencode_agent_outputs "$target" "$opencode_active"
     echo "Warning: agents orchestration switching enabled but no provider outputs resolved; no mutations applied." >&2
     return 0
   fi
@@ -166,6 +196,8 @@ sync_portable_agents() {
 
   apply_codex_agent_mappings "${codex_mappings[@]}"
   apply_opencode_agent_mappings "${opencode_mappings[@]}"
+  cleanup_codex_agent_outputs "$target" "$codex_active" "${codex_mappings[@]}"
+  cleanup_opencode_agent_outputs "$target" "$opencode_active" "${opencode_mappings[@]}"
 
   local file
   for file in "${tmp_files[@]}"; do

--- a/tooling/lib/agents.sh
+++ b/tooling/lib/agents.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# agents.sh — Portable agents sync orchestration
+# Sourced by: sync.sh
+
+# shellcheck source=tooling/lib/common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+# shellcheck source=tooling/lib/vendors/codex/agents.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/vendors/codex/agents.sh"
+# shellcheck source=tooling/lib/vendors/opencode/agents.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/vendors/opencode/agents.sh"
+
+validate_agents_config() {
+  local target="$1"
+  local agents_file="$target/.agentic/agents.yaml"
+
+  [[ ! -f "$agents_file" ]] && return 0
+
+  if ! yq -e '.' "$agents_file" > /dev/null 2>&1; then
+    echo "Error: Invalid YAML in $agents_file" >&2
+    return 1
+  fi
+
+  local enabled_type
+  enabled_type=$(yq '.enabled | type' "$agents_file" 2>/dev/null || echo "!!null")
+  if [[ "$enabled_type" != "!!null" && "$enabled_type" != "!!bool" ]]; then
+    echo "Error: enabled must be boolean in $agents_file" >&2
+    return 1
+  fi
+
+  local provider_keys=()
+  while IFS= read -r provider; do
+    [[ -z "$provider" || "$provider" == "null" ]] && continue
+    provider_keys+=("$provider")
+  done < <(yq '.providers | keys | .[]' "$agents_file" 2>/dev/null || true)
+
+  local key
+  for key in "${provider_keys[@]}"; do
+    case "$key" in
+      codex|opencode) ;;
+      *)
+        echo "Error: Invalid provider key '$key' in $agents_file" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  return 0
+}
+
+sync_portable_agents() {
+  local target="$1"
+  local agents_file="$target/.agentic/agents.yaml"
+  local enabled
+
+  [[ ! -f "$agents_file" ]] && return 0
+
+  validate_agents_config "$target" || return 1
+
+  enabled=$(yq '.enabled // false' "$agents_file" 2>/dev/null || echo "false")
+  if [[ "$enabled" != "true" ]]; then
+    echo "Portable agents sync: disabled (no-op)."
+    return 0
+  fi
+
+  echo "Portable agents sync: enabled."
+  sync_codex_agents "$target" "$agents_file"
+  sync_opencode_agents "$target" "$agents_file"
+}

--- a/tooling/lib/agents.sh
+++ b/tooling/lib/agents.sh
@@ -46,7 +46,13 @@ validate_agents_config() {
     agent_keys+=("$agent")
   done < <(yq '.agents | keys | .[]' "$agents_file" 2>/dev/null || true)
 
-  local key desc prompt provider_keys provider reasoning
+  local subagent_keys=()
+  while IFS= read -r subagent; do
+    [[ -z "$subagent" || "$subagent" == "null" ]] && continue
+    subagent_keys+=("$subagent")
+  done < <(yq '.subagents | keys | .[]' "$agents_file" 2>/dev/null || true)
+
+  local key desc prompt provider_keys provider reasoning provider_enabled_type parent
   for key in "${agent_keys[@]}"; do
     if [[ ! "$key" =~ ^[a-z]+$ ]]; then
       echo "Error: Invalid agent key '$key' in $agents_file (expected lowercase letters only)" >&2
@@ -75,12 +81,71 @@ validate_agents_config() {
           ;;
       esac
 
+      provider_enabled_type=$(yq ".agents.\"$key\".providers.\"$provider\".enabled | type" "$agents_file" 2>/dev/null || echo "!!null")
+      if [[ "$provider_enabled_type" != "!!null" && "$provider_enabled_type" != "!!bool" ]]; then
+        echo "Error: Agent '$key' provider '$provider' enabled must be boolean in $agents_file" >&2
+        return 1
+      fi
+
       reasoning=$(yq -r ".agents.\"$key\".providers.\"$provider\".reasoning_effort" "$agents_file" 2>/dev/null || echo "null")
       if [[ "$reasoning" != "null" ]]; then
         case "$reasoning" in
           low|medium|high|extra_high) ;;
           *)
             echo "Error: Agent '$key' provider '$provider' has invalid reasoning_effort '$reasoning' in $agents_file" >&2
+            return 1
+            ;;
+        esac
+      fi
+    done
+  done
+
+  for key in "${subagent_keys[@]}"; do
+    if [[ ! "$key" =~ ^[a-z]+$ ]]; then
+      echo "Error: Invalid subagent key '$key' in $agents_file (expected lowercase letters only)" >&2
+      return 1
+    fi
+
+    parent=$(yq -r ".subagents.\"$key\".parent // \"\"" "$agents_file" 2>/dev/null || echo "")
+    desc=$(yq -r ".subagents.\"$key\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
+    prompt=$(yq -r ".subagents.\"$key\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
+    if [[ -z "$parent" || -z "$desc" || -z "$prompt" || "$parent" == "null" || "$desc" == "null" || "$prompt" == "null" ]]; then
+      echo "Error: Subagent '$key' must define non-empty parent, description, and prompt in $agents_file" >&2
+      return 1
+    fi
+
+    if ! yq -e ".agents.\"$parent\"" "$agents_file" > /dev/null 2>&1; then
+      echo "Error: Subagent '$key' parent '$parent' does not reference an existing agent key in $agents_file" >&2
+      return 1
+    fi
+
+    provider_keys=()
+    while IFS= read -r provider; do
+      [[ -z "$provider" || "$provider" == "null" ]] && continue
+      provider_keys+=("$provider")
+    done < <(yq ".subagents.\"$key\".providers | keys | .[]" "$agents_file" 2>/dev/null || true)
+
+    for provider in "${provider_keys[@]}"; do
+      case "$provider" in
+        codex|opencode) ;;
+        *)
+          echo "Error: Subagent '$key' has invalid provider '$provider' in $agents_file" >&2
+          return 1
+          ;;
+      esac
+
+      provider_enabled_type=$(yq ".subagents.\"$key\".providers.\"$provider\".enabled | type" "$agents_file" 2>/dev/null || echo "!!null")
+      if [[ "$provider_enabled_type" != "!!null" && "$provider_enabled_type" != "!!bool" ]]; then
+        echo "Error: Subagent '$key' provider '$provider' enabled must be boolean in $agents_file" >&2
+        return 1
+      fi
+
+      reasoning=$(yq -r ".subagents.\"$key\".providers.\"$provider\".reasoning_effort" "$agents_file" 2>/dev/null || echo "null")
+      if [[ "$reasoning" != "null" ]]; then
+        case "$reasoning" in
+          low|medium|high|extra_high) ;;
+          *)
+            echo "Error: Subagent '$key' provider '$provider' has invalid reasoning_effort '$reasoning' in $agents_file" >&2
             return 1
             ;;
         esac
@@ -96,6 +161,7 @@ sync_portable_agents() {
   local agents_file="$target/.agentic/agents.yaml"
   local enabled
   local agent_count
+  local subagent_count
   local codex_mappings=()
   local opencode_mappings=()
   local all_mappings=()
@@ -113,9 +179,11 @@ sync_portable_agents() {
 
   echo "Agents orchestration switching: enabled."
   agent_count=$(yq '.agents | length' "$agents_file" 2>/dev/null || echo 0)
+  subagent_count=$(yq '.subagents | length' "$agents_file" 2>/dev/null || echo 0)
   [[ "$agent_count" == "null" ]] && agent_count=0
-  if [[ "$agent_count" -eq 0 ]]; then
-    echo "Warning: agents orchestration switching enabled but no agent definitions found; no mutations applied." >&2
+  [[ "$subagent_count" == "null" ]] && subagent_count=0
+  if [[ "$agent_count" -eq 0 && "$subagent_count" -eq 0 ]]; then
+    echo "Warning: agents orchestration switching enabled but no agent/subagent definitions found; no mutations applied." >&2
     apply_codex_agent_mappings "$target"
     apply_opencode_agent_mappings "$target"
     return 0

--- a/tooling/lib/agents.sh
+++ b/tooling/lib/agents.sh
@@ -91,47 +91,11 @@ validate_agents_config() {
   return 0
 }
 
-preflight_portable_agents_mappings() {
-  local -n all_mappings_ref="$1"
-  local entry source_abs target_abs target_rel
-
-  for entry in "${all_mappings_ref[@]}"; do
-    IFS=$'\t' read -r source_abs target_abs target_rel <<< "$entry"
-
-    if [[ -e "$target_abs" ]]; then
-      if [[ ! -f "$target_abs" ]]; then
-        echo "Error: Unmanaged destination conflict at $target_rel (not a file)" >&2
-        return 1
-      fi
-      if ! cmp -s "$source_abs" "$target_abs"; then
-        echo "Error: Unmanaged destination conflict at $target_rel (already exists with different content)" >&2
-        return 1
-      fi
-    fi
-  done
-
-  return 0
-}
-
-is_agent_provider_active() {
-  local provider="$1"
-  local active_vendors_csv="$2"
-
-  # Backward compatibility: missing active_vendors means no provider filter.
-  [[ -z "$active_vendors_csv" ]] && return 0
-
-  [[ ",$active_vendors_csv," == *",$provider,"* ]]
-}
-
 sync_portable_agents() {
   local target="$1"
   local agents_file="$target/.agentic/agents.yaml"
-  local config_file="$target/.agentic/config.yaml"
   local enabled
   local agent_count
-  local active_vendors_csv=""
-  local codex_active="true"
-  local opencode_active="true"
   local codex_mappings=()
   local opencode_mappings=()
   local all_mappings=()
@@ -152,29 +116,17 @@ sync_portable_agents() {
   [[ "$agent_count" == "null" ]] && agent_count=0
   if [[ "$agent_count" -eq 0 ]]; then
     echo "Warning: agents orchestration switching enabled but no agent definitions found; no mutations applied." >&2
+    apply_codex_agent_mappings "$target"
+    apply_opencode_agent_mappings "$target"
     return 0
   fi
 
-  if [[ -f "$config_file" ]]; then
-    active_vendors_csv=$(read_active_vendors "$config_file")
-  fi
-  if ! is_agent_provider_active "codex" "$active_vendors_csv"; then
-    codex_active="false"
-  fi
-  if ! is_agent_provider_active "opencode" "$active_vendors_csv"; then
-    opencode_active="false"
-  fi
-
-  if [[ "$codex_active" == "true" ]]; then
-    collect_codex_agent_mappings "$target" "$agents_file" codex_mappings
-  fi
-  if [[ "$opencode_active" == "true" ]]; then
-    collect_opencode_agent_mappings "$target" "$agents_file" opencode_mappings
-  fi
+  collect_codex_agent_mappings "$target" "$agents_file" codex_mappings
+  collect_opencode_agent_mappings "$target" "$agents_file" opencode_mappings
 
   if [[ "${#codex_mappings[@]}" -eq 0 && "${#opencode_mappings[@]}" -eq 0 ]]; then
-    cleanup_codex_agent_outputs "$target" "$codex_active"
-    cleanup_opencode_agent_outputs "$target" "$opencode_active"
+    apply_codex_agent_mappings "$target"
+    apply_opencode_agent_mappings "$target"
     echo "Warning: agents orchestration switching enabled but no provider outputs resolved; no mutations applied." >&2
     return 0
   fi
@@ -186,18 +138,8 @@ sync_portable_agents() {
     tmp_files+=("$rendered_file")
   done
 
-  if ! preflight_portable_agents_mappings all_mappings; then
-    local file
-    for file in "${tmp_files[@]}"; do
-      rm -f "$file"
-    done
-    return 1
-  fi
-
-  apply_codex_agent_mappings "${codex_mappings[@]}"
-  apply_opencode_agent_mappings "${opencode_mappings[@]}"
-  cleanup_codex_agent_outputs "$target" "$codex_active" "${codex_mappings[@]}"
-  cleanup_opencode_agent_outputs "$target" "$opencode_active" "${opencode_mappings[@]}"
+  apply_codex_agent_mappings "$target" "${codex_mappings[@]}"
+  apply_opencode_agent_mappings "$target" "${opencode_mappings[@]}"
 
   local file
   for file in "${tmp_files[@]}"; do

--- a/tooling/lib/agents.sh
+++ b/tooling/lib/agents.sh
@@ -34,6 +34,12 @@ validate_agents_config() {
     return 1
   fi
 
+  local enabled
+  enabled=$(yq -r '.enabled // false' "$agents_file" 2>/dev/null || echo "false")
+  if [[ "$enabled" != "true" ]]; then
+    return 0
+  fi
+
   local agent_keys=()
   while IFS= read -r agent; do
     [[ -z "$agent" || "$agent" == "null" ]] && continue

--- a/tooling/lib/agents.sh
+++ b/tooling/lib/agents.sh
@@ -46,7 +46,7 @@ validate_agents_config() {
     agent_keys+=("$agent")
   done < <(yq '.agents | keys | .[]' "$agents_file" 2>/dev/null || true)
 
-  local key desc prompt provider_keys provider
+  local key desc prompt provider_keys provider reasoning
   for key in "${agent_keys[@]}"; do
     if [[ ! "$key" =~ ^[a-z]+$ ]]; then
       echo "Error: Invalid agent key '$key' in $agents_file (expected lowercase letters only)" >&2
@@ -74,6 +74,17 @@ validate_agents_config() {
           return 1
           ;;
       esac
+
+      reasoning=$(yq -r ".agents.\"$key\".providers.\"$provider\".reasoning_effort" "$agents_file" 2>/dev/null || echo "null")
+      if [[ "$reasoning" != "null" ]]; then
+        case "$reasoning" in
+          low|medium|high|extra_high) ;;
+          *)
+            echo "Error: Agent '$key' provider '$provider' has invalid reasoning_effort '$reasoning' in $agents_file" >&2
+            return 1
+            ;;
+        esac
+      fi
     done
   done
 

--- a/tooling/lib/agents.sh
+++ b/tooling/lib/agents.sh
@@ -106,14 +106,6 @@ sync_portable_agents() {
   local all_mappings=()
   local tmp_files=()
 
-  cleanup_tmp_files() {
-    local file
-    for file in "${tmp_files[@]}"; do
-      rm -f "$file"
-    done
-  }
-  trap cleanup_tmp_files RETURN
-
   [[ ! -f "$agents_file" ]] && return 0
 
   validate_agents_config "$target" || return 1
@@ -147,8 +139,19 @@ sync_portable_agents() {
     tmp_files+=("$rendered_file")
   done
 
-  preflight_portable_agents_mappings all_mappings || return 1
+  if ! preflight_portable_agents_mappings all_mappings; then
+    local file
+    for file in "${tmp_files[@]}"; do
+      rm -f "$file"
+    done
+    return 1
+  fi
 
-  apply_codex_agent_mappings codex_mappings
-  apply_opencode_agent_mappings opencode_mappings
+  apply_codex_agent_mappings "${codex_mappings[@]}"
+  apply_opencode_agent_mappings "${opencode_mappings[@]}"
+
+  local file
+  for file in "${tmp_files[@]}"; do
+    rm -f "$file"
+  done
 }

--- a/tooling/lib/agents.sh
+++ b/tooling/lib/agents.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# agents.sh — Portable agents sync orchestration
+# agents.sh — Agents orchestration switching sync
 # Sourced by: sync.sh
 
 # shellcheck source=tooling/lib/common.sh
@@ -27,21 +27,70 @@ validate_agents_config() {
     return 1
   fi
 
-  local provider_keys=()
-  while IFS= read -r provider; do
-    [[ -z "$provider" || "$provider" == "null" ]] && continue
-    provider_keys+=("$provider")
-  done < <(yq '.providers | keys | .[]' "$agents_file" 2>/dev/null || true)
+  local version
+  version=$(yq '.version // ""' "$agents_file" 2>/dev/null || echo "")
+  if [[ "$version" != "1" ]]; then
+    echo "Error: version must be \"1\" in $agents_file" >&2
+    return 1
+  fi
 
-  local key
-  for key in "${provider_keys[@]}"; do
-    case "$key" in
-      codex|opencode) ;;
-      *)
-        echo "Error: Invalid provider key '$key' in $agents_file" >&2
+  local agent_keys=()
+  while IFS= read -r agent; do
+    [[ -z "$agent" || "$agent" == "null" ]] && continue
+    agent_keys+=("$agent")
+  done < <(yq '.agents | keys | .[]' "$agents_file" 2>/dev/null || true)
+
+  local key desc prompt provider_keys provider
+  for key in "${agent_keys[@]}"; do
+    if [[ ! "$key" =~ ^[a-z]+$ ]]; then
+      echo "Error: Invalid agent key '$key' in $agents_file (expected lowercase letters only)" >&2
+      return 1
+    fi
+
+    desc=$(yq -r ".agents.\"$key\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
+    prompt=$(yq -r ".agents.\"$key\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
+    if [[ -z "$desc" || -z "$prompt" || "$desc" == "null" || "$prompt" == "null" ]]; then
+      echo "Error: Agent '$key' must define non-empty description and prompt in $agents_file" >&2
+      return 1
+    fi
+
+    provider_keys=()
+    while IFS= read -r provider; do
+      [[ -z "$provider" || "$provider" == "null" ]] && continue
+      provider_keys+=("$provider")
+    done < <(yq ".agents.\"$key\".providers | keys | .[]" "$agents_file" 2>/dev/null || true)
+
+    for provider in "${provider_keys[@]}"; do
+      case "$provider" in
+        codex|opencode) ;;
+        *)
+          echo "Error: Agent '$key' has invalid provider '$provider' in $agents_file" >&2
+          return 1
+          ;;
+      esac
+    done
+  done
+
+  return 0
+}
+
+preflight_portable_agents_mappings() {
+  local -n all_mappings_ref="$1"
+  local entry source_abs target_abs target_rel
+
+  for entry in "${all_mappings_ref[@]}"; do
+    IFS=$'\t' read -r source_abs target_abs target_rel <<< "$entry"
+
+    if [[ -e "$target_abs" ]]; then
+      if [[ ! -f "$target_abs" ]]; then
+        echo "Error: Unmanaged destination conflict at $target_rel (not a file)" >&2
         return 1
-        ;;
-    esac
+      fi
+      if ! cmp -s "$source_abs" "$target_abs"; then
+        echo "Error: Unmanaged destination conflict at $target_rel (already exists with different content)" >&2
+        return 1
+      fi
+    fi
   done
 
   return 0
@@ -51,6 +100,19 @@ sync_portable_agents() {
   local target="$1"
   local agents_file="$target/.agentic/agents.yaml"
   local enabled
+  local agent_count
+  local codex_mappings=()
+  local opencode_mappings=()
+  local all_mappings=()
+  local tmp_files=()
+
+  cleanup_tmp_files() {
+    local file
+    for file in "${tmp_files[@]}"; do
+      rm -f "$file"
+    done
+  }
+  trap cleanup_tmp_files RETURN
 
   [[ ! -f "$agents_file" ]] && return 0
 
@@ -58,11 +120,35 @@ sync_portable_agents() {
 
   enabled=$(yq '.enabled // false' "$agents_file" 2>/dev/null || echo "false")
   if [[ "$enabled" != "true" ]]; then
-    echo "Portable agents sync: disabled (no-op)."
+    echo "Agents orchestration switching: disabled (no-op)."
     return 0
   fi
 
-  echo "Portable agents sync: enabled."
-  sync_codex_agents "$target" "$agents_file"
-  sync_opencode_agents "$target" "$agents_file"
+  echo "Agents orchestration switching: enabled."
+  agent_count=$(yq '.agents | length' "$agents_file" 2>/dev/null || echo 0)
+  [[ "$agent_count" == "null" ]] && agent_count=0
+  if [[ "$agent_count" -eq 0 ]]; then
+    echo "Warning: agents orchestration switching enabled but no agent definitions found; no mutations applied." >&2
+    return 0
+  fi
+
+  collect_codex_agent_mappings "$target" "$agents_file" codex_mappings
+  collect_opencode_agent_mappings "$target" "$agents_file" opencode_mappings
+
+  if [[ "${#codex_mappings[@]}" -eq 0 && "${#opencode_mappings[@]}" -eq 0 ]]; then
+    echo "Warning: agents orchestration switching enabled but no provider outputs resolved; no mutations applied." >&2
+    return 0
+  fi
+
+  all_mappings=("${codex_mappings[@]}" "${opencode_mappings[@]}")
+  local entry rendered_file _
+  for entry in "${all_mappings[@]}"; do
+    IFS=$'\t' read -r rendered_file _ <<< "$entry"
+    tmp_files+=("$rendered_file")
+  done
+
+  preflight_portable_agents_mappings all_mappings || return 1
+
+  apply_codex_agent_mappings codex_mappings
+  apply_opencode_agent_mappings opencode_mappings
 }

--- a/tooling/lib/cli.sh
+++ b/tooling/lib/cli.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR/common.sh"
 # Read version from VERSION file at repo root (two levels up from tooling/lib/)
 VERSION=$(cat "$(dirname "${BASH_SOURCE[0]}")/../../VERSION" 2>/dev/null || echo "1.0.0")
 
-# ── Library discovery (now in common.sh, keeping for API compatibility) ──────
+# ── Library discovery (in common.sh) ─────────────────────────────────────────
 # These functions are now sourced from common.sh:
 # - discover_library()
 # - find_target_config()

--- a/tooling/lib/cli.sh
+++ b/tooling/lib/cli.sh
@@ -146,6 +146,7 @@ Description:
   - .agentic/profile.yaml
   - .agentic/mcp.yaml
   - .agentic/providers.yaml
+  - .agentic/agents.yaml (portable agents sync: disabled by default)
   - .agentic/project-skills/
 
 Examples:
@@ -168,6 +169,7 @@ Arguments:
 Description:
   Regenerates AGENTS.md and vendor files from the local .agentic/profile.yaml.
   Active vendors are preserved after regeneration.
+  Portable agents mappings run only when .agentic/agents.yaml has enabled: true.
 
 Examples:
   agentic sync

--- a/tooling/lib/cli.sh
+++ b/tooling/lib/cli.sh
@@ -146,7 +146,7 @@ Description:
   - .agentic/profile.yaml
   - .agentic/mcp.yaml
   - .agentic/providers.yaml
-  - .agentic/agents.yaml (agents orchestration switching: disabled by default)
+  - .agentic/agents.yaml
   - .agentic/project-skills/
 
 Examples:

--- a/tooling/lib/cli.sh
+++ b/tooling/lib/cli.sh
@@ -146,7 +146,7 @@ Description:
   - .agentic/profile.yaml
   - .agentic/mcp.yaml
   - .agentic/providers.yaml
-  - .agentic/agents.yaml (portable agents sync: disabled by default)
+  - .agentic/agents.yaml (agents orchestration switching: disabled by default)
   - .agentic/project-skills/
 
 Examples:
@@ -169,7 +169,7 @@ Arguments:
 Description:
   Regenerates AGENTS.md and vendor files from the local .agentic/profile.yaml.
   Active vendors are preserved after regeneration.
-  Portable agents mappings run only when .agentic/agents.yaml has enabled: true.
+  Agents orchestration switching runs only when .agentic/agents.yaml has enabled: true.
 
 Examples:
   agentic sync

--- a/tooling/lib/common.sh
+++ b/tooling/lib/common.sh
@@ -270,7 +270,7 @@ discover_target() {
 # Config reading helpers
 # ══════════════════════════════════════════════════════════════════════════════
 
-# Read active vendors from config, handling both array and legacy string formats
+# Read active vendors from config.
 # Usage: read_active_vendors <config_file>
 # Returns: comma-separated vendor string
 read_active_vendors() {
@@ -278,13 +278,8 @@ read_active_vendors() {
   local vendors=""
   
   if [[ -f "$config" ]]; then
-    # Try new array format first, fall back to old string format
     vendors=$(yq '.active_vendors // [] | join(",")' "$config" 2>/dev/null || true)
-    if [[ -z "$vendors" || "$vendors" == "null" ]]; then
-      # Fallback to old format
-      vendors=$(yq '.active_vendor // ""' "$config" 2>/dev/null || true)
-      [[ "$vendors" == "null" ]] && vendors=""
-    fi
+    [[ "$vendors" == "null" ]] && vendors=""
   fi
   
   echo "$vendors"

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -932,6 +932,7 @@ opencode.json
 .opencode/skills
 .agents/skills
 .cursor/rules
+.agentic/agents/
 
 $MARKER_END
 BLOCK
@@ -958,6 +959,7 @@ opencode.json
 .agentic/skills/
 .agentic/fragments/
 .agentic/vendor-files/
+.agentic/agents/
 
 $MARKER_END
 BLOCK

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -491,7 +491,7 @@ inject_local_override() {
   esac
 }
 
-# ── MCP seeding (new file first, profile fallback) ───────────────────────────
+# ── MCP seeding (from .agentic/mcp.yaml only) ────────────────────────────────
 seed_mcp_servers() {
   local target_mcp_file="$TARGET/.agentic/mcp.yaml"
 
@@ -507,19 +507,6 @@ seed_mcp_servers() {
         --strategy "$mcp_strategy"
     fi
     return 0
-  fi
-
-  local has_legacy_mcp
-  has_legacy_mcp=$(yq '.mcp.servers // "null"' "$PROFILE_FILE")
-  if [[ "$has_legacy_mcp" != "null" && "$has_legacy_mcp" != "{}" ]]; then
-    warn "Deprecated MCP declaration in profile detected. Move MCP config to $target_mcp_file"
-    local mcp_strategy
-    mcp_strategy=$(yq '.mcp.strategy // "merge"' "$PROFILE_FILE")
-    bash "$LIBRARY/tooling/lib/mcp.sh" \
-      --action seed \
-      --target "$TARGET" \
-      --profile-file "$PROFILE_FILE" \
-      --strategy "$mcp_strategy"
   fi
 }
 

--- a/tooling/lib/init.sh
+++ b/tooling/lib/init.sh
@@ -39,10 +39,11 @@ CONFIG_FILE="$AGENTIC_DIR/config.yaml"
 PROFILE_FILE="$AGENTIC_DIR/profile.yaml"
 MCP_FILE="$AGENTIC_DIR/mcp.yaml"
 PROVIDERS_FILE="$AGENTIC_DIR/providers.yaml"
+AGENTS_FILE="$AGENTIC_DIR/agents.yaml"
 
 mkdir -p "$PROJECT_SKILLS_DIR"
 
-if [[ -e "$CONFIG_FILE" || -e "$PROFILE_FILE" || -e "$MCP_FILE" || -e "$PROVIDERS_FILE" ]]; then
+if [[ -e "$CONFIG_FILE" || -e "$PROFILE_FILE" || -e "$MCP_FILE" || -e "$PROVIDERS_FILE" || -e "$AGENTS_FILE" ]]; then
   echo "Error: .agentic skeleton already exists in $TARGET" >&2
   echo "Refusing to overwrite existing files. Remove them manually if needed." >&2
   exit 1
@@ -122,11 +123,19 @@ default_provider: ""
 providers: {}
 EOF
 
+cat > "$AGENTS_FILE" <<'EOF'
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
+version: "1"
+enabled: false
+providers: {}
+EOF
+
 echo "Initialized .agentic skeleton in: $TARGET/.agentic"
 echo "  - config.yaml"
 echo "  - profile.yaml"
 echo "  - mcp.yaml"
 echo "  - providers.yaml"
+echo "  - agents.yaml"
 echo "  - project-skills/"
 
 run_sync=false

--- a/tooling/lib/init.sh
+++ b/tooling/lib/init.sh
@@ -13,6 +13,7 @@ TARGET=""
 PROMPT_SYNC=true
 FORCE_SYNC=false
 SKIP_SYNC=false
+AGENTS_SCHEMA_URL="https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -123,8 +124,8 @@ default_provider: ""
 providers: {}
 EOF
 
-cat > "$AGENTS_FILE" <<'EOF'
-# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
+cat > "$AGENTS_FILE" <<EOF
+# yaml-language-server: \$schema=$AGENTS_SCHEMA_URL
 version: "1"
 enabled: false
 agents: {}

--- a/tooling/lib/init.sh
+++ b/tooling/lib/init.sh
@@ -127,7 +127,7 @@ cat > "$AGENTS_FILE" <<'EOF'
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
 version: "1"
 enabled: false
-providers: {}
+agents: {}
 EOF
 
 echo "Initialized .agentic skeleton in: $TARGET/.agentic"

--- a/tooling/lib/mcp.sh
+++ b/tooling/lib/mcp.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 ACTION=""
 TARGET=""
 NAME=""
-PROFILE_FILE=""
 MCP_FILE_INPUT=""
 STRATEGY="merge"
 
@@ -15,7 +14,6 @@ while [[ $# -gt 0 ]]; do
     --action) ACTION="$2"; shift 2 ;;
     --target) TARGET="$2"; shift 2 ;;
     --name)   NAME="$2";   shift 2 ;;
-    --profile-file) PROFILE_FILE="$2"; shift 2 ;;
     --mcp-file) MCP_FILE_INPUT="$2"; shift 2 ;;
     --strategy)     STRATEGY="$2";   shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
@@ -360,19 +358,15 @@ case "$ACTION" in
   remove) action_remove ;;
   list)   action_list   ;;
   seed)
-    # Non-interactive seed from .agentic/mcp.yaml or legacy profile mcp key
+    # Non-interactive seed from .agentic/mcp.yaml
     seed_source_file=""
-    seed_source_path=""
     if [[ -n "$MCP_FILE_INPUT" ]]; then
       seed_source_file="$MCP_FILE_INPUT"
       seed_source_path="."
-    elif [[ -n "$PROFILE_FILE" ]]; then
-      seed_source_file="$PROFILE_FILE"
-      seed_source_path=".mcp"
     fi
 
     [[ -z "$seed_source_file" ]] && {
-      echo "Error: --mcp-file or --profile-file required for seed action" >&2
+      echo "Error: --mcp-file required for seed action" >&2
       exit 1
     }
     [[ -f "$seed_source_file" ]] || { echo "Error: seed source file not found: $seed_source_file" >&2; exit 1; }

--- a/tooling/lib/sync.sh
+++ b/tooling/lib/sync.sh
@@ -54,19 +54,6 @@ if [[ -f "$CONFIG_PATH" ]]; then
   [[ "$LIBRARY" == "null" || "$LIBRARY" == '""' ]] && LIBRARY=""
 fi
 
-# Fall back to legacy library_path key if agentic_root is empty
-if [[ -z "$LIBRARY" && -f "$CONFIG_PATH" ]]; then
-  legacy_path=$(yq '.library_path // ""' "$CONFIG_PATH" 2>/dev/null || echo "")
-  if [[ -n "$legacy_path" && "$legacy_path" != "null" && "$legacy_path" != '""' ]]; then
-    warn "library_path is deprecated. Use agentic_root in .agentic/config.yaml"
-    # Resolve relative paths
-    if [[ "$legacy_path" != /* ]]; then
-      legacy_path="$(cd "$TARGET" && cd "$legacy_path" 2>/dev/null && pwd)" || true
-    fi
-    LIBRARY="$legacy_path"
-  fi
-fi
-
 # Fall back to env vars if not in config
 if [[ -z "$LIBRARY" ]]; then
   if [[ -n "${AGENTIC_REPO_ROOT:-}" ]]; then

--- a/tooling/lib/sync.sh
+++ b/tooling/lib/sync.sh
@@ -11,6 +11,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 # shellcheck source=tooling/lib/providers.sh
 source "$SCRIPT_DIR/providers.sh"
+# shellcheck source=tooling/lib/agents.sh
+source "$SCRIPT_DIR/agents.sh"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 TARGET=""
@@ -39,6 +41,7 @@ LOCAL_PROFILE="$TARGET/.agentic/profile.yaml"
 }
 
 validate_providers_config "$TARGET"
+validate_agents_config "$TARGET"
 
 # ── Resolve library path ────────────────────────────────────────────────────────
 # Use discover_library_from_target function which reads from target's config
@@ -118,6 +121,8 @@ if [[ -n "$ACTIVE_VENDORS" ]]; then
   VENDOR_SWITCH="$LIBRARY/tooling/lib/vendor-switch.sh"
   bash "$VENDOR_SWITCH" --library "$LIBRARY" --target "$TARGET" "$ACTIVE_VENDORS"
 fi
+
+sync_portable_agents "$TARGET"
 
 echo ""
 echo "Sync complete. Project regenerated from local profile."

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -712,31 +712,6 @@ fi
 assert_file_contains "$TMP/t32/.agentic/config.yaml" "active_vendors:" "T32"
 assert_file_contains "$TMP/t32/.agentic/config.yaml" "  - codex" "T32"
 
-# T33 — vendor-switch: migration removes old stash directory
-run_test "T33 — vendor-switch: migrates from old stash system"
-mkdir -p "$TMP/t33"
-bash "$COMPOSE" \
-  --library "$LIBRARY" \
-  --profile golang-hexagonal-cobra-cli \
-  --target "$TMP/t33" \
-  > /dev/null 2>&1
-
-# Simulate old stash directory
-mkdir -p "$TMP/t33/.agentic/vendor-stash/claude"
-echo "old file" > "$TMP/t33/.agentic/vendor-stash/claude/CLAUDE.md"
-
-# Run vendor-switch
-bash "$VENDOR_SWITCH" \
-  --library "$LIBRARY" \
-  --target "$TMP/t33" \
-  claude \
-  > /dev/null 2>&1
-
-# Old stash should be removed
-assert_file_not_exists "$TMP/t33/.agentic/vendor-stash" "T33"
-# New vendor-files should exist
-assert_file_exists "$TMP/t33/.agentic/vendor-files/claude/CLAUDE.md" "T33"
-
 # T34 — skills README contains vendor compatibility table
 run_test "T34 — deploy-skills: README contains vendor compatibility info"
 mkdir -p "$TMP/t34"
@@ -1367,13 +1342,28 @@ assert_stdout_contains "$T57_OUTPUT" "--global" "T57"
 assert_stdout_contains "$T57_OUTPUT" "--branch" "T57"
 
 # ══════════════════════════════════════════════════════════════════════════════
-# MCP SERVER SEEDING TESTS (profile mcp: key)
+# MCP SERVER SEEDING TESTS
 # ══════════════════════════════════════════════════════════════════════════════
 
 # T67 — compose: MCP seed creates .mcp.json with correct keys
 run_test "T67 — compose: MCP seed creates .mcp.json"
-# Create a profile with mcp.servers
-mkdir -p "$TMP/t67"
+# Create an mcp.yaml source
+mkdir -p "$TMP/t67/.agentic"
+cat > "$TMP/t67/.agentic/mcp.yaml" <<'EOF'
+strategy: merge
+servers:
+  github:
+    type: stdio
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-github"]
+  postgres:
+    type: stdio
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-postgres"]
+    env:
+      DATABASE_URL: "postgresql://localhost:5432"
+EOF
+
 cat > "$TMP/t67-profile.yaml" <<'EOF'
 meta:
   name: Test MCP Profile
@@ -1388,19 +1378,6 @@ output:
   lint_command: ""
 vendors:
   enabled: []
-mcp:
-  strategy: merge
-  servers:
-    github:
-      type: stdio
-      command: npx
-      args: ["-y", "@modelcontextprotocol/server-github"]
-    postgres:
-      type: stdio
-      command: npx
-      args: ["-y", "@modelcontextprotocol/server-postgres"]
-      env:
-        DATABASE_URL: "postgresql://localhost:5432"
 EOF
 
 bash "$COMPOSE" \
@@ -1418,9 +1395,18 @@ assert_file_contains "$TMP/t67/.mcp.json" '"command": "npx"' "T67"
 
 # T68 — compose: MCP seed writes to opencode.json with translations
 run_test "T68 — compose: MCP seed translates for opencode.json"
-mkdir -p "$TMP/t68"
+mkdir -p "$TMP/t68/.agentic"
 # Create opencode.json first (simulating existing vendor)
 echo '{"mcp":{}}' > "$TMP/t68/opencode.json"
+cat > "$TMP/t68/.agentic/mcp.yaml" <<'EOF'
+servers:
+  test-server:
+    type: stdio
+    command: npx
+    args: ["-y", "some-server"]
+    env:
+      MY_TOKEN: "${MY_TOKEN}"
+EOF
 
 cat > "$TMP/t68-profile.yaml" <<'EOF'
 meta:
@@ -1436,14 +1422,6 @@ output:
   lint_command: ""
 vendors:
   enabled: []
-mcp:
-  servers:
-    test-server:
-      type: stdio
-      command: npx
-      args: ["-y", "some-server"]
-      env:
-        MY_TOKEN: "${MY_TOKEN}"
 EOF
 
 bash "$COMPOSE" \
@@ -1459,10 +1437,16 @@ assert_file_contains "$TMP/t68/opencode.json" '"environment"' "T68"
 
 # T69 — compose: MCP seed writes to .gemini/settings.json without type field
 run_test "T69 — compose: MCP seed translates for .gemini/settings.json"
-mkdir -p "$TMP/t69/.gemini"
+mkdir -p "$TMP/t69/.agentic" "$TMP/t69/.gemini"
 echo '{"mcpServers":{}}' > "$TMP/t69/.gemini/settings.json"
 mkdir -p "$TMP/t69/.cursor"
 echo '{"mcpServers":{}}' > "$TMP/t69/.cursor/mcp.json"
+cat > "$TMP/t69/.agentic/mcp.yaml" <<'EOF'
+servers:
+  http-server:
+    type: http
+    url: "http://localhost:3000"
+EOF
 
 cat > "$TMP/t69-profile.yaml" <<'EOF'
 meta:
@@ -1478,11 +1462,6 @@ output:
   lint_command: ""
 vendors:
   enabled: []
-mcp:
-  servers:
-    http-server:
-      type: http
-      url: "http://localhost:3000"
 EOF
 
 bash "$COMPOSE" \
@@ -1503,9 +1482,17 @@ assert_file_contains "$TMP/t69/.cursor/mcp.json" '"type": "http"' "T69 cursor tr
 
 # T70 — compose: MCP merge strategy preserves existing servers
 run_test "T70 — compose: MCP merge preserves existing servers"
-mkdir -p "$TMP/t70"
+mkdir -p "$TMP/t70/.agentic"
 # Pre-existing .mcp.json with a server
 echo '{"mcpServers":{"existing-server":{"type":"stdio","command":"echo","args":["hello"]}}}' > "$TMP/t70/.mcp.json"
+cat > "$TMP/t70/.agentic/mcp.yaml" <<'EOF'
+strategy: merge
+servers:
+  new-server:
+    type: stdio
+    command: echo
+    args: ["new"]
+EOF
 
 cat > "$TMP/t70-profile.yaml" <<'EOF'
 meta:
@@ -1521,13 +1508,6 @@ output:
   lint_command: ""
 vendors:
   enabled: []
-mcp:
-  strategy: merge
-  servers:
-    new-server:
-      type: stdio
-      command: echo
-      args: ["new"]
 EOF
 
 bash "$COMPOSE" \
@@ -1541,10 +1521,17 @@ assert_file_contains "$TMP/t70/.mcp.json" "new-server" "T70"
 
 # T71 — compose: MCP replace strategy removes old servers
 run_test "T71 — compose: MCP replace removes old servers"
-mkdir -p "$TMP/t71"
+mkdir -p "$TMP/t71/.agentic"
 echo '{"mcpServers":{"old-server":{"type":"stdio","command":"old","args":["old"]}}}' > "$TMP/t71/.mcp.json"
 mkdir -p "$TMP/t71/.cursor"
 echo '{"mcpServers":{"old-server":{"type":"stdio","command":"old","args":["old"]}}}' > "$TMP/t71/.cursor/mcp.json"
+cat > "$TMP/t71/.agentic/mcp.yaml" <<'EOF'
+strategy: replace
+servers:
+  brand-new:
+    type: http
+    url: "http://localhost:8080"
+EOF
 
 cat > "$TMP/t71-profile.yaml" <<'EOF'
 meta:
@@ -1560,12 +1547,6 @@ output:
   lint_command: ""
 vendors:
   enabled: []
-mcp:
-  strategy: replace
-  servers:
-    brand-new:
-      type: http
-      url: "http://localhost:8080"
 EOF
 
 bash "$COMPOSE" \
@@ -1581,7 +1562,15 @@ assert_file_not_contains "$TMP/t71/.cursor/mcp.json" "old-server" "T71 cursor re
 
 # T71B — compose: invalid existing .cursor/mcp.json fails safely
 run_test "T71B — compose: invalid .cursor/mcp.json fails"
-mkdir -p "$TMP/t71b/.cursor"
+mkdir -p "$TMP/t71b/.agentic" "$TMP/t71b/.cursor"
+cat > "$TMP/t71b/.agentic/mcp.yaml" <<'EOF'
+strategy: merge
+servers:
+  server-a:
+    type: stdio
+    command: npx
+    args: ["-y", "foo"]
+EOF
 cat > "$TMP/t71b-profile.yaml" <<'EOF'
 meta:
   name: Test Cursor MCP Invalid
@@ -1596,13 +1585,6 @@ output:
   lint_command: ""
 vendors:
   enabled: []
-mcp:
-  strategy: merge
-  servers:
-    server-a:
-      type: stdio
-      command: npx
-      args: ["-y", "foo"]
 EOF
 printf '%s\n' '{invalid' > "$TMP/t71b/.cursor/mcp.json"
 T71B_EXIT=0
@@ -2303,7 +2285,7 @@ AGENTIC_REPO_ROOT="$LIBRARY" "$CLI" init "$TMP/t101" --sync > /dev/null 2>&1
 assert_file_exists "$TMP/t101/AGENTS.md" "T101 AGENTS"
 assert_file_contains "$TMP/t101/AGENTS.md" "<!-- AUTO-GENERATED by agentic library -->" "T101 generated marker"
 
-# T102 — compose: .agentic/mcp.yaml takes precedence over legacy profile mcp
+# T102 — compose: .agentic/mcp.yaml takes precedence over profile mcp
 run_test "T102 — compose: mcp.yaml precedence"
 mkdir -p "$TMP/t102/.agentic"
 cat > "$TMP/t102/.agentic/mcp.yaml" <<'EOF'
@@ -2349,13 +2331,13 @@ assert_file_exists "$TMP/t102/.mcp.json" "T102 mcp json"
 assert_file_contains "$TMP/t102/.mcp.json" "file-server" "T102 file server present"
 assert_file_not_contains "$TMP/t102/.mcp.json" "legacy-server" "T102 legacy server ignored"
 
-# T103 — compose: legacy profile mcp still works with deprecation warning
-run_test "T103 — compose: legacy profile mcp fallback warning"
+# T103 — compose: profile mcp block is ignored without .agentic/mcp.yaml
+run_test "T103 — compose: profile mcp block is ignored"
 mkdir -p "$TMP/t103"
 cat > "$TMP/t103-profile.yaml" <<'EOF'
 meta:
-  name: Test Legacy MCP
-  description: Test legacy mcp fallback
+  name: Test Profile MCP Ignored
+  description: Profile mcp should be ignored
   version: "1.0.0"
 fragments:
   base:
@@ -2369,21 +2351,19 @@ vendors:
 mcp:
   strategy: merge
   servers:
-    legacy-only:
+    ignored-server:
       type: stdio
       command: legacy-mcp
       args: ["--ok"]
 EOF
 T103_EXIT=0
-T103_OUTPUT=$(bash "$COMPOSE" \
+bash "$COMPOSE" \
   --library "$LIBRARY" \
   --profile-file "$TMP/t103-profile.yaml" \
   --target "$TMP/t103" \
-  2>&1) || T103_EXIT=$?
+  > /dev/null 2>&1 || T103_EXIT=$?
 assert_exit_code 0 "$T103_EXIT" "T103"
-assert_stdout_contains "$T103_OUTPUT" "Deprecated MCP declaration in profile detected" "T103 warning"
-assert_file_exists "$TMP/t103/.mcp.json" "T103 mcp json"
-assert_file_contains "$TMP/t103/.mcp.json" "legacy-only" "T103 legacy server seeded"
+assert_file_not_exists "$TMP/t103/.mcp.json" "T103 mcp json not generated"
 
 # T103B — compose: invalid providers.yaml fails clearly
 run_test "T103B — compose: invalid providers config fails"
@@ -2438,7 +2418,7 @@ T103C_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
 assert_exit_code 1 "$T103C_EXIT" "T103C"
 assert_stdout_contains "$T103C_OUTPUT" "must be boolean" "T103C"
 
-# T103D — sync: missing agents.yaml remains backward-compatible
+# T103D — sync: missing agents.yaml is skipped
 run_test "T103D — sync: missing agents.yaml is skipped"
 mkdir -p "$TMP/t103d"
 bash "$COMPOSE" \
@@ -2590,9 +2570,9 @@ agents:
         enabled: true
 EOF
 T103I_EXIT=0
-T103I_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103i" \
-  2>&1) || T103I_EXIT=$?
+  > /dev/null 2>&1 || T103I_EXIT=$?
 assert_exit_code 0 "$T103I_EXIT" "T103I"
 assert_file_contains "$TMP/t103i/.codex/agents/architect.md" "unmanaged local content" "T103I preserved destination"
 assert_file_exists "$TMP/t103i/.agentic/agents/codex/architect.md" "T103I codex canonical write"
@@ -2767,7 +2747,7 @@ agents:
       opencode:
         enabled: true
 EOF
-yq -i '.active_vendors = ["codex"] | del(.active_vendor)' "$TMP/t103o/.agentic/config.yaml"
+yq -i '.active_vendors = ["codex"]' "$TMP/t103o/.agentic/config.yaml"
 T103O_EXIT=0
 bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103o" \
@@ -2800,7 +2780,7 @@ agents:
       opencode:
         enabled: true
 EOF
-yq -i '.active_vendors = ["opencode"] | del(.active_vendor)' "$TMP/t103p/.agentic/config.yaml"
+yq -i '.active_vendors = ["opencode"]' "$TMP/t103p/.agentic/config.yaml"
 T103P_EXIT=0
 bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103p" \
@@ -2833,7 +2813,7 @@ agents:
       opencode:
         enabled: true
 EOF
-yq -i '.active_vendors = ["codex", "opencode"] | del(.active_vendor)' "$TMP/t103q/.agentic/config.yaml"
+yq -i '.active_vendors = ["codex", "opencode"]' "$TMP/t103q/.agentic/config.yaml"
 T103Q_EXIT=0
 bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103q" \
@@ -3233,34 +3213,6 @@ bash "$VENDOR_SWITCH" \
 assert_symlink_exists "$TMP/t127c/.cursor/rules" "T127C rules symlink created"
 assert_file_exists "$TMP/t127c/.cursor/rules.backup.1/custom.mdc" "T127C incremental backup created"
 assert_file_exists "$TMP/t127c/.cursor/rules.backup/existing.txt" "T127C existing backup retained"
-
-# T127CA — vendor-switch: codex migrates legacy .agents/orchestration to backup and activates .codex/agents
-run_test "T127CA — vendor-switch: codex legacy orchestration migration"
-mkdir -p "$TMP/t127ca"
-mkdir -p "$TMP/t127ca/.agents/orchestration"
-mkdir -p "$TMP/t127ca/.agents/orchestration.backup"
-printf '%s\n' "existing backup marker" > "$TMP/t127ca/.agents/orchestration.backup/existing.txt"
-printf '%s\n' "legacy codex agent" > "$TMP/t127ca/.agents/orchestration/architect.md"
-bash "$COMPOSE" \
-  --library "$LIBRARY" \
-  --profile typescript-hexagonal-microservice \
-  --target "$TMP/t127ca" \
-  > /dev/null 2>&1
-bash "$VENDOR_GEN" \
-  --library "$LIBRARY" \
-  --target "$TMP/t127ca" \
-  --vendors codex \
-  > /dev/null 2>&1
-bash "$VENDOR_SWITCH" \
-  --library "$LIBRARY" \
-  --target "$TMP/t127ca" \
-  codex \
-  > /dev/null 2>&1
-assert_symlink_exists "$TMP/t127ca/.codex/agents" "T127CA codex symlink created"
-assert_symlink_target "$TMP/t127ca/.codex/agents" "../.agentic/agents/codex" "T127CA codex symlink target"
-assert_file_exists "$TMP/t127ca/.agents/orchestration.backup.1/architect.md" "T127CA legacy path migrated"
-assert_file_exists "$TMP/t127ca/.agents/orchestration.backup/existing.txt" "T127CA existing backup retained"
-assert_file_not_exists "$TMP/t127ca/.agents/orchestration" "T127CA legacy path replaced"
 
 # T127D — vendor-switch: rollback restores prior vendor state on post-mutation failure
 run_test "T127D — vendor-switch: rollback restores prior state on failure"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2468,8 +2468,6 @@ bash "$COMPOSE" \
   --profile typescript-hexagonal-microservice \
   --target "$TMP/t103f" \
   > /dev/null 2>&1
-mkdir -p "$TMP/t103f/.agentic/portable"
-echo "architect agent instructions" > "$TMP/t103f/.agentic/portable/architect.md"
 cat > "$TMP/t103f/.agentic/agents.yaml" <<'EOF'
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
 version: "1"
@@ -2477,7 +2475,9 @@ enabled: true
 agents:
   architect:
     description: "Plans the implementation."
-    prompt: ".agentic/portable/architect.md"
+    prompt: |
+      You are the architect agent.
+      Focus on planning and boundaries.
     providers:
       codex:
         enabled: true
@@ -2493,8 +2493,8 @@ bash "$LIBRARY/tooling/lib/sync.sh" \
 assert_exit_code 0 "$T103F_EXIT" "T103F"
 assert_file_exists "$TMP/t103f/.agents/orchestration/architect.md" "T103F codex target"
 assert_file_exists "$TMP/t103f/.opencode/agents/architect.md" "T103F opencode target"
-assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "architect agent instructions" "T103F codex content"
-assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "architect agent instructions" "T103F opencode content"
+assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "You are the architect agent." "T103F codex content"
+assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "You are the architect agent." "T103F opencode content"
 assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "model: gpt-5.3-codex" "T103F codex model"
 assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "model: openai/gpt-5" "T103F opencode model"
 
@@ -2550,8 +2550,6 @@ bash "$COMPOSE" \
   --profile typescript-hexagonal-microservice \
   --target "$TMP/t103i" \
   > /dev/null 2>&1
-mkdir -p "$TMP/t103i/.agentic/portable"
-echo "architect agent instructions" > "$TMP/t103i/.agentic/portable/architect.md"
 mkdir -p "$TMP/t103i/.agents/orchestration"
 echo "unmanaged local content" > "$TMP/t103i/.agents/orchestration/architect.md"
 cat > "$TMP/t103i/.agentic/agents.yaml" <<'EOF'
@@ -2561,7 +2559,9 @@ enabled: true
 agents:
   architect:
     description: "Plans the implementation."
-    prompt: ".agentic/portable/architect.md"
+    prompt: |
+      You are the architect agent.
+      Focus on planning and boundaries.
     providers:
       codex:
         enabled: true
@@ -2576,6 +2576,106 @@ assert_exit_code 1 "$T103I_EXIT" "T103I"
 assert_stdout_contains "$T103I_OUTPUT" "Unmanaged destination conflict" "T103I"
 assert_file_contains "$TMP/t103i/.agents/orchestration/architect.md" "unmanaged local content" "T103I preserved destination"
 assert_file_not_exists "$TMP/t103i/.opencode/agents/architect.md" "T103I zero writes"
+
+# T103J — sync: invalid agent key fails validation
+run_test "T103J — sync: invalid agent key fails"
+mkdir -p "$TMP/t103j"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103j" \
+  > /dev/null 2>&1
+cat > "$TMP/t103j/.agentic/agents.yaml" <<'EOF'
+version: "1"
+enabled: true
+agents:
+  Architect:
+    description: "Invalid key casing."
+    prompt: "text"
+EOF
+T103J_EXIT=0
+T103J_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103j" \
+  2>&1) || T103J_EXIT=$?
+assert_exit_code 1 "$T103J_EXIT" "T103J"
+assert_stdout_contains "$T103J_OUTPUT" "Invalid agent key" "T103J"
+
+# T103K — sync: missing prompt/description fails validation
+run_test "T103K — sync: missing prompt or description fails"
+mkdir -p "$TMP/t103k"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103k" \
+  > /dev/null 2>&1
+cat > "$TMP/t103k/.agentic/agents.yaml" <<'EOF'
+version: "1"
+enabled: true
+agents:
+  architect:
+    description: ""
+    prompt: ""
+EOF
+T103K_EXIT=0
+T103K_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103k" \
+  2>&1) || T103K_EXIT=$?
+assert_exit_code 1 "$T103K_EXIT" "T103K"
+assert_stdout_contains "$T103K_OUTPUT" "must define non-empty description and prompt" "T103K"
+
+# T103L — sync: invalid provider under agent fails validation
+run_test "T103L — sync: invalid provider fails"
+mkdir -p "$TMP/t103l"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103l" \
+  > /dev/null 2>&1
+cat > "$TMP/t103l/.agentic/agents.yaml" <<'EOF'
+version: "1"
+enabled: true
+agents:
+  architect:
+    description: "Provider validation test."
+    prompt: "text"
+    providers:
+      claude:
+        enabled: true
+EOF
+T103L_EXIT=0
+T103L_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103l" \
+  2>&1) || T103L_EXIT=$?
+assert_exit_code 1 "$T103L_EXIT" "T103L"
+assert_stdout_contains "$T103L_OUTPUT" "has invalid provider" "T103L"
+
+# T103M — sync: provider-disabled agents resolve no outputs and warn
+run_test "T103M — sync: provider-disabled definitions resolve no outputs"
+mkdir -p "$TMP/t103m"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103m" \
+  > /dev/null 2>&1
+cat > "$TMP/t103m/.agentic/agents.yaml" <<'EOF'
+version: "1"
+enabled: true
+agents:
+  architect:
+    description: "Provider disabled test."
+    prompt: "some prompt text"
+    providers:
+      codex:
+        enabled: false
+      opencode:
+        enabled: false
+EOF
+T103M_EXIT=0
+T103M_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103m" \
+  2>&1) || T103M_EXIT=$?
+assert_exit_code 0 "$T103M_EXIT" "T103M"
+assert_stdout_contains "$T103M_OUTPUT" "no provider outputs resolved; no mutations applied" "T103M"
 
 # T104 — compose: standalone typescript-react-spa profile
 run_test "T104 — compose: standalone typescript-react-spa profile"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2277,6 +2277,7 @@ assert_file_contains "$TMP/t99/.agentic/mcp.yaml" "# yaml-language-server: \$sch
 assert_file_contains "$TMP/t99/.agentic/providers.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/providers.schema.json" "T100 providers schema"
 assert_file_contains "$TMP/t99/.agentic/agents.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json" "T100 agents schema"
 assert_file_contains "$TMP/t99/.agentic/agents.yaml" "enabled: false" "T100 agents noop"
+assert_file_contains "$TMP/t99/.agentic/agents.yaml" "agents: {}" "T100 agents empty defs"
 
 # T101 — init --sync: scaffolds and composes immediately
 run_test "T101 — init --sync composes project"
@@ -2436,7 +2437,7 @@ T103D_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
 assert_exit_code 0 "$T103D_EXIT" "T103D"
 assert_stdout_contains "$T103D_OUTPUT" "Sync complete" "T103D"
 
-# T103E — sync: no-op agents.yaml skips portable agents sync
+# T103E — sync: no-op agents.yaml skips agents orchestration switching
 run_test "T103E — sync: no-op agents config skips sync"
 mkdir -p "$TMP/t103e"
 bash "$COMPOSE" \
@@ -2450,7 +2451,7 @@ cat > "$TMP/t103e/.agentic/agents.yaml" <<'EOF'
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
 version: "1"
 enabled: false
-providers: {}
+agents: {}
 EOF
 T103E_EXIT=0
 bash "$LIBRARY/tooling/lib/sync.sh" \
@@ -2459,8 +2460,8 @@ bash "$LIBRARY/tooling/lib/sync.sh" \
 assert_exit_code 0 "$T103E_EXIT" "T103E"
 assert_file_not_exists "$TMP/t103e/.agents/AGENTS.md" "T103E"
 
-# T103F — sync: opt-in agents.yaml syncs codex and opencode mappings
-run_test "T103F — sync: opt-in agents config syncs mappings"
+# T103F — sync: opt-in agents.yaml syncs codex and opencode agent definitions
+run_test "T103F — sync: opt-in agents config syncs agent definitions"
 mkdir -p "$TMP/t103f"
 bash "$COMPOSE" \
   --library "$LIBRARY" \
@@ -2468,33 +2469,113 @@ bash "$COMPOSE" \
   --target "$TMP/t103f" \
   > /dev/null 2>&1
 mkdir -p "$TMP/t103f/.agentic/portable"
-echo "portable codex instructions" > "$TMP/t103f/.agentic/portable/codex.md"
-echo "portable opencode instructions" > "$TMP/t103f/.agentic/portable/opencode.md"
+echo "architect agent instructions" > "$TMP/t103f/.agentic/portable/architect.md"
 cat > "$TMP/t103f/.agentic/agents.yaml" <<'EOF'
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
 version: "1"
 enabled: true
-providers:
-  codex:
-    enabled: true
-    mappings:
-      - source: ".agentic/portable/codex.md"
-        target: ".agents/AGENTS.md"
-  opencode:
-    enabled: true
-    mappings:
-      - source: ".agentic/portable/opencode.md"
-        target: ".opencode/AGENTS.md"
+agents:
+  architect:
+    description: "Plans the implementation."
+    prompt: ".agentic/portable/architect.md"
+    providers:
+      codex:
+        enabled: true
+        model: "gpt-5.3-codex"
+      opencode:
+        enabled: true
+        model: "openai/gpt-5"
 EOF
 T103F_EXIT=0
 bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103f" \
   > /dev/null 2>&1 || T103F_EXIT=$?
 assert_exit_code 0 "$T103F_EXIT" "T103F"
-assert_file_exists "$TMP/t103f/.agents/AGENTS.md" "T103F codex target"
-assert_file_exists "$TMP/t103f/.opencode/AGENTS.md" "T103F opencode target"
-assert_file_contains "$TMP/t103f/.agents/AGENTS.md" "portable codex instructions" "T103F codex content"
-assert_file_contains "$TMP/t103f/.opencode/AGENTS.md" "portable opencode instructions" "T103F opencode content"
+assert_file_exists "$TMP/t103f/.agents/orchestration/architect.md" "T103F codex target"
+assert_file_exists "$TMP/t103f/.opencode/agents/architect.md" "T103F opencode target"
+assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "architect agent instructions" "T103F codex content"
+assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "architect agent instructions" "T103F opencode content"
+assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "model: gpt-5.3-codex" "T103F codex model"
+assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "model: openai/gpt-5" "T103F opencode model"
+
+# T103G — sync: enabled with no agent definitions warns and performs no mutations
+run_test "T103G — sync: enabled with empty agents is warning/no-op"
+mkdir -p "$TMP/t103g"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103g" \
+  > /dev/null 2>&1
+cat > "$TMP/t103g/.agentic/agents.yaml" <<'EOF'
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
+version: "1"
+enabled: true
+agents: {}
+EOF
+T103G_EXIT=0
+T103G_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103g" \
+  2>&1) || T103G_EXIT=$?
+assert_exit_code 0 "$T103G_EXIT" "T103G"
+assert_stdout_contains "$T103G_OUTPUT" "enabled but no agent definitions found; no mutations applied" "T103G warning"
+assert_file_not_exists "$TMP/t103g/.agents/orchestration/architect.md" "T103G codex no-op"
+assert_file_not_exists "$TMP/t103g/.opencode/agents/architect.md" "T103G opencode no-op"
+
+# T103H — sync: agents.yaml version must be exactly "1"
+run_test "T103H — sync: invalid agents.yaml version fails"
+mkdir -p "$TMP/t103h"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103h" \
+  > /dev/null 2>&1
+cat > "$TMP/t103h/.agentic/agents.yaml" <<'EOF'
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
+version: "2"
+enabled: true
+agents: {}
+EOF
+T103H_EXIT=0
+T103H_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103h" \
+  2>&1) || T103H_EXIT=$?
+assert_exit_code 1 "$T103H_EXIT" "T103H"
+assert_stdout_contains "$T103H_OUTPUT" "version must be \"1\"" "T103H"
+
+# T103I — sync: unmanaged destination conflict fails before any write
+run_test "T103I — sync: unmanaged destination conflict preflight fails"
+mkdir -p "$TMP/t103i"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103i" \
+  > /dev/null 2>&1
+mkdir -p "$TMP/t103i/.agentic/portable"
+echo "architect agent instructions" > "$TMP/t103i/.agentic/portable/architect.md"
+mkdir -p "$TMP/t103i/.agents/orchestration"
+echo "unmanaged local content" > "$TMP/t103i/.agents/orchestration/architect.md"
+cat > "$TMP/t103i/.agentic/agents.yaml" <<'EOF'
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
+version: "1"
+enabled: true
+agents:
+  architect:
+    description: "Plans the implementation."
+    prompt: ".agentic/portable/architect.md"
+    providers:
+      codex:
+        enabled: true
+      opencode:
+        enabled: true
+EOF
+T103I_EXIT=0
+T103I_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103i" \
+  2>&1) || T103I_EXIT=$?
+assert_exit_code 1 "$T103I_EXIT" "T103I"
+assert_stdout_contains "$T103I_OUTPUT" "Unmanaged destination conflict" "T103I"
+assert_file_contains "$TMP/t103i/.agents/orchestration/architect.md" "unmanaged local content" "T103I preserved destination"
+assert_file_not_exists "$TMP/t103i/.opencode/agents/architect.md" "T103I zero writes"
 
 # T104 — compose: standalone typescript-react-spa profile
 run_test "T104 — compose: standalone typescript-react-spa profile"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2538,7 +2538,7 @@ T103G_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103g" \
   2>&1) || T103G_EXIT=$?
 assert_exit_code 0 "$T103G_EXIT" "T103G"
-assert_stdout_contains "$T103G_OUTPUT" "enabled but no agent definitions found; no mutations applied" "T103G warning"
+assert_stdout_contains "$T103G_OUTPUT" "no mutations applied" "T103G warning"
 assert_file_not_exists "$TMP/t103g/.agentic/agents/codex/architect.md" "T103G codex no-op"
 assert_file_not_exists "$TMP/t103g/.agentic/agents/opencode/architect.md" "T103G opencode no-op"
 
@@ -2571,8 +2571,8 @@ bash "$COMPOSE" \
   --profile typescript-hexagonal-microservice \
   --target "$TMP/t103i" \
   > /dev/null 2>&1
-mkdir -p "$TMP/t103i/.agents/orchestration"
-echo "unmanaged local content" > "$TMP/t103i/.agents/orchestration/architect.md"
+mkdir -p "$TMP/t103i/.codex/agents"
+echo "unmanaged local content" > "$TMP/t103i/.codex/agents/architect.md"
 cat > "$TMP/t103i/.agentic/agents.yaml" <<'EOF'
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
 version: "1"
@@ -2594,7 +2594,7 @@ T103I_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103i" \
   2>&1) || T103I_EXIT=$?
 assert_exit_code 0 "$T103I_EXIT" "T103I"
-assert_file_contains "$TMP/t103i/.agents/orchestration/architect.md" "unmanaged local content" "T103I preserved destination"
+assert_file_contains "$TMP/t103i/.codex/agents/architect.md" "unmanaged local content" "T103I preserved destination"
 assert_file_exists "$TMP/t103i/.agentic/agents/codex/architect.md" "T103I codex canonical write"
 assert_file_exists "$TMP/t103i/.agentic/agents/opencode/architect.md" "T103I opencode canonical write"
 
@@ -2773,8 +2773,8 @@ bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103o" \
   > /dev/null 2>&1 || T103O_EXIT=$?
 assert_exit_code 0 "$T103O_EXIT" "T103O"
-assert_symlink_exists "$TMP/t103o/.agents/orchestration" "T103O codex symlink exists"
-assert_symlink_target "$TMP/t103o/.agents/orchestration" "../.agentic/agents/codex" "T103O codex symlink target"
+assert_symlink_exists "$TMP/t103o/.codex/agents" "T103O codex symlink exists"
+assert_symlink_target "$TMP/t103o/.codex/agents" "../.agentic/agents/codex" "T103O codex symlink target"
 assert_file_not_exists "$TMP/t103o/.opencode/agents" "T103O opencode symlink removed"
 assert_file_exists "$TMP/t103o/.agentic/agents/codex/architect.md" "T103O codex canonical"
 assert_file_exists "$TMP/t103o/.agentic/agents/opencode/architect.md" "T103O opencode canonical retained"
@@ -2808,7 +2808,7 @@ bash "$LIBRARY/tooling/lib/sync.sh" \
 assert_exit_code 0 "$T103P_EXIT" "T103P"
 assert_symlink_exists "$TMP/t103p/.opencode/agents" "T103P opencode symlink exists"
 assert_symlink_target "$TMP/t103p/.opencode/agents" "../.agentic/agents/opencode" "T103P opencode symlink target"
-assert_file_not_exists "$TMP/t103p/.agents/orchestration" "T103P codex symlink removed"
+assert_file_not_exists "$TMP/t103p/.codex/agents" "T103P codex symlink removed"
 assert_file_exists "$TMP/t103p/.agentic/agents/codex/architect.md" "T103P codex canonical retained"
 assert_file_exists "$TMP/t103p/.agentic/agents/opencode/architect.md" "T103P opencode canonical"
 
@@ -2839,8 +2839,8 @@ bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103q" \
   > /dev/null 2>&1 || T103Q_EXIT=$?
 assert_exit_code 0 "$T103Q_EXIT" "T103Q"
-assert_symlink_exists "$TMP/t103q/.agents/orchestration" "T103Q codex symlink"
-assert_symlink_target "$TMP/t103q/.agents/orchestration" "../.agentic/agents/codex" "T103Q codex symlink target"
+assert_symlink_exists "$TMP/t103q/.codex/agents" "T103Q codex symlink"
+assert_symlink_target "$TMP/t103q/.codex/agents" "../.agentic/agents/codex" "T103Q codex symlink target"
 assert_symlink_exists "$TMP/t103q/.opencode/agents" "T103Q opencode symlink"
 assert_symlink_target "$TMP/t103q/.opencode/agents" "../.agentic/agents/opencode" "T103Q opencode symlink target"
 assert_file_exists "$TMP/t103q/.agentic/agents/codex/architect.md" "T103Q codex canonical"
@@ -3233,6 +3233,34 @@ bash "$VENDOR_SWITCH" \
 assert_symlink_exists "$TMP/t127c/.cursor/rules" "T127C rules symlink created"
 assert_file_exists "$TMP/t127c/.cursor/rules.backup.1/custom.mdc" "T127C incremental backup created"
 assert_file_exists "$TMP/t127c/.cursor/rules.backup/existing.txt" "T127C existing backup retained"
+
+# T127CA — vendor-switch: codex migrates legacy .agents/orchestration to backup and activates .codex/agents
+run_test "T127CA — vendor-switch: codex legacy orchestration migration"
+mkdir -p "$TMP/t127ca"
+mkdir -p "$TMP/t127ca/.agents/orchestration"
+mkdir -p "$TMP/t127ca/.agents/orchestration.backup"
+printf '%s\n' "existing backup marker" > "$TMP/t127ca/.agents/orchestration.backup/existing.txt"
+printf '%s\n' "legacy codex agent" > "$TMP/t127ca/.agents/orchestration/architect.md"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t127ca" \
+  > /dev/null 2>&1
+bash "$VENDOR_GEN" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127ca" \
+  --vendors codex \
+  > /dev/null 2>&1
+bash "$VENDOR_SWITCH" \
+  --library "$LIBRARY" \
+  --target "$TMP/t127ca" \
+  codex \
+  > /dev/null 2>&1
+assert_symlink_exists "$TMP/t127ca/.codex/agents" "T127CA codex symlink created"
+assert_symlink_target "$TMP/t127ca/.codex/agents" "../.agentic/agents/codex" "T127CA codex symlink target"
+assert_file_exists "$TMP/t127ca/.agents/orchestration.backup.1/architect.md" "T127CA legacy path migrated"
+assert_file_exists "$TMP/t127ca/.agents/orchestration.backup/existing.txt" "T127CA existing backup retained"
+assert_file_not_exists "$TMP/t127ca/.agents/orchestration" "T127CA legacy path replaced"
 
 # T127D — vendor-switch: rollback restores prior vendor state on post-mutation failure
 run_test "T127D — vendor-switch: rollback restores prior state on failure"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2729,6 +2729,111 @@ T103N_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
 assert_exit_code 1 "$T103N_EXIT" "T103N"
 assert_stdout_contains "$T103N_OUTPUT" "invalid reasoning_effort" "T103N"
 
+# T103O — sync: single-provider codex removes opencode scaffolds
+run_test "T103O — sync: codex-only active vendors removes opencode scaffolds"
+mkdir -p "$TMP/t103o"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103o" \
+  > /dev/null 2>&1
+mkdir -p "$TMP/t103o/.agents/orchestration" "$TMP/t103o/.opencode/agents"
+echo "stale codex orphan" > "$TMP/t103o/.agents/orchestration/orphan.md"
+echo "stale opencode orphan" > "$TMP/t103o/.opencode/agents/orphan.md"
+cat > "$TMP/t103o/.agentic/agents.yaml" <<'EOF'
+version: "1"
+enabled: true
+agents:
+  architect:
+    description: "Single provider codex test."
+    prompt: "Architect codex prompt"
+    providers:
+      codex:
+        enabled: true
+      opencode:
+        enabled: true
+EOF
+yq -i '.active_vendors = ["codex"] | del(.active_vendor)' "$TMP/t103o/.agentic/config.yaml"
+T103O_EXIT=0
+bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103o" \
+  > /dev/null 2>&1 || T103O_EXIT=$?
+assert_exit_code 0 "$T103O_EXIT" "T103O"
+assert_file_exists "$TMP/t103o/.agents/orchestration/architect.md" "T103O codex kept"
+assert_file_not_exists "$TMP/t103o/.agents/orchestration/orphan.md" "T103O codex orphan removed"
+assert_file_not_exists "$TMP/t103o/.opencode/agents/architect.md" "T103O opencode removed"
+assert_file_not_exists "$TMP/t103o/.opencode/agents/orphan.md" "T103O opencode orphan removed"
+
+# T103P — sync: single-provider opencode removes codex scaffolds
+run_test "T103P — sync: opencode-only active vendors removes codex scaffolds"
+mkdir -p "$TMP/t103p"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103p" \
+  > /dev/null 2>&1
+mkdir -p "$TMP/t103p/.agents/orchestration" "$TMP/t103p/.opencode/agents"
+echo "stale codex orphan" > "$TMP/t103p/.agents/orchestration/orphan.md"
+echo "stale opencode orphan" > "$TMP/t103p/.opencode/agents/orphan.md"
+cat > "$TMP/t103p/.agentic/agents.yaml" <<'EOF'
+version: "1"
+enabled: true
+agents:
+  architect:
+    description: "Single provider opencode test."
+    prompt: "Architect opencode prompt"
+    providers:
+      codex:
+        enabled: true
+      opencode:
+        enabled: true
+EOF
+yq -i '.active_vendors = ["opencode"] | del(.active_vendor)' "$TMP/t103p/.agentic/config.yaml"
+T103P_EXIT=0
+bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103p" \
+  > /dev/null 2>&1 || T103P_EXIT=$?
+assert_exit_code 0 "$T103P_EXIT" "T103P"
+assert_file_exists "$TMP/t103p/.opencode/agents/architect.md" "T103P opencode kept"
+assert_file_not_exists "$TMP/t103p/.opencode/agents/orphan.md" "T103P opencode orphan removed"
+assert_file_not_exists "$TMP/t103p/.agents/orchestration/architect.md" "T103P codex removed"
+assert_file_not_exists "$TMP/t103p/.agents/orchestration/orphan.md" "T103P codex orphan removed"
+
+# T103Q — sync: multi-provider keeps both and removes only orphans
+run_test "T103Q — sync: multi-provider keeps both scaffolds and prunes orphans"
+mkdir -p "$TMP/t103q"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103q" \
+  > /dev/null 2>&1
+mkdir -p "$TMP/t103q/.agents/orchestration" "$TMP/t103q/.opencode/agents"
+echo "stale codex orphan" > "$TMP/t103q/.agents/orchestration/orphan.md"
+echo "stale opencode orphan" > "$TMP/t103q/.opencode/agents/orphan.md"
+cat > "$TMP/t103q/.agentic/agents.yaml" <<'EOF'
+version: "1"
+enabled: true
+agents:
+  architect:
+    description: "Multi-provider cleanup test."
+    prompt: "Architect multi-provider prompt"
+    providers:
+      codex:
+        enabled: true
+      opencode:
+        enabled: true
+EOF
+yq -i '.active_vendors = ["codex", "opencode"] | del(.active_vendor)' "$TMP/t103q/.agentic/config.yaml"
+T103Q_EXIT=0
+bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103q" \
+  > /dev/null 2>&1 || T103Q_EXIT=$?
+assert_exit_code 0 "$T103Q_EXIT" "T103Q"
+assert_file_exists "$TMP/t103q/.agents/orchestration/architect.md" "T103Q codex kept"
+assert_file_exists "$TMP/t103q/.opencode/agents/architect.md" "T103Q opencode kept"
+assert_file_not_exists "$TMP/t103q/.agents/orchestration/orphan.md" "T103Q codex orphan removed"
+assert_file_not_exists "$TMP/t103q/.opencode/agents/orphan.md" "T103Q opencode orphan removed"
+
 # T104 — compose: standalone typescript-react-spa profile
 run_test "T104 — compose: standalone typescript-react-spa profile"
 T104_EXIT=0

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2262,6 +2262,7 @@ assert_file_exists "$TMP/t99/.agentic/config.yaml" "T99 config"
 assert_file_exists "$TMP/t99/.agentic/profile.yaml" "T99 profile"
 assert_file_exists "$TMP/t99/.agentic/mcp.yaml" "T99 mcp"
 assert_file_exists "$TMP/t99/.agentic/providers.yaml" "T99 providers"
+assert_file_exists "$TMP/t99/.agentic/agents.yaml" "T99 agents"
 if [[ -d "$TMP/t99/.agentic/project-skills" ]]; then
   pass "T99 project-skills directory exists"
 else
@@ -2274,6 +2275,8 @@ assert_file_contains "$TMP/t99/.agentic/config.yaml" "# yaml-language-server: \$
 assert_file_contains "$TMP/t99/.agentic/profile.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json" "T100 profile schema"
 assert_file_contains "$TMP/t99/.agentic/mcp.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/mcp.schema.json" "T100 mcp schema"
 assert_file_contains "$TMP/t99/.agentic/providers.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/providers.schema.json" "T100 providers schema"
+assert_file_contains "$TMP/t99/.agentic/agents.yaml" "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json" "T100 agents schema"
+assert_file_contains "$TMP/t99/.agentic/agents.yaml" "enabled: false" "T100 agents noop"
 
 # T101 — init --sync: scaffolds and composes immediately
 run_test "T101 — init --sync composes project"
@@ -2416,6 +2419,82 @@ T103C_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
   2>&1) || T103C_EXIT=$?
 assert_exit_code 1 "$T103C_EXIT" "T103C"
 assert_stdout_contains "$T103C_OUTPUT" "must be boolean" "T103C"
+
+# T103D — sync: missing agents.yaml remains backward-compatible
+run_test "T103D — sync: missing agents.yaml is skipped"
+mkdir -p "$TMP/t103d"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103d" \
+  > /dev/null 2>&1
+rm -f "$TMP/t103d/.agentic/agents.yaml"
+T103D_EXIT=0
+T103D_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103d" \
+  2>&1) || T103D_EXIT=$?
+assert_exit_code 0 "$T103D_EXIT" "T103D"
+assert_stdout_contains "$T103D_OUTPUT" "Sync complete" "T103D"
+
+# T103E — sync: no-op agents.yaml skips portable agents sync
+run_test "T103E — sync: no-op agents config skips sync"
+mkdir -p "$TMP/t103e"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103e" \
+  > /dev/null 2>&1
+mkdir -p "$TMP/t103e/.agentic/portable"
+echo "portable codex instructions" > "$TMP/t103e/.agentic/portable/codex.md"
+cat > "$TMP/t103e/.agentic/agents.yaml" <<'EOF'
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
+version: "1"
+enabled: false
+providers: {}
+EOF
+T103E_EXIT=0
+bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103e" \
+  > /dev/null 2>&1 || T103E_EXIT=$?
+assert_exit_code 0 "$T103E_EXIT" "T103E"
+assert_file_not_exists "$TMP/t103e/.agents/AGENTS.md" "T103E"
+
+# T103F — sync: opt-in agents.yaml syncs codex and opencode mappings
+run_test "T103F — sync: opt-in agents config syncs mappings"
+mkdir -p "$TMP/t103f"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103f" \
+  > /dev/null 2>&1
+mkdir -p "$TMP/t103f/.agentic/portable"
+echo "portable codex instructions" > "$TMP/t103f/.agentic/portable/codex.md"
+echo "portable opencode instructions" > "$TMP/t103f/.agentic/portable/opencode.md"
+cat > "$TMP/t103f/.agentic/agents.yaml" <<'EOF'
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/agents.schema.json
+version: "1"
+enabled: true
+providers:
+  codex:
+    enabled: true
+    mappings:
+      - source: ".agentic/portable/codex.md"
+        target: ".agents/AGENTS.md"
+  opencode:
+    enabled: true
+    mappings:
+      - source: ".agentic/portable/opencode.md"
+        target: ".opencode/AGENTS.md"
+EOF
+T103F_EXIT=0
+bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103f" \
+  > /dev/null 2>&1 || T103F_EXIT=$?
+assert_exit_code 0 "$T103F_EXIT" "T103F"
+assert_file_exists "$TMP/t103f/.agents/AGENTS.md" "T103F codex target"
+assert_file_exists "$TMP/t103f/.opencode/AGENTS.md" "T103F opencode target"
+assert_file_contains "$TMP/t103f/.agents/AGENTS.md" "portable codex instructions" "T103F codex content"
+assert_file_contains "$TMP/t103f/.opencode/AGENTS.md" "portable opencode instructions" "T103F opencode content"
 
 # T104 — compose: standalone typescript-react-spa profile
 run_test "T104 — compose: standalone typescript-react-spa profile"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2623,6 +2623,28 @@ T103K_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
 assert_exit_code 1 "$T103K_EXIT" "T103K"
 assert_stdout_contains "$T103K_OUTPUT" "must define non-empty description and prompt" "T103K"
 
+# T103K2 — sync: disabled config allows incomplete agent definitions
+run_test "T103K2 — sync: enabled false bypasses strict agent field checks"
+mkdir -p "$TMP/t103k2"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103k2" \
+  > /dev/null 2>&1
+cat > "$TMP/t103k2/.agentic/agents.yaml" <<'EOF'
+version: "1"
+enabled: false
+agents:
+  architect:
+    prompt: "asdasd"
+EOF
+T103K2_EXIT=0
+T103K2_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103k2" \
+  2>&1) || T103K2_EXIT=$?
+assert_exit_code 0 "$T103K2_EXIT" "T103K2"
+assert_stdout_contains "$T103K2_OUTPUT" "disabled (no-op)" "T103K2"
+
 # T103L — sync: invalid provider under agent fails validation
 run_test "T103L — sync: invalid provider fails"
 mkdir -p "$TMP/t103l"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2482,9 +2482,11 @@ agents:
       codex:
         enabled: true
         model: "gpt-5.3-codex"
+        reasoning_effort: "extra_high"
       opencode:
         enabled: true
         model: "openai/gpt-5"
+        reasoning_effort: "extra_high"
 EOF
 T103F_EXIT=0
 bash "$LIBRARY/tooling/lib/sync.sh" \
@@ -2497,6 +2499,8 @@ assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "You are th
 assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "You are the architect agent." "T103F opencode content"
 assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "model: gpt-5.3-codex" "T103F codex model"
 assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "model: openai/gpt-5" "T103F opencode model"
+assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "reasoning_effort: xhigh" "T103F codex reasoning mapping"
+assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "reasoning_effort: xhigh" "T103F opencode reasoning mapping"
 
 # T103G — sync: enabled with no agent definitions warns and performs no mutations
 run_test "T103G — sync: enabled with empty agents is warning/no-op"
@@ -2698,6 +2702,32 @@ T103M_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
   2>&1) || T103M_EXIT=$?
 assert_exit_code 0 "$T103M_EXIT" "T103M"
 assert_stdout_contains "$T103M_OUTPUT" "no provider outputs resolved; no mutations applied" "T103M"
+
+# T103N — sync: invalid reasoning_effort fails validation
+run_test "T103N — sync: invalid reasoning_effort fails"
+mkdir -p "$TMP/t103n"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-microservice \
+  --target "$TMP/t103n" \
+  > /dev/null 2>&1
+cat > "$TMP/t103n/.agentic/agents.yaml" <<'EOF'
+version: "1"
+enabled: true
+agents:
+  architect:
+    description: "Invalid reasoning test."
+    prompt: "text"
+    providers:
+      codex:
+        reasoning_effort: "mediumg"
+EOF
+T103N_EXIT=0
+T103N_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
+  --target "$TMP/t103n" \
+  2>&1) || T103N_EXIT=$?
+assert_exit_code 1 "$T103N_EXIT" "T103N"
+assert_stdout_contains "$T103N_OUTPUT" "invalid reasoning_effort" "T103N"
 
 # T104 — compose: standalone typescript-react-spa profile
 run_test "T104 — compose: standalone typescript-react-spa profile"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -119,6 +119,17 @@ assert_symlink_exists() {
   fi
 }
 
+assert_symlink_target() {
+  local path="$1" expected="$2" label="$3"
+  local actual
+  actual=$(readlink "$path" 2>/dev/null || true)
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$label — symlink target: $expected"
+  else
+    fail "$label — expected symlink target '$expected', got '$actual'"
+  fi
+}
+
 assert_not_symlink() {
   local path="$1" label="$2"
   if [[ ! -L "$path" ]]; then
@@ -892,6 +903,7 @@ assert_file_contains "$TMP/t41/.gitignore" ".claude/skills" "T41"
 assert_file_contains "$TMP/t41/.gitignore" ".opencode/skills" "T41"
 assert_file_contains "$TMP/t41/.gitignore" ".agents/skills" "T41"
 assert_file_contains "$TMP/t41/.gitignore" ".cursor/rules" "T41"
+assert_file_contains "$TMP/t41/.gitignore" ".agentic/agents/" "T41"
 # Project-owned files must NOT be ignored
 assert_file_not_contains "$TMP/t41/.gitignore" "AGENTS.md" "T41"
 assert_file_not_contains "$TMP/t41/.gitignore" "config.yaml" "T41"
@@ -914,6 +926,7 @@ bash "$COMPOSE" \
 assert_file_contains "$TMP/t_gl/.gitignore" ".agentic/skills/" "T_GITIGNORE_LINK_MODE"
 assert_file_contains "$TMP/t_gl/.gitignore" ".agentic/fragments/" "T_GITIGNORE_LINK_MODE"
 assert_file_contains "$TMP/t_gl/.gitignore" ".agentic/vendor-files/" "T_GITIGNORE_LINK_MODE"
+assert_file_contains "$TMP/t_gl/.gitignore" ".agentic/agents/" "T_GITIGNORE_LINK_MODE"
 assert_file_contains "$TMP/t_gl/.gitignore" ".cursor/rules" "T_GITIGNORE_LINK_MODE"
 assert_file_contains "$TMP/t_gl/.gitignore" "# agentic:start" "T_GITIGNORE_LINK_MODE"
 
@@ -970,6 +983,7 @@ bash "$COMPOSE" --library "$LIBRARY" --profile golang-hexagonal-cobra-cli \
   --target "$TMP/t_c2l" > /dev/null 2>&1
 # Runtime dirs must NOT be in gitignore yet
 assert_file_not_contains "$TMP/t_c2l/.gitignore" ".agentic/skills/" "T_GITIGNORE_COPY_TO_LINK"
+assert_file_contains "$TMP/t_c2l/.gitignore" ".agentic/agents/" "T_GITIGNORE_COPY_TO_LINK"
 # Second deploy: switch to link mode
 bash "$COMPOSE" --library "$LIBRARY" --profile golang-hexagonal-cobra-cli \
   --target "$TMP/t_c2l" --link > /dev/null 2>&1
@@ -977,6 +991,7 @@ bash "$COMPOSE" --library "$LIBRARY" --profile golang-hexagonal-cobra-cli \
 assert_file_contains "$TMP/t_c2l/.gitignore" ".agentic/skills/" "T_GITIGNORE_COPY_TO_LINK"
 assert_file_contains "$TMP/t_c2l/.gitignore" ".agentic/fragments/" "T_GITIGNORE_COPY_TO_LINK"
 assert_file_contains "$TMP/t_c2l/.gitignore" ".agentic/vendor-files/" "T_GITIGNORE_COPY_TO_LINK"
+assert_file_contains "$TMP/t_c2l/.gitignore" ".agentic/agents/" "T_GITIGNORE_COPY_TO_LINK"
 # Exactly one managed block
 count=$(grep -c "# agentic:start" "$TMP/t_c2l/.gitignore" || true)
 if [[ "$count" -eq 1 ]]; then
@@ -993,6 +1008,7 @@ bash "$COMPOSE" --library "$LIBRARY" --profile golang-hexagonal-cobra-cli \
   --target "$TMP/t_l2c" --link > /dev/null 2>&1
 # Runtime dirs must be in gitignore
 assert_file_contains "$TMP/t_l2c/.gitignore" ".agentic/skills/" "T_GITIGNORE_LINK_TO_COPY"
+assert_file_contains "$TMP/t_l2c/.gitignore" ".agentic/agents/" "T_GITIGNORE_LINK_TO_COPY"
 # Second deploy: switch to copy mode (no --link)
 bash "$COMPOSE" --library "$LIBRARY" --profile golang-hexagonal-cobra-cli \
   --target "$TMP/t_l2c" > /dev/null 2>&1
@@ -1000,6 +1016,7 @@ bash "$COMPOSE" --library "$LIBRARY" --profile golang-hexagonal-cobra-cli \
 assert_file_not_contains "$TMP/t_l2c/.gitignore" ".agentic/skills/" "T_GITIGNORE_LINK_TO_COPY"
 assert_file_not_contains "$TMP/t_l2c/.gitignore" ".agentic/fragments/" "T_GITIGNORE_LINK_TO_COPY"
 assert_file_not_contains "$TMP/t_l2c/.gitignore" ".agentic/vendor-files/" "T_GITIGNORE_LINK_TO_COPY"
+assert_file_contains "$TMP/t_l2c/.gitignore" ".agentic/agents/" "T_GITIGNORE_LINK_TO_COPY"
 # Exactly one managed block
 count=$(grep -c "# agentic:start" "$TMP/t_l2c/.gitignore" || true)
 if [[ "$count" -eq 1 ]]; then
@@ -2493,14 +2510,14 @@ bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103f" \
   > /dev/null 2>&1 || T103F_EXIT=$?
 assert_exit_code 0 "$T103F_EXIT" "T103F"
-assert_file_exists "$TMP/t103f/.agents/orchestration/architect.md" "T103F codex target"
-assert_file_exists "$TMP/t103f/.opencode/agents/architect.md" "T103F opencode target"
-assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "You are the architect agent." "T103F codex content"
-assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "You are the architect agent." "T103F opencode content"
-assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "model: gpt-5.3-codex" "T103F codex model"
-assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "model: openai/gpt-5" "T103F opencode model"
-assert_file_contains "$TMP/t103f/.agents/orchestration/architect.md" "reasoning_effort: xhigh" "T103F codex reasoning mapping"
-assert_file_contains "$TMP/t103f/.opencode/agents/architect.md" "reasoning_effort: xhigh" "T103F opencode reasoning mapping"
+assert_file_exists "$TMP/t103f/.agentic/agents/codex/architect.md" "T103F codex canonical target"
+assert_file_exists "$TMP/t103f/.agentic/agents/opencode/architect.md" "T103F opencode canonical target"
+assert_file_contains "$TMP/t103f/.agentic/agents/codex/architect.md" "You are the architect agent." "T103F codex content"
+assert_file_contains "$TMP/t103f/.agentic/agents/opencode/architect.md" "You are the architect agent." "T103F opencode content"
+assert_file_contains "$TMP/t103f/.agentic/agents/codex/architect.md" "model: gpt-5.3-codex" "T103F codex model"
+assert_file_contains "$TMP/t103f/.agentic/agents/opencode/architect.md" "model: openai/gpt-5" "T103F opencode model"
+assert_file_contains "$TMP/t103f/.agentic/agents/codex/architect.md" "reasoning_effort: xhigh" "T103F codex reasoning mapping"
+assert_file_contains "$TMP/t103f/.agentic/agents/opencode/architect.md" "reasoning_effort: xhigh" "T103F opencode reasoning mapping"
 
 # T103G — sync: enabled with no agent definitions warns and performs no mutations
 run_test "T103G — sync: enabled with empty agents is warning/no-op"
@@ -2522,8 +2539,8 @@ T103G_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
   2>&1) || T103G_EXIT=$?
 assert_exit_code 0 "$T103G_EXIT" "T103G"
 assert_stdout_contains "$T103G_OUTPUT" "enabled but no agent definitions found; no mutations applied" "T103G warning"
-assert_file_not_exists "$TMP/t103g/.agents/orchestration/architect.md" "T103G codex no-op"
-assert_file_not_exists "$TMP/t103g/.opencode/agents/architect.md" "T103G opencode no-op"
+assert_file_not_exists "$TMP/t103g/.agentic/agents/codex/architect.md" "T103G codex no-op"
+assert_file_not_exists "$TMP/t103g/.agentic/agents/opencode/architect.md" "T103G opencode no-op"
 
 # T103H — sync: agents.yaml version must be exactly "1"
 run_test "T103H — sync: invalid agents.yaml version fails"
@@ -2546,8 +2563,8 @@ T103H_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
 assert_exit_code 1 "$T103H_EXIT" "T103H"
 assert_stdout_contains "$T103H_OUTPUT" "version must be \"1\"" "T103H"
 
-# T103I — sync: unmanaged destination conflict fails before any write
-run_test "T103I — sync: unmanaged destination conflict preflight fails"
+# T103I — sync: provider-local unmanaged files do not block canonical generation
+run_test "T103I — sync: unmanaged provider-local files do not block canonical generation"
 mkdir -p "$TMP/t103i"
 bash "$COMPOSE" \
   --library "$LIBRARY" \
@@ -2576,10 +2593,10 @@ T103I_EXIT=0
 T103I_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103i" \
   2>&1) || T103I_EXIT=$?
-assert_exit_code 1 "$T103I_EXIT" "T103I"
-assert_stdout_contains "$T103I_OUTPUT" "Unmanaged destination conflict" "T103I"
+assert_exit_code 0 "$T103I_EXIT" "T103I"
 assert_file_contains "$TMP/t103i/.agents/orchestration/architect.md" "unmanaged local content" "T103I preserved destination"
-assert_file_not_exists "$TMP/t103i/.opencode/agents/architect.md" "T103I zero writes"
+assert_file_exists "$TMP/t103i/.agentic/agents/codex/architect.md" "T103I codex canonical write"
+assert_file_exists "$TMP/t103i/.agentic/agents/opencode/architect.md" "T103I opencode canonical write"
 
 # T103J — sync: invalid agent key fails validation
 run_test "T103J — sync: invalid agent key fails"
@@ -2729,17 +2746,14 @@ T103N_OUTPUT=$(bash "$LIBRARY/tooling/lib/sync.sh" \
 assert_exit_code 1 "$T103N_EXIT" "T103N"
 assert_stdout_contains "$T103N_OUTPUT" "invalid reasoning_effort" "T103N"
 
-# T103O — sync: single-provider codex removes opencode scaffolds
-run_test "T103O — sync: codex-only active vendors removes opencode scaffolds"
+# T103O — sync: codex-only active vendors keeps codex agent symlink only
+run_test "T103O — sync: codex-only active vendors creates codex agent symlink only"
 mkdir -p "$TMP/t103o"
 bash "$COMPOSE" \
   --library "$LIBRARY" \
   --profile typescript-hexagonal-microservice \
   --target "$TMP/t103o" \
   > /dev/null 2>&1
-mkdir -p "$TMP/t103o/.agents/orchestration" "$TMP/t103o/.opencode/agents"
-echo "stale codex orphan" > "$TMP/t103o/.agents/orchestration/orphan.md"
-echo "stale opencode orphan" > "$TMP/t103o/.opencode/agents/orphan.md"
 cat > "$TMP/t103o/.agentic/agents.yaml" <<'EOF'
 version: "1"
 enabled: true
@@ -2759,22 +2773,20 @@ bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103o" \
   > /dev/null 2>&1 || T103O_EXIT=$?
 assert_exit_code 0 "$T103O_EXIT" "T103O"
-assert_file_exists "$TMP/t103o/.agents/orchestration/architect.md" "T103O codex kept"
-assert_file_not_exists "$TMP/t103o/.agents/orchestration/orphan.md" "T103O codex orphan removed"
-assert_file_not_exists "$TMP/t103o/.opencode/agents/architect.md" "T103O opencode removed"
-assert_file_not_exists "$TMP/t103o/.opencode/agents/orphan.md" "T103O opencode orphan removed"
+assert_symlink_exists "$TMP/t103o/.agents/orchestration" "T103O codex symlink exists"
+assert_symlink_target "$TMP/t103o/.agents/orchestration" "../.agentic/agents/codex" "T103O codex symlink target"
+assert_file_not_exists "$TMP/t103o/.opencode/agents" "T103O opencode symlink removed"
+assert_file_exists "$TMP/t103o/.agentic/agents/codex/architect.md" "T103O codex canonical"
+assert_file_exists "$TMP/t103o/.agentic/agents/opencode/architect.md" "T103O opencode canonical retained"
 
-# T103P — sync: single-provider opencode removes codex scaffolds
-run_test "T103P — sync: opencode-only active vendors removes codex scaffolds"
+# T103P — sync: opencode-only active vendors keeps opencode agent symlink only
+run_test "T103P — sync: opencode-only active vendors creates opencode agent symlink only"
 mkdir -p "$TMP/t103p"
 bash "$COMPOSE" \
   --library "$LIBRARY" \
   --profile typescript-hexagonal-microservice \
   --target "$TMP/t103p" \
   > /dev/null 2>&1
-mkdir -p "$TMP/t103p/.agents/orchestration" "$TMP/t103p/.opencode/agents"
-echo "stale codex orphan" > "$TMP/t103p/.agents/orchestration/orphan.md"
-echo "stale opencode orphan" > "$TMP/t103p/.opencode/agents/orphan.md"
 cat > "$TMP/t103p/.agentic/agents.yaml" <<'EOF'
 version: "1"
 enabled: true
@@ -2794,22 +2806,20 @@ bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103p" \
   > /dev/null 2>&1 || T103P_EXIT=$?
 assert_exit_code 0 "$T103P_EXIT" "T103P"
-assert_file_exists "$TMP/t103p/.opencode/agents/architect.md" "T103P opencode kept"
-assert_file_not_exists "$TMP/t103p/.opencode/agents/orphan.md" "T103P opencode orphan removed"
-assert_file_not_exists "$TMP/t103p/.agents/orchestration/architect.md" "T103P codex removed"
-assert_file_not_exists "$TMP/t103p/.agents/orchestration/orphan.md" "T103P codex orphan removed"
+assert_symlink_exists "$TMP/t103p/.opencode/agents" "T103P opencode symlink exists"
+assert_symlink_target "$TMP/t103p/.opencode/agents" "../.agentic/agents/opencode" "T103P opencode symlink target"
+assert_file_not_exists "$TMP/t103p/.agents/orchestration" "T103P codex symlink removed"
+assert_file_exists "$TMP/t103p/.agentic/agents/codex/architect.md" "T103P codex canonical retained"
+assert_file_exists "$TMP/t103p/.agentic/agents/opencode/architect.md" "T103P opencode canonical"
 
-# T103Q — sync: multi-provider keeps both and removes only orphans
-run_test "T103Q — sync: multi-provider keeps both scaffolds and prunes orphans"
+# T103Q — sync: multi-provider keeps both provider symlinks
+run_test "T103Q — sync: multi-provider keeps both provider symlinks"
 mkdir -p "$TMP/t103q"
 bash "$COMPOSE" \
   --library "$LIBRARY" \
   --profile typescript-hexagonal-microservice \
   --target "$TMP/t103q" \
   > /dev/null 2>&1
-mkdir -p "$TMP/t103q/.agents/orchestration" "$TMP/t103q/.opencode/agents"
-echo "stale codex orphan" > "$TMP/t103q/.agents/orchestration/orphan.md"
-echo "stale opencode orphan" > "$TMP/t103q/.opencode/agents/orphan.md"
 cat > "$TMP/t103q/.agentic/agents.yaml" <<'EOF'
 version: "1"
 enabled: true
@@ -2829,10 +2839,12 @@ bash "$LIBRARY/tooling/lib/sync.sh" \
   --target "$TMP/t103q" \
   > /dev/null 2>&1 || T103Q_EXIT=$?
 assert_exit_code 0 "$T103Q_EXIT" "T103Q"
-assert_file_exists "$TMP/t103q/.agents/orchestration/architect.md" "T103Q codex kept"
-assert_file_exists "$TMP/t103q/.opencode/agents/architect.md" "T103Q opencode kept"
-assert_file_not_exists "$TMP/t103q/.agents/orchestration/orphan.md" "T103Q codex orphan removed"
-assert_file_not_exists "$TMP/t103q/.opencode/agents/orphan.md" "T103Q opencode orphan removed"
+assert_symlink_exists "$TMP/t103q/.agents/orchestration" "T103Q codex symlink"
+assert_symlink_target "$TMP/t103q/.agents/orchestration" "../.agentic/agents/codex" "T103Q codex symlink target"
+assert_symlink_exists "$TMP/t103q/.opencode/agents" "T103Q opencode symlink"
+assert_symlink_target "$TMP/t103q/.opencode/agents" "../.agentic/agents/opencode" "T103Q opencode symlink target"
+assert_file_exists "$TMP/t103q/.agentic/agents/codex/architect.md" "T103Q codex canonical"
+assert_file_exists "$TMP/t103q/.agentic/agents/opencode/architect.md" "T103Q opencode canonical"
 
 # T104 — compose: standalone typescript-react-spa profile
 run_test "T104 — compose: standalone typescript-react-spa profile"

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -145,6 +145,8 @@ snapshot_current_switch_state() {
     "$TARGET/.claude/skills"
     "$TARGET/.opencode/skills"
     "$TARGET/.agents/skills"
+    "$TARGET/.codex/agents"
+    "$TARGET/.agents/orchestration"
   )
 
   local cursor_rel_path
@@ -236,6 +238,7 @@ remove_all_vendor_symlinks() {
   [[ -L "$TARGET/.opencode/skills" ]] && rm "$TARGET/.opencode/skills"
   [[ -L "$TARGET/.opencode/agents" ]] && rm "$TARGET/.opencode/agents"
   [[ -L "$TARGET/.agents/skills" ]] && rm "$TARGET/.agents/skills"
+  [[ -L "$TARGET/.codex/agents" ]] && rm "$TARGET/.codex/agents"
   [[ -L "$TARGET/.agents/orchestration" ]] && rm "$TARGET/.agents/orchestration"
   local cursor_rel_path cursor_abs_path
   for cursor_rel_path in "${CURSOR_MANAGED_PATHS[@]}"; do
@@ -249,6 +252,7 @@ remove_all_vendor_symlinks() {
   [[ -d "$TARGET/.gemini" ]] && rmdir "$TARGET/.gemini" 2>/dev/null || true
   [[ -d "$TARGET/.claude" ]] && rmdir "$TARGET/.claude" 2>/dev/null || true
   [[ -d "$TARGET/.opencode" ]] && rmdir "$TARGET/.opencode" 2>/dev/null || true
+  [[ -d "$TARGET/.codex" ]] && rmdir "$TARGET/.codex" 2>/dev/null || true
   [[ -d "$TARGET/.agents" ]] && rmdir "$TARGET/.agents" 2>/dev/null || true
   [[ -d "$TARGET/.cursor" ]] && rmdir "$TARGET/.cursor" 2>/dev/null || true
 }

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -109,31 +109,6 @@ done
 # ── Read current active vendors ────────────────────────────────────────────────
 CURRENT_VENDORS=$(read_active_vendors "$CONFIG")
 
-# ── Legacy migration: stash system ─────────────────────────────────────────────
-migrate_from_stash() {
-  local stash_dir="$TARGET/.agentic/vendor-stash"
-  if [[ -d "$stash_dir" ]]; then
-    echo "Migrating from old stash system..."
-    safe_rm_rf "$stash_dir"
-    echo "  Removed: .agentic/vendor-stash/"
-  fi
-}
-
-# ── Legacy migration: active_vendor string → active_vendors array ──────────────
-migrate_active_vendor_format() {
-  if [[ -f "$CONFIG" ]]; then
-    # Check if old format exists and new format doesn't
-    local old_vendor new_vendors
-    old_vendor=$(yq '.active_vendor // ""' "$CONFIG" 2>/dev/null || true)
-    new_vendors=$(yq '.active_vendors // ""' "$CONFIG" 2>/dev/null || true)
-    
-    if [[ -n "$old_vendor" && "$old_vendor" != "null" && ( -z "$new_vendors" || "$new_vendors" == "null" ) ]]; then
-      echo "Migrating config: active_vendor → active_vendors..."
-      yq -i 'del(.active_vendor) | .active_vendors = ["'"$old_vendor"'"]' "$CONFIG"
-    fi
-  fi
-}
-
 snapshot_current_switch_state() {
   local managed_paths=(
     "$TARGET/CLAUDE.md"
@@ -146,7 +121,6 @@ snapshot_current_switch_state() {
     "$TARGET/.opencode/skills"
     "$TARGET/.agents/skills"
     "$TARGET/.codex/agents"
-    "$TARGET/.agents/orchestration"
   )
 
   local cursor_rel_path
@@ -239,7 +213,6 @@ remove_all_vendor_symlinks() {
   [[ -L "$TARGET/.opencode/agents" ]] && rm "$TARGET/.opencode/agents"
   [[ -L "$TARGET/.agents/skills" ]] && rm "$TARGET/.agents/skills"
   [[ -L "$TARGET/.codex/agents" ]] && rm "$TARGET/.codex/agents"
-  [[ -L "$TARGET/.agents/orchestration" ]] && rm "$TARGET/.agents/orchestration"
   local cursor_rel_path cursor_abs_path
   for cursor_rel_path in "${CURSOR_MANAGED_PATHS[@]}"; do
     cursor_abs_path="$TARGET/$cursor_rel_path"
@@ -289,10 +262,6 @@ vendor_files_exist() {
 
 # ── Main ───────────────────────────────────────────────────────────────────────
 
-# Run legacy migrations
-migrate_from_stash
-migrate_active_vendor_format
-
 # Guard: if link mode and agentic_root is missing, fail clearly
 if [[ -f "$CONFIG" ]]; then
   DEPLOY_MODE=$(yq '.deploy_mode // "copy"' "$CONFIG" 2>/dev/null || echo "copy")
@@ -341,8 +310,7 @@ if [[ -f "$CONFIG" ]]; then
   done
   yaml_array+="]"
   
-  # Remove old active_vendor if present, set active_vendors array
-  yq -i "del(.active_vendor) | .active_vendors = $yaml_array" "$CONFIG"
+  yq -i ".active_vendors = $yaml_array" "$CONFIG"
 fi
 
 SWITCH_COMMITTED=1

--- a/tooling/lib/vendor-switch.sh
+++ b/tooling/lib/vendor-switch.sh
@@ -234,7 +234,9 @@ remove_all_vendor_symlinks() {
   # Remove skill symlinks
   [[ -L "$TARGET/.claude/skills" ]] && rm "$TARGET/.claude/skills"
   [[ -L "$TARGET/.opencode/skills" ]] && rm "$TARGET/.opencode/skills"
+  [[ -L "$TARGET/.opencode/agents" ]] && rm "$TARGET/.opencode/agents"
   [[ -L "$TARGET/.agents/skills" ]] && rm "$TARGET/.agents/skills"
+  [[ -L "$TARGET/.agents/orchestration" ]] && rm "$TARGET/.agents/orchestration"
   local cursor_rel_path cursor_abs_path
   for cursor_rel_path in "${CURSOR_MANAGED_PATHS[@]}"; do
     cursor_abs_path="$TARGET/$cursor_rel_path"

--- a/tooling/lib/vendors/codex/agents.sh
+++ b/tooling/lib/vendors/codex/agents.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# codex/agents.sh — Portable agents mapping for Codex
+
+sync_codex_agents() {
+  local target="$1"
+  local agents_file="$2"
+  local enabled
+  enabled=$(yq '.providers.codex.enabled // false' "$agents_file" 2>/dev/null || echo "false")
+  [[ "$enabled" != "true" ]] && return 0
+
+  local mapping_count idx source_rel target_rel source_abs target_abs
+  mapping_count=$(yq '.providers.codex.mappings | length' "$agents_file" 2>/dev/null || echo 0)
+  [[ "$mapping_count" == "null" ]] && mapping_count=0
+  [[ "$mapping_count" -eq 0 ]] && return 0
+
+  for ((idx = 0; idx < mapping_count; idx++)); do
+    source_rel=$(yq ".providers.codex.mappings[$idx].source // \"\"" "$agents_file" 2>/dev/null || echo "")
+    target_rel=$(yq ".providers.codex.mappings[$idx].target // \"\"" "$agents_file" 2>/dev/null || echo "")
+
+    if [[ -z "$source_rel" || -z "$target_rel" || "$source_rel" == "null" || "$target_rel" == "null" ]]; then
+      echo "Warning: skipping invalid codex mapping at index $idx in $agents_file" >&2
+      continue
+    fi
+    if [[ "$source_rel" == /* || "$target_rel" == /* ]]; then
+      echo "Warning: codex mappings must use project-relative paths; skipping index $idx" >&2
+      continue
+    fi
+
+    source_abs="$target/$source_rel"
+    target_abs="$target/$target_rel"
+    if [[ ! -f "$source_abs" ]]; then
+      echo "Warning: codex mapping source not found: $source_rel" >&2
+      continue
+    fi
+
+    mkdir -p "$(dirname "$target_abs")"
+    cp "$source_abs" "$target_abs"
+    echo "  ✔  Codex agent synced: $source_rel -> $target_rel"
+  done
+}

--- a/tooling/lib/vendors/codex/agents.sh
+++ b/tooling/lib/vendors/codex/agents.sh
@@ -67,3 +67,48 @@ apply_codex_agent_mappings() {
     echo "  ✔  Codex agent synced: $target_rel"
   done
 }
+
+cleanup_codex_agent_outputs() {
+  local target="$1"
+  local active="$2"
+  shift 2
+
+  local output_dir="$target/.agents/orchestration"
+  [[ ! -d "$output_dir" ]] && return 0
+
+  if [[ "$active" != "true" ]]; then
+    rm -rf "$output_dir"
+    rmdir "$target/.agents" 2>/dev/null || true
+    echo "  ✔  Codex agent scaffolds removed (inactive provider)"
+    return 0
+  fi
+
+  local expected=()
+  local entry target_rel basename
+  for entry in "$@"; do
+    IFS=$'\t' read -r _ _ target_rel <<< "$entry"
+    basename=$(basename "$target_rel")
+    expected+=("$basename")
+  done
+
+  shopt -s nullglob
+  local file keep
+  for file in "$output_dir"/*.md; do
+    keep=false
+    basename=$(basename "$file")
+    for target_rel in "${expected[@]}"; do
+      if [[ "$basename" == "$target_rel" ]]; then
+        keep=true
+        break
+      fi
+    done
+    if [[ "$keep" == "false" ]]; then
+      rm -f "$file"
+      echo "  ✔  Codex orphan removed: .agents/orchestration/$basename"
+    fi
+  done
+  shopt -u nullglob
+
+  rmdir "$output_dir" 2>/dev/null || true
+  rmdir "$target/.agents" 2>/dev/null || true
+}

--- a/tooling/lib/vendors/codex/agents.sh
+++ b/tooling/lib/vendors/codex/agents.sh
@@ -57,10 +57,9 @@ collect_codex_agent_mappings() {
 }
 
 apply_codex_agent_mappings() {
-  local -n mappings_ref="$1"
   local entry source_abs target_abs target_rel
 
-  for entry in "${mappings_ref[@]}"; do
+  for entry in "$@"; do
     IFS=$'\t' read -r source_abs target_abs target_rel <<< "$entry"
     mkdir -p "$(dirname "$target_abs")"
     cp "$source_abs" "$target_abs"

--- a/tooling/lib/vendors/codex/agents.sh
+++ b/tooling/lib/vendors/codex/agents.sh
@@ -1,40 +1,69 @@
 #!/usr/bin/env bash
-# codex/agents.sh — Portable agents mapping for Codex
+# codex/agents.sh — Agents orchestration switching output for Codex
 
-sync_codex_agents() {
+collect_codex_agent_mappings() {
   local target="$1"
   local agents_file="$2"
-  local enabled
-  enabled=$(yq '.providers.codex.enabled // false' "$agents_file" 2>/dev/null || echo "false")
-  [[ "$enabled" != "true" ]] && return 0
+  local -n mappings_ref="$3"
 
-  local mapping_count idx source_rel target_rel source_abs target_abs
-  mapping_count=$(yq '.providers.codex.mappings | length' "$agents_file" 2>/dev/null || echo 0)
-  [[ "$mapping_count" == "null" ]] && mapping_count=0
-  [[ "$mapping_count" -eq 0 ]] && return 0
+  local agent_names=()
+  while IFS= read -r name; do
+    [[ -z "$name" || "$name" == "null" ]] && continue
+    agent_names+=("$name")
+  done < <(yq '.agents | keys | .[]' "$agents_file" 2>/dev/null || true)
 
-  for ((idx = 0; idx < mapping_count; idx++)); do
-    source_rel=$(yq ".providers.codex.mappings[$idx].source // \"\"" "$agents_file" 2>/dev/null || echo "")
-    target_rel=$(yq ".providers.codex.mappings[$idx].target // \"\"" "$agents_file" 2>/dev/null || echo "")
+  local name prompt_rel desc model reasoning enabled source_abs target_rel target_abs tmp_render
+  for name in "${agent_names[@]}"; do
+    enabled=$(yq ".agents.\"$name\".providers.codex.enabled // true" "$agents_file" 2>/dev/null || echo "true")
+    [[ "$enabled" != "true" ]] && continue
 
-    if [[ -z "$source_rel" || -z "$target_rel" || "$source_rel" == "null" || "$target_rel" == "null" ]]; then
-      echo "Warning: skipping invalid codex mapping at index $idx in $agents_file" >&2
+    prompt_rel=$(yq -r ".agents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
+    desc=$(yq -r ".agents.\"$name\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
+    model=$(yq -r ".agents.\"$name\".providers.codex.model // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning=$(yq -r ".agents.\"$name\".providers.codex.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
+
+    if [[ -z "$prompt_rel" || "$prompt_rel" == "null" ]]; then
+      echo "Warning: skipping codex agent '$name' because prompt is empty" >&2
       continue
     fi
-    if [[ "$source_rel" == /* || "$target_rel" == /* ]]; then
-      echo "Warning: codex mappings must use project-relative paths; skipping index $idx" >&2
+    if [[ "$prompt_rel" == /* || "$prompt_rel" == *".."* ]]; then
+      echo "Warning: codex agent '$name' prompt path must be project-relative; skipping" >&2
       continue
     fi
 
-    source_abs="$target/$source_rel"
-    target_abs="$target/$target_rel"
+    source_abs="$target/$prompt_rel"
     if [[ ! -f "$source_abs" ]]; then
-      echo "Warning: codex mapping source not found: $source_rel" >&2
+      echo "Warning: codex agent '$name' prompt source not found: $prompt_rel" >&2
       continue
     fi
 
+    target_rel=".agents/orchestration/$name.md"
+    target_abs="$target/$target_rel"
+    tmp_render="$(mktemp "${TMPDIR:-/tmp}/agentic-codex-agent-XXXXXX.md")"
+    {
+      echo "# Agent: $name"
+      echo
+      echo "provider: codex"
+      [[ -n "$model" ]] && echo "model: $model"
+      [[ -n "$reasoning" ]] && echo "reasoning_effort: $reasoning"
+      echo "description: $desc"
+      echo
+      cat "$source_abs"
+      echo
+    } > "$tmp_render"
+
+    mappings_ref+=("$tmp_render"$'\t'"$target_abs"$'\t'"$target_rel")
+  done
+}
+
+apply_codex_agent_mappings() {
+  local -n mappings_ref="$1"
+  local entry source_abs target_abs target_rel
+
+  for entry in "${mappings_ref[@]}"; do
+    IFS=$'\t' read -r source_abs target_abs target_rel <<< "$entry"
     mkdir -p "$(dirname "$target_abs")"
     cp "$source_abs" "$target_abs"
-    echo "  ✔  Codex agent synced: $source_rel -> $target_rel"
+    echo "  ✔  Codex agent synced: $target_rel"
   done
 }

--- a/tooling/lib/vendors/codex/agents.sh
+++ b/tooling/lib/vendors/codex/agents.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # codex/agents.sh — Agents orchestration switching output for Codex
 
+map_reasoning_effort_codex() {
+  local canonical="$1"
+  case "$canonical" in
+    low|medium|high) printf '%s' "$canonical" ;;
+    extra_high) printf '%s' "xhigh" ;;
+    *) printf '%s' "" ;;
+  esac
+}
+
 collect_codex_agent_mappings() {
   local target="$1"
   local agents_file="$2"
@@ -12,7 +21,7 @@ collect_codex_agent_mappings() {
     agent_names+=("$name")
   done < <(yq '.agents | keys | .[]' "$agents_file" 2>/dev/null || true)
 
-  local name prompt_text desc model reasoning enabled target_rel target_abs tmp_render
+  local name prompt_text desc model reasoning_canonical reasoning enabled target_rel target_abs tmp_render
   for name in "${agent_names[@]}"; do
     enabled=$(yq -r ".agents.\"$name\".providers.codex.enabled" "$agents_file" 2>/dev/null || echo "null")
     [[ "$enabled" == "null" ]] && enabled="true"
@@ -21,7 +30,8 @@ collect_codex_agent_mappings() {
     prompt_text=$(yq -r ".agents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
     desc=$(yq -r ".agents.\"$name\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
     model=$(yq -r ".agents.\"$name\".providers.codex.model // \"\"" "$agents_file" 2>/dev/null || echo "")
-    reasoning=$(yq -r ".agents.\"$name\".providers.codex.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning_canonical=$(yq -r ".agents.\"$name\".providers.codex.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning=$(map_reasoning_effort_codex "$reasoning_canonical")
 
     if [[ -z "$prompt_text" || "$prompt_text" == "null" ]]; then
       echo "Warning: skipping codex agent '$name' because prompt text is empty" >&2

--- a/tooling/lib/vendors/codex/agents.sh
+++ b/tooling/lib/vendors/codex/agents.sh
@@ -12,28 +12,19 @@ collect_codex_agent_mappings() {
     agent_names+=("$name")
   done < <(yq '.agents | keys | .[]' "$agents_file" 2>/dev/null || true)
 
-  local name prompt_rel desc model reasoning enabled source_abs target_rel target_abs tmp_render
+  local name prompt_text desc model reasoning enabled target_rel target_abs tmp_render
   for name in "${agent_names[@]}"; do
-    enabled=$(yq ".agents.\"$name\".providers.codex.enabled // true" "$agents_file" 2>/dev/null || echo "true")
+    enabled=$(yq -r ".agents.\"$name\".providers.codex.enabled" "$agents_file" 2>/dev/null || echo "null")
+    [[ "$enabled" == "null" ]] && enabled="true"
     [[ "$enabled" != "true" ]] && continue
 
-    prompt_rel=$(yq -r ".agents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
+    prompt_text=$(yq -r ".agents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
     desc=$(yq -r ".agents.\"$name\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
     model=$(yq -r ".agents.\"$name\".providers.codex.model // \"\"" "$agents_file" 2>/dev/null || echo "")
     reasoning=$(yq -r ".agents.\"$name\".providers.codex.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
 
-    if [[ -z "$prompt_rel" || "$prompt_rel" == "null" ]]; then
-      echo "Warning: skipping codex agent '$name' because prompt is empty" >&2
-      continue
-    fi
-    if [[ "$prompt_rel" == /* || "$prompt_rel" == *".."* ]]; then
-      echo "Warning: codex agent '$name' prompt path must be project-relative; skipping" >&2
-      continue
-    fi
-
-    source_abs="$target/$prompt_rel"
-    if [[ ! -f "$source_abs" ]]; then
-      echo "Warning: codex agent '$name' prompt source not found: $prompt_rel" >&2
+    if [[ -z "$prompt_text" || "$prompt_text" == "null" ]]; then
+      echo "Warning: skipping codex agent '$name' because prompt text is empty" >&2
       continue
     fi
 
@@ -48,7 +39,7 @@ collect_codex_agent_mappings() {
       [[ -n "$reasoning" ]] && echo "reasoning_effort: $reasoning"
       echo "description: $desc"
       echo
-      cat "$source_abs"
+      printf '%s\n' "$prompt_text"
       echo
     } > "$tmp_render"
 

--- a/tooling/lib/vendors/codex/agents.sh
+++ b/tooling/lib/vendors/codex/agents.sh
@@ -55,6 +55,49 @@ collect_codex_agent_mappings() {
 
     mappings_ref+=("$tmp_render"$'\t'"$target_abs"$'\t'"$target_rel")
   done
+
+  local subagent_names=()
+  while IFS= read -r name; do
+    [[ -z "$name" || "$name" == "null" ]] && continue
+    subagent_names+=("$name")
+  done < <(yq '.subagents | keys | .[]' "$agents_file" 2>/dev/null || true)
+
+  local parent
+  for name in "${subagent_names[@]}"; do
+    enabled=$(yq -r ".subagents.\"$name\".providers.codex.enabled" "$agents_file" 2>/dev/null || echo "null")
+    [[ "$enabled" == "null" ]] && enabled="true"
+    [[ "$enabled" != "true" ]] && continue
+
+    parent=$(yq -r ".subagents.\"$name\".parent // \"\"" "$agents_file" 2>/dev/null || echo "")
+    prompt_text=$(yq -r ".subagents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
+    desc=$(yq -r ".subagents.\"$name\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
+    model=$(yq -r ".subagents.\"$name\".providers.codex.model // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning_canonical=$(yq -r ".subagents.\"$name\".providers.codex.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning=$(map_reasoning_effort_codex "$reasoning_canonical")
+
+    if [[ -z "$prompt_text" || "$prompt_text" == "null" ]]; then
+      echo "Warning: skipping codex subagent '$name' because prompt text is empty" >&2
+      continue
+    fi
+
+    target_rel=".agentic/agents/codex/$name.subagent.md"
+    target_abs="$target/$target_rel"
+    tmp_render="$(mktemp "${TMPDIR:-/tmp}/agentic-codex-subagent-XXXXXX.md")"
+    {
+      echo "# Subagent: $name"
+      echo
+      echo "provider: codex"
+      echo "parent: $parent"
+      [[ -n "$model" ]] && echo "model: $model"
+      [[ -n "$reasoning" ]] && echo "reasoning_effort: $reasoning"
+      echo "description: $desc"
+      echo
+      printf '%s\n' "$prompt_text"
+      echo
+    } > "$tmp_render"
+
+    mappings_ref+=("$tmp_render"$'\t'"$target_abs"$'\t'"$target_rel")
+  done
 }
 
 apply_codex_agent_mappings() {

--- a/tooling/lib/vendors/codex/agents.sh
+++ b/tooling/lib/vendors/codex/agents.sh
@@ -38,7 +38,7 @@ collect_codex_agent_mappings() {
       continue
     fi
 
-    target_rel=".agents/orchestration/$name.md"
+    target_rel=".agentic/agents/codex/$name.md"
     target_abs="$target/$target_rel"
     tmp_render="$(mktemp "${TMPDIR:-/tmp}/agentic-codex-agent-XXXXXX.md")"
     {
@@ -58,57 +58,29 @@ collect_codex_agent_mappings() {
 }
 
 apply_codex_agent_mappings() {
-  local entry source_abs target_abs target_rel
-
-  for entry in "$@"; do
-    IFS=$'\t' read -r source_abs target_abs target_rel <<< "$entry"
-    mkdir -p "$(dirname "$target_abs")"
-    cp "$source_abs" "$target_abs"
-    echo "  ✔  Codex agent synced: $target_rel"
-  done
-}
-
-cleanup_codex_agent_outputs() {
   local target="$1"
-  local active="$2"
-  shift 2
+  shift
 
-  local output_dir="$target/.agents/orchestration"
-  [[ ! -d "$output_dir" ]] && return 0
+  local output_dir="$target/.agentic/agents/codex"
+  local output_parent="$target/.agentic/agents"
+  local staged_dir
+  staged_dir="$(mktemp -d "${TMPDIR:-/tmp}/agentic-codex-agents-XXXXXX")"
 
-  if [[ "$active" != "true" ]]; then
-    rm -rf "$output_dir"
-    rmdir "$target/.agents" 2>/dev/null || true
-    echo "  ✔  Codex agent scaffolds removed (inactive provider)"
-    return 0
-  fi
-
-  local expected=()
-  local entry target_rel basename
+  local entry source_abs target_rel dest_basename
   for entry in "$@"; do
-    IFS=$'\t' read -r _ _ target_rel <<< "$entry"
-    basename=$(basename "$target_rel")
-    expected+=("$basename")
+    IFS=$'\t' read -r source_abs _ target_rel <<< "$entry"
+    dest_basename="$(basename "$target_rel")"
+    cp "$source_abs" "$staged_dir/$dest_basename"
   done
 
-  shopt -s nullglob
-  local file keep
-  for file in "$output_dir"/*.md; do
-    keep=false
-    basename=$(basename "$file")
-    for target_rel in "${expected[@]}"; do
-      if [[ "$basename" == "$target_rel" ]]; then
-        keep=true
-        break
-      fi
-    done
-    if [[ "$keep" == "false" ]]; then
-      rm -f "$file"
-      echo "  ✔  Codex orphan removed: .agents/orchestration/$basename"
-    fi
-  done
-  shopt -u nullglob
-
-  rmdir "$output_dir" 2>/dev/null || true
-  rmdir "$target/.agents" 2>/dev/null || true
+  mkdir -p "$output_parent"
+  rm -rf "$output_dir"
+  if [[ -n "$(find "$staged_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+    mv "$staged_dir" "$output_dir"
+    echo "  ✔  Codex agents synced: .agentic/agents/codex"
+  else
+    rm -rf "$staged_dir"
+    rmdir "$output_parent" 2>/dev/null || true
+    echo "  ✔  Codex agents cleared: .agentic/agents/codex"
+  fi
 }

--- a/tooling/lib/vendors/codex/switch.sh
+++ b/tooling/lib/vendors/codex/switch.sh
@@ -5,11 +5,22 @@ vendor_codex_files_exist() {
   [[ -d "$VENDOR_FILES_DIR/codex" ]]
 }
 
+vendor_codex_preflight_conflicts() {
+  local target_path="$TARGET/.agents/orchestration"
+  if [[ -e "$target_path" && ! -L "$target_path" ]]; then
+    echo "Error: Cannot activate codex agents because $target_path exists and is not a symlink." >&2
+    return 1
+  fi
+}
+
 vendor_codex_create_symlinks() {
   echo "    Codex reads AGENTS.md natively — no file symlink needed"
   if [[ -d "$TARGET/.agentic/skills" ]]; then
     mkdir -p "$TARGET/.agents"
-    ln -sf "../.agentic/skills" "$TARGET/.agents/skills"
+    ln -sfn "../.agentic/skills" "$TARGET/.agents/skills"
     echo "    Linked: .agents/skills → ../.agentic/skills"
   fi
+  mkdir -p "$TARGET/.agents"
+  ln -sfn "../.agentic/agents/codex" "$TARGET/.agents/orchestration"
+  echo "    Linked: .agents/orchestration → ../.agentic/agents/codex"
 }

--- a/tooling/lib/vendors/codex/switch.sh
+++ b/tooling/lib/vendors/codex/switch.sh
@@ -6,16 +6,6 @@ vendor_codex_files_exist() {
 }
 
 vendor_codex_preflight_conflicts() {
-  local legacy_path="$TARGET/.agents/orchestration"
-  if [[ -e "$legacy_path" && ! -L "$legacy_path" ]]; then
-    local backup_path
-    backup_path="$(next_backup_path "$legacy_path")"
-    mv "$legacy_path" "$backup_path"
-    mkdir -p "$ROLLBACK_DIR"
-    printf '%s\t%s\n' "$legacy_path" "$backup_path" >> "$ROLLBACK_CURSOR_MOVES_FILE"
-    echo "  Migrated: .agents/orchestration → ${backup_path#"$TARGET"/}"
-  fi
-
   local target_path="$TARGET/.codex/agents"
   if [[ -e "$target_path" && ! -L "$target_path" ]]; then
     echo "Error: Cannot activate codex agents because $target_path exists and is not a symlink." >&2

--- a/tooling/lib/vendors/codex/switch.sh
+++ b/tooling/lib/vendors/codex/switch.sh
@@ -6,7 +6,17 @@ vendor_codex_files_exist() {
 }
 
 vendor_codex_preflight_conflicts() {
-  local target_path="$TARGET/.agents/orchestration"
+  local legacy_path="$TARGET/.agents/orchestration"
+  if [[ -e "$legacy_path" && ! -L "$legacy_path" ]]; then
+    local backup_path
+    backup_path="$(next_backup_path "$legacy_path")"
+    mv "$legacy_path" "$backup_path"
+    mkdir -p "$ROLLBACK_DIR"
+    printf '%s\t%s\n' "$legacy_path" "$backup_path" >> "$ROLLBACK_CURSOR_MOVES_FILE"
+    echo "  Migrated: .agents/orchestration → ${backup_path#"$TARGET"/}"
+  fi
+
+  local target_path="$TARGET/.codex/agents"
   if [[ -e "$target_path" && ! -L "$target_path" ]]; then
     echo "Error: Cannot activate codex agents because $target_path exists and is not a symlink." >&2
     return 1
@@ -20,7 +30,7 @@ vendor_codex_create_symlinks() {
     ln -sfn "../.agentic/skills" "$TARGET/.agents/skills"
     echo "    Linked: .agents/skills → ../.agentic/skills"
   fi
-  mkdir -p "$TARGET/.agents"
-  ln -sfn "../.agentic/agents/codex" "$TARGET/.agents/orchestration"
-  echo "    Linked: .agents/orchestration → ../.agentic/agents/codex"
+  mkdir -p "$TARGET/.codex"
+  ln -sfn "../.agentic/agents/codex" "$TARGET/.codex/agents"
+  echo "    Linked: .codex/agents → ../.agentic/agents/codex"
 }

--- a/tooling/lib/vendors/opencode/agents.sh
+++ b/tooling/lib/vendors/opencode/agents.sh
@@ -12,28 +12,19 @@ collect_opencode_agent_mappings() {
     agent_names+=("$name")
   done < <(yq '.agents | keys | .[]' "$agents_file" 2>/dev/null || true)
 
-  local name prompt_rel desc model reasoning enabled source_abs target_rel target_abs tmp_render
+  local name prompt_text desc model reasoning enabled target_rel target_abs tmp_render
   for name in "${agent_names[@]}"; do
-    enabled=$(yq ".agents.\"$name\".providers.opencode.enabled // true" "$agents_file" 2>/dev/null || echo "true")
+    enabled=$(yq -r ".agents.\"$name\".providers.opencode.enabled" "$agents_file" 2>/dev/null || echo "null")
+    [[ "$enabled" == "null" ]] && enabled="true"
     [[ "$enabled" != "true" ]] && continue
 
-    prompt_rel=$(yq -r ".agents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
+    prompt_text=$(yq -r ".agents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
     desc=$(yq -r ".agents.\"$name\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
     model=$(yq -r ".agents.\"$name\".providers.opencode.model // \"\"" "$agents_file" 2>/dev/null || echo "")
     reasoning=$(yq -r ".agents.\"$name\".providers.opencode.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
 
-    if [[ -z "$prompt_rel" || "$prompt_rel" == "null" ]]; then
-      echo "Warning: skipping opencode agent '$name' because prompt is empty" >&2
-      continue
-    fi
-    if [[ "$prompt_rel" == /* || "$prompt_rel" == *".."* ]]; then
-      echo "Warning: opencode agent '$name' prompt path must be project-relative; skipping" >&2
-      continue
-    fi
-
-    source_abs="$target/$prompt_rel"
-    if [[ ! -f "$source_abs" ]]; then
-      echo "Warning: opencode agent '$name' prompt source not found: $prompt_rel" >&2
+    if [[ -z "$prompt_text" || "$prompt_text" == "null" ]]; then
+      echo "Warning: skipping opencode agent '$name' because prompt text is empty" >&2
       continue
     fi
 
@@ -48,7 +39,7 @@ collect_opencode_agent_mappings() {
       [[ -n "$reasoning" ]] && echo "reasoning_effort: $reasoning"
       echo "description: $desc"
       echo
-      cat "$source_abs"
+      printf '%s\n' "$prompt_text"
       echo
     } > "$tmp_render"
 

--- a/tooling/lib/vendors/opencode/agents.sh
+++ b/tooling/lib/vendors/opencode/agents.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # opencode/agents.sh — Agents orchestration switching output for OpenCode
 
+map_reasoning_effort_opencode() {
+  local canonical="$1"
+  case "$canonical" in
+    low|medium|high) printf '%s' "$canonical" ;;
+    extra_high) printf '%s' "xhigh" ;;
+    *) printf '%s' "" ;;
+  esac
+}
+
 collect_opencode_agent_mappings() {
   local target="$1"
   local agents_file="$2"
@@ -12,7 +21,7 @@ collect_opencode_agent_mappings() {
     agent_names+=("$name")
   done < <(yq '.agents | keys | .[]' "$agents_file" 2>/dev/null || true)
 
-  local name prompt_text desc model reasoning enabled target_rel target_abs tmp_render
+  local name prompt_text desc model reasoning_canonical reasoning enabled target_rel target_abs tmp_render
   for name in "${agent_names[@]}"; do
     enabled=$(yq -r ".agents.\"$name\".providers.opencode.enabled" "$agents_file" 2>/dev/null || echo "null")
     [[ "$enabled" == "null" ]] && enabled="true"
@@ -21,7 +30,8 @@ collect_opencode_agent_mappings() {
     prompt_text=$(yq -r ".agents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
     desc=$(yq -r ".agents.\"$name\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
     model=$(yq -r ".agents.\"$name\".providers.opencode.model // \"\"" "$agents_file" 2>/dev/null || echo "")
-    reasoning=$(yq -r ".agents.\"$name\".providers.opencode.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning_canonical=$(yq -r ".agents.\"$name\".providers.opencode.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning=$(map_reasoning_effort_opencode "$reasoning_canonical")
 
     if [[ -z "$prompt_text" || "$prompt_text" == "null" ]]; then
       echo "Warning: skipping opencode agent '$name' because prompt text is empty" >&2

--- a/tooling/lib/vendors/opencode/agents.sh
+++ b/tooling/lib/vendors/opencode/agents.sh
@@ -67,3 +67,48 @@ apply_opencode_agent_mappings() {
     echo "  ✔  OpenCode agent synced: $target_rel"
   done
 }
+
+cleanup_opencode_agent_outputs() {
+  local target="$1"
+  local active="$2"
+  shift 2
+
+  local output_dir="$target/.opencode/agents"
+  [[ ! -d "$output_dir" ]] && return 0
+
+  if [[ "$active" != "true" ]]; then
+    rm -rf "$output_dir"
+    rmdir "$target/.opencode" 2>/dev/null || true
+    echo "  ✔  OpenCode agent scaffolds removed (inactive provider)"
+    return 0
+  fi
+
+  local expected_files=()
+  local entry target_rel expected_name
+  for entry in "$@"; do
+    IFS=$'\t' read -r _ _ target_rel <<< "$entry"
+    expected_name=$(basename "$target_rel")
+    expected_files+=("$expected_name")
+  done
+
+  shopt -s nullglob
+  local file keep file_name expected_file
+  for file in "$output_dir"/*.md; do
+    keep=false
+    file_name=$(basename "$file")
+    for expected_file in "${expected_files[@]}"; do
+      if [[ "$file_name" == "$expected_file" ]]; then
+        keep=true
+        break
+      fi
+    done
+    if [[ "$keep" == "false" ]]; then
+      rm -f "$file"
+      echo "  ✔  OpenCode orphan removed: .opencode/agents/$file_name"
+    fi
+  done
+  shopt -u nullglob
+
+  rmdir "$output_dir" 2>/dev/null || true
+  rmdir "$target/.opencode" 2>/dev/null || true
+}

--- a/tooling/lib/vendors/opencode/agents.sh
+++ b/tooling/lib/vendors/opencode/agents.sh
@@ -38,7 +38,7 @@ collect_opencode_agent_mappings() {
       continue
     fi
 
-    target_rel=".opencode/agents/$name.md"
+    target_rel=".agentic/agents/opencode/$name.md"
     target_abs="$target/$target_rel"
     tmp_render="$(mktemp "${TMPDIR:-/tmp}/agentic-opencode-agent-XXXXXX.md")"
     {
@@ -58,57 +58,29 @@ collect_opencode_agent_mappings() {
 }
 
 apply_opencode_agent_mappings() {
-  local entry source_abs target_abs target_rel
-
-  for entry in "$@"; do
-    IFS=$'\t' read -r source_abs target_abs target_rel <<< "$entry"
-    mkdir -p "$(dirname "$target_abs")"
-    cp "$source_abs" "$target_abs"
-    echo "  ✔  OpenCode agent synced: $target_rel"
-  done
-}
-
-cleanup_opencode_agent_outputs() {
   local target="$1"
-  local active="$2"
-  shift 2
+  shift
 
-  local output_dir="$target/.opencode/agents"
-  [[ ! -d "$output_dir" ]] && return 0
+  local output_dir="$target/.agentic/agents/opencode"
+  local output_parent="$target/.agentic/agents"
+  local staged_dir
+  staged_dir="$(mktemp -d "${TMPDIR:-/tmp}/agentic-opencode-agents-XXXXXX")"
 
-  if [[ "$active" != "true" ]]; then
-    rm -rf "$output_dir"
-    rmdir "$target/.opencode" 2>/dev/null || true
-    echo "  ✔  OpenCode agent scaffolds removed (inactive provider)"
-    return 0
-  fi
-
-  local expected_files=()
-  local entry target_rel expected_name
+  local entry source_abs target_rel dest_basename
   for entry in "$@"; do
-    IFS=$'\t' read -r _ _ target_rel <<< "$entry"
-    expected_name=$(basename "$target_rel")
-    expected_files+=("$expected_name")
+    IFS=$'\t' read -r source_abs _ target_rel <<< "$entry"
+    dest_basename="$(basename "$target_rel")"
+    cp "$source_abs" "$staged_dir/$dest_basename"
   done
 
-  shopt -s nullglob
-  local file keep file_name expected_file
-  for file in "$output_dir"/*.md; do
-    keep=false
-    file_name=$(basename "$file")
-    for expected_file in "${expected_files[@]}"; do
-      if [[ "$file_name" == "$expected_file" ]]; then
-        keep=true
-        break
-      fi
-    done
-    if [[ "$keep" == "false" ]]; then
-      rm -f "$file"
-      echo "  ✔  OpenCode orphan removed: .opencode/agents/$file_name"
-    fi
-  done
-  shopt -u nullglob
-
-  rmdir "$output_dir" 2>/dev/null || true
-  rmdir "$target/.opencode" 2>/dev/null || true
+  mkdir -p "$output_parent"
+  rm -rf "$output_dir"
+  if [[ -n "$(find "$staged_dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+    mv "$staged_dir" "$output_dir"
+    echo "  ✔  OpenCode agents synced: .agentic/agents/opencode"
+  else
+    rm -rf "$staged_dir"
+    rmdir "$output_parent" 2>/dev/null || true
+    echo "  ✔  OpenCode agents cleared: .agentic/agents/opencode"
+  fi
 }

--- a/tooling/lib/vendors/opencode/agents.sh
+++ b/tooling/lib/vendors/opencode/agents.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# opencode/agents.sh — Portable agents mapping for OpenCode
+
+sync_opencode_agents() {
+  local target="$1"
+  local agents_file="$2"
+  local enabled
+  enabled=$(yq '.providers.opencode.enabled // false' "$agents_file" 2>/dev/null || echo "false")
+  [[ "$enabled" != "true" ]] && return 0
+
+  local mapping_count idx source_rel target_rel source_abs target_abs
+  mapping_count=$(yq '.providers.opencode.mappings | length' "$agents_file" 2>/dev/null || echo 0)
+  [[ "$mapping_count" == "null" ]] && mapping_count=0
+  [[ "$mapping_count" -eq 0 ]] && return 0
+
+  for ((idx = 0; idx < mapping_count; idx++)); do
+    source_rel=$(yq ".providers.opencode.mappings[$idx].source // \"\"" "$agents_file" 2>/dev/null || echo "")
+    target_rel=$(yq ".providers.opencode.mappings[$idx].target // \"\"" "$agents_file" 2>/dev/null || echo "")
+
+    if [[ -z "$source_rel" || -z "$target_rel" || "$source_rel" == "null" || "$target_rel" == "null" ]]; then
+      echo "Warning: skipping invalid opencode mapping at index $idx in $agents_file" >&2
+      continue
+    fi
+    if [[ "$source_rel" == /* || "$target_rel" == /* ]]; then
+      echo "Warning: opencode mappings must use project-relative paths; skipping index $idx" >&2
+      continue
+    fi
+
+    source_abs="$target/$source_rel"
+    target_abs="$target/$target_rel"
+    if [[ ! -f "$source_abs" ]]; then
+      echo "Warning: opencode mapping source not found: $source_rel" >&2
+      continue
+    fi
+
+    mkdir -p "$(dirname "$target_abs")"
+    cp "$source_abs" "$target_abs"
+    echo "  ✔  OpenCode agent synced: $source_rel -> $target_rel"
+  done
+}

--- a/tooling/lib/vendors/opencode/agents.sh
+++ b/tooling/lib/vendors/opencode/agents.sh
@@ -57,10 +57,9 @@ collect_opencode_agent_mappings() {
 }
 
 apply_opencode_agent_mappings() {
-  local -n mappings_ref="$1"
   local entry source_abs target_abs target_rel
 
-  for entry in "${mappings_ref[@]}"; do
+  for entry in "$@"; do
     IFS=$'\t' read -r source_abs target_abs target_rel <<< "$entry"
     mkdir -p "$(dirname "$target_abs")"
     cp "$source_abs" "$target_abs"

--- a/tooling/lib/vendors/opencode/agents.sh
+++ b/tooling/lib/vendors/opencode/agents.sh
@@ -55,6 +55,49 @@ collect_opencode_agent_mappings() {
 
     mappings_ref+=("$tmp_render"$'\t'"$target_abs"$'\t'"$target_rel")
   done
+
+  local subagent_names=()
+  while IFS= read -r name; do
+    [[ -z "$name" || "$name" == "null" ]] && continue
+    subagent_names+=("$name")
+  done < <(yq '.subagents | keys | .[]' "$agents_file" 2>/dev/null || true)
+
+  local parent
+  for name in "${subagent_names[@]}"; do
+    enabled=$(yq -r ".subagents.\"$name\".providers.opencode.enabled" "$agents_file" 2>/dev/null || echo "null")
+    [[ "$enabled" == "null" ]] && enabled="true"
+    [[ "$enabled" != "true" ]] && continue
+
+    parent=$(yq -r ".subagents.\"$name\".parent // \"\"" "$agents_file" 2>/dev/null || echo "")
+    prompt_text=$(yq -r ".subagents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
+    desc=$(yq -r ".subagents.\"$name\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
+    model=$(yq -r ".subagents.\"$name\".providers.opencode.model // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning_canonical=$(yq -r ".subagents.\"$name\".providers.opencode.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning=$(map_reasoning_effort_opencode "$reasoning_canonical")
+
+    if [[ -z "$prompt_text" || "$prompt_text" == "null" ]]; then
+      echo "Warning: skipping opencode subagent '$name' because prompt text is empty" >&2
+      continue
+    fi
+
+    target_rel=".agentic/agents/opencode/$name.subagent.md"
+    target_abs="$target/$target_rel"
+    tmp_render="$(mktemp "${TMPDIR:-/tmp}/agentic-opencode-subagent-XXXXXX.md")"
+    {
+      echo "# Subagent: $name"
+      echo
+      echo "provider: opencode"
+      echo "parent: $parent"
+      [[ -n "$model" ]] && echo "model: $model"
+      [[ -n "$reasoning" ]] && echo "reasoning_effort: $reasoning"
+      echo "description: $desc"
+      echo
+      printf '%s\n' "$prompt_text"
+      echo
+    } > "$tmp_render"
+
+    mappings_ref+=("$tmp_render"$'\t'"$target_abs"$'\t'"$target_rel")
+  done
 }
 
 apply_opencode_agent_mappings() {

--- a/tooling/lib/vendors/opencode/agents.sh
+++ b/tooling/lib/vendors/opencode/agents.sh
@@ -1,40 +1,69 @@
 #!/usr/bin/env bash
-# opencode/agents.sh — Portable agents mapping for OpenCode
+# opencode/agents.sh — Agents orchestration switching output for OpenCode
 
-sync_opencode_agents() {
+collect_opencode_agent_mappings() {
   local target="$1"
   local agents_file="$2"
-  local enabled
-  enabled=$(yq '.providers.opencode.enabled // false' "$agents_file" 2>/dev/null || echo "false")
-  [[ "$enabled" != "true" ]] && return 0
+  local -n mappings_ref="$3"
 
-  local mapping_count idx source_rel target_rel source_abs target_abs
-  mapping_count=$(yq '.providers.opencode.mappings | length' "$agents_file" 2>/dev/null || echo 0)
-  [[ "$mapping_count" == "null" ]] && mapping_count=0
-  [[ "$mapping_count" -eq 0 ]] && return 0
+  local agent_names=()
+  while IFS= read -r name; do
+    [[ -z "$name" || "$name" == "null" ]] && continue
+    agent_names+=("$name")
+  done < <(yq '.agents | keys | .[]' "$agents_file" 2>/dev/null || true)
 
-  for ((idx = 0; idx < mapping_count; idx++)); do
-    source_rel=$(yq ".providers.opencode.mappings[$idx].source // \"\"" "$agents_file" 2>/dev/null || echo "")
-    target_rel=$(yq ".providers.opencode.mappings[$idx].target // \"\"" "$agents_file" 2>/dev/null || echo "")
+  local name prompt_rel desc model reasoning enabled source_abs target_rel target_abs tmp_render
+  for name in "${agent_names[@]}"; do
+    enabled=$(yq ".agents.\"$name\".providers.opencode.enabled // true" "$agents_file" 2>/dev/null || echo "true")
+    [[ "$enabled" != "true" ]] && continue
 
-    if [[ -z "$source_rel" || -z "$target_rel" || "$source_rel" == "null" || "$target_rel" == "null" ]]; then
-      echo "Warning: skipping invalid opencode mapping at index $idx in $agents_file" >&2
+    prompt_rel=$(yq -r ".agents.\"$name\".prompt // \"\"" "$agents_file" 2>/dev/null || echo "")
+    desc=$(yq -r ".agents.\"$name\".description // \"\"" "$agents_file" 2>/dev/null || echo "")
+    model=$(yq -r ".agents.\"$name\".providers.opencode.model // \"\"" "$agents_file" 2>/dev/null || echo "")
+    reasoning=$(yq -r ".agents.\"$name\".providers.opencode.reasoning_effort // \"\"" "$agents_file" 2>/dev/null || echo "")
+
+    if [[ -z "$prompt_rel" || "$prompt_rel" == "null" ]]; then
+      echo "Warning: skipping opencode agent '$name' because prompt is empty" >&2
       continue
     fi
-    if [[ "$source_rel" == /* || "$target_rel" == /* ]]; then
-      echo "Warning: opencode mappings must use project-relative paths; skipping index $idx" >&2
+    if [[ "$prompt_rel" == /* || "$prompt_rel" == *".."* ]]; then
+      echo "Warning: opencode agent '$name' prompt path must be project-relative; skipping" >&2
       continue
     fi
 
-    source_abs="$target/$source_rel"
-    target_abs="$target/$target_rel"
+    source_abs="$target/$prompt_rel"
     if [[ ! -f "$source_abs" ]]; then
-      echo "Warning: opencode mapping source not found: $source_rel" >&2
+      echo "Warning: opencode agent '$name' prompt source not found: $prompt_rel" >&2
       continue
     fi
 
+    target_rel=".opencode/agents/$name.md"
+    target_abs="$target/$target_rel"
+    tmp_render="$(mktemp "${TMPDIR:-/tmp}/agentic-opencode-agent-XXXXXX.md")"
+    {
+      echo "# Agent: $name"
+      echo
+      echo "provider: opencode"
+      [[ -n "$model" ]] && echo "model: $model"
+      [[ -n "$reasoning" ]] && echo "reasoning_effort: $reasoning"
+      echo "description: $desc"
+      echo
+      cat "$source_abs"
+      echo
+    } > "$tmp_render"
+
+    mappings_ref+=("$tmp_render"$'\t'"$target_abs"$'\t'"$target_rel")
+  done
+}
+
+apply_opencode_agent_mappings() {
+  local -n mappings_ref="$1"
+  local entry source_abs target_abs target_rel
+
+  for entry in "${mappings_ref[@]}"; do
+    IFS=$'\t' read -r source_abs target_abs target_rel <<< "$entry"
     mkdir -p "$(dirname "$target_abs")"
     cp "$source_abs" "$target_abs"
-    echo "  ✔  OpenCode agent synced: $source_rel -> $target_rel"
+    echo "  ✔  OpenCode agent synced: $target_rel"
   done
 }

--- a/tooling/lib/vendors/opencode/switch.sh
+++ b/tooling/lib/vendors/opencode/switch.sh
@@ -5,10 +5,21 @@ vendor_opencode_files_exist() {
   [[ -d "$VENDOR_FILES_DIR/opencode" ]]
 }
 
+vendor_opencode_preflight_conflicts() {
+  local target_path="$TARGET/.opencode/agents"
+  if [[ -e "$target_path" && ! -L "$target_path" ]]; then
+    echo "Error: Cannot activate opencode agents because $target_path exists and is not a symlink." >&2
+    return 1
+  fi
+}
+
 vendor_opencode_create_symlinks() {
   if [[ -d "$TARGET/.agentic/skills" ]]; then
     mkdir -p "$TARGET/.opencode"
-    ln -sf "../.agentic/skills" "$TARGET/.opencode/skills"
+    ln -sfn "../.agentic/skills" "$TARGET/.opencode/skills"
     echo "    Linked: .opencode/skills → ../.agentic/skills"
   fi
+  mkdir -p "$TARGET/.opencode"
+  ln -sfn "../.agentic/agents/opencode" "$TARGET/.opencode/agents"
+  echo "    Linked: .opencode/agents → ../.agentic/agents/opencode"
 }

--- a/vendors/claude/README.md
+++ b/vendors/claude/README.md
@@ -21,7 +21,7 @@ The `vendor-gen` step copies skill directories from this library into the target
 | File | Purpose |
 |---|---|
 | `AGENTS.md` | Primary — assembled from fragments, read by Claude natively |
-| `CLAUDE.md` | Thin pointer to AGENTS.md for backward compatibility |
+| `CLAUDE.md` | Thin pointer to AGENTS.md for Claude entrypoint conventions |
 | `.claude/skills/*/` | Skill directories copied from this library |
 
 ## Notes

--- a/vendors/codex/README.md
+++ b/vendors/codex/README.md
@@ -12,6 +12,7 @@ OpenAI Codex reads `AGENTS.md` natively:
 | File | Purpose |
 |---|---|
 | `AGENTS.md` | Primary — Codex reads this natively |
+| `.codex/agents/` | Provider-local subagents path (symlink target when orchestration switching is enabled) |
 
 ## Monorepo Support
 
@@ -34,3 +35,4 @@ Use `just compose` once per service with its own profile.
 
 - Codex is the most native consumer of AGENTS.md — no adapter transformation is required.
 - The passthrough adapter exists to track which sections were intended for Codex.
+- Orchestration `agents` are declared in `.agentic/agents.yaml`; generated artifacts live in `.agentic/agents/codex/` and are exposed at provider-local `.codex/agents/`.

--- a/vendors/opencode/README.md
+++ b/vendors/opencode/README.md
@@ -12,7 +12,12 @@ Opencode reads `AGENTS.md` natively (same as Claude Code and OpenAI Codex). No t
 |---|---|---|
 | `AGENTS.md` | project root | Canonical instructions, read natively by Opencode |
 | `.opencode/skills/` | project root | Skills directory (Opencode's native path) |
+| `.opencode/agents/` | project root | Provider-local subagents path (symlink target when orchestration switching is enabled) |
 
 ## Skills
 
 Skills deploy to `.opencode/skills/` — Opencode's native skills path. Opencode also supports `.claude/skills/` and `.agents/skills/` as compatibility fallbacks, but `.opencode/skills/` is the canonical location.
+
+## Agents orchestration
+
+Orchestration `agents` are declared in `.agentic/agents.yaml`. Generated artifacts live in `.agentic/agents/opencode/` and are exposed at provider-local `.opencode/agents/` (subagents path).

--- a/vendors/opencode/README.md
+++ b/vendors/opencode/README.md
@@ -16,7 +16,7 @@ Opencode reads `AGENTS.md` natively (same as Claude Code and OpenAI Codex). No t
 
 ## Skills
 
-Skills deploy to `.opencode/skills/` — Opencode's native skills path. Opencode also supports `.claude/skills/` and `.agents/skills/` as compatibility fallbacks, but `.opencode/skills/` is the canonical location.
+Skills deploy to `.opencode/skills/` — Opencode's native skills path.
 
 ## Agents orchestration
 


### PR DESCRIPTION
## Summary
This PR delivers issue #118 as an opt-in **Agents Orchestration Switching** capability via `.agentic/agents.yaml`, and finalizes the implementation in a **forward-only** model.

## Final contract (v1)
- `version: "1"`
- `enabled: <bool>`
- `agents: { <agent_name>: { description, prompt, providers{...} } }`
- `subagents: { <subagent_name>: { description, prompt, parent, providers{...} } }`

## What changed
- Added/validated orchestration contract and runtime flow:
  - `schemas/agents.schema.json`
  - `tooling/lib/agents.sh`
  - `tooling/lib/vendors/codex/agents.sh`
  - `tooling/lib/vendors/opencode/agents.sh`
- Codex provider-local agents path aligned to:
  - `.codex/agents`
- Removed backward-compat/migration approaches from this implementation:
  - removed `active_vendor` migration/fallback handling
  - removed `.agentic/vendor-stash` migration handling
  - removed sync fallback to `library_path`
  - removed compose/profile-level `mcp:` fallback
  - MCP seeding is now sourced from `.agentic/mcp.yaml` only
- Updated tests to match forward-only behavior and MCP source-of-truth:
  - `tooling/lib/test.sh`
- Updated docs to match current behavior and improve user-facing clarity:
  - `docs/agents.md`
  - `docs/commands.md`
  - `docs/custom-rules.md`
  - `docs/customization.md`
  - `docs/vendors.md`
  - `vendors/claude/README.md`
  - `vendors/opencode/README.md`

## Validation
- `just lint` ✅
- `just test` ✅ (`534/534`)

Closes #118
