### PR TITLE
fix(compose): correct nested profile behavior in --link mode

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -228,6 +228,7 @@ self-contained and cloneable without the library installed on every machine.
 Those same directories are symlinks pointing to the library on the deploying machine.
 Committing a symlink to an absolute local path breaks every other machine, so they
 are gitignored automatically.
+This behavior applies to both standalone and nested profiles.
 
 ### What this means for your repo
 

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -150,9 +150,29 @@ copy_fragments_to_target() {
 # ── Fragment symlink (used in --link mode) ────────────────────────────────────
 link_fragments_to_library() {
   local dest="$TARGET/.agentic/fragments"
+  mkdir -p "$TARGET/.agentic"
   # Remove any existing copy or symlink using safe_rm_rf
   safe_rm_rf "$dest"
   ln -sf "$LIBRARY/agents" "$dest"
+}
+
+# Render a fragment reference path for AGENTS.md tables based on deploy mode.
+fragment_reference_path() {
+  local frag="$1"
+  local fname rel_path group
+  fname=$(basename "$frag")
+
+  if [[ "$LINK_MODE" == "true" ]]; then
+    rel_path="${frag#"$LIBRARY"/agents/}"
+    group=$(dirname "$rel_path")
+    if [[ "$group" == "." ]]; then
+      printf '.agentic/fragments/%s' "$fname"
+    else
+      printf '.agentic/fragments/%s/%s' "$group" "$fname"
+    fi
+  else
+    printf '.agentic/fragments/%s' "$fname"
+  fi
 }
 
 # ── Fragment reference table (lean mode) ──────────────────────────────────────
@@ -164,26 +184,11 @@ build_fragment_reference_table() {
   section+="|------|------|"$'\n'
 
   for frag in "${RESOLVED_FRAGMENTS[@]+"${RESOLVED_FRAGMENTS[@]}"}"; do
-    local heading fname rel_path group
+    local heading frag_ref
     heading=$(grep -m1 '^## ' "$frag" | head -1)
     heading="${heading#'## '}"
-    fname=$(basename "$frag")
-    # In link mode, preserve the subdirectory structure since .agentic/fragments is a symlink
-    # to $LIBRARY/agents where files live in subdirectories (e.g., base/git-conventions.md)
-    if [[ "$LINK_MODE" == "true" ]]; then
-      rel_path="${frag#"$LIBRARY"/agents/}"
-      group=$(dirname "$rel_path")
-      if [[ "$group" == "." ]]; then
-        # Fragment is directly in agents/ (no subdirectory)
-        section+="| ${heading} | \`.agentic/fragments/${fname}\` |"$'\n'
-      else
-        # Fragment is in a subdirectory (e.g., base/git-conventions.md)
-        section+="| ${heading} | \`.agentic/fragments/${group}/${fname}\` |"$'\n'
-      fi
-    else
-      # Copy mode: fragments are flattened into .agentic/fragments/
-      section+="| ${heading} | \`.agentic/fragments/${fname}\` |"$'\n'
-    fi
+    frag_ref=$(fragment_reference_path "$frag")
+    section+="| ${heading} | \`${frag_ref}\` |"$'\n'
   done
 
   printf '%s' "$section"
@@ -708,15 +713,21 @@ compose_nested() {
     done
   done
 
-  # ── Copy ALL fragments to .agentic/fragments/ (always in nested mode) ───────
+  # ── Materialize fragments for nested mode ───────────────────────────────────
   local dest="$TARGET/.agentic/fragments"
-  mkdir -p "$dest"
-  for f in "${root_frags[@]+"${root_frags[@]}"}"; do
-    cp "$f" "$dest/$(basename "$f")"
-  done
-  for f in "${all_tier_frags[@]+"${all_tier_frags[@]}"}"; do
-    cp "$f" "$dest/$(basename "$f")"
-  done
+  if [[ "$LINK_MODE" == "true" ]]; then
+    link_fragments_to_library
+  else
+    # Remove existing symlink/dir before re-copy to avoid writing into library through symlinks.
+    safe_rm_rf "$dest"
+    mkdir -p "$dest"
+    for f in "${root_frags[@]+"${root_frags[@]}"}"; do
+      cp "$f" "$dest/$(basename "$f")"
+    done
+    for f in "${all_tier_frags[@]+"${all_tier_frags[@]}"}"; do
+      cp "$f" "$dest/$(basename "$f")"
+    done
+  fi
 
   # ── Root AGENTS.md ──────────────────────────────────────────────────────────
   local root_out="$OUTPUT"
@@ -734,22 +745,11 @@ compose_nested() {
     root_out+="| Area | File |"$'\n'
     root_out+="|------|------|"$'\n'
     for f in "${root_frags[@]+"${root_frags[@]}"}"; do
-      local h fname rel_path group
+      local h frag_ref
       h=$(grep -m1 '^## ' "$f" | head -1)
       h="${h#'## '}"
-      fname=$(basename "$f")
-      # In link mode, preserve the subdirectory structure
-      if [[ "$LINK_MODE" == "true" ]]; then
-        rel_path="${f#"$LIBRARY"/agents/}"
-        group=$(dirname "$rel_path")
-        if [[ "$group" == "." ]]; then
-          root_out+="| ${h} | \`.agentic/fragments/${fname}\` |"$'\n'
-        else
-          root_out+="| ${h} | \`.agentic/fragments/${group}/${fname}\` |"$'\n'
-        fi
-      else
-        root_out+="| ${h} | \`.agentic/fragments/${fname}\` |"$'\n'
-      fi
+      frag_ref=$(fragment_reference_path "$f")
+      root_out+="| ${h} | \`${frag_ref}\` |"$'\n'
     done
   fi
 
@@ -817,11 +817,11 @@ compose_nested() {
         tier_out+="| Area | File |"$'\n'
         tier_out+="|------|------|"$'\n'
         for f in "${tier_frags[@]}"; do
-          local h fname
+          local h frag_ref
           h=$(grep -m1 '^## ' "$f" | head -1)
           h="${h#'## '}"
-          fname=$(basename "$f")
-          tier_out+="| ${h} | \`.agentic/fragments/${fname}\` |"$'\n'
+          frag_ref=$(fragment_reference_path "$f")
+          tier_out+="| ${h} | \`${frag_ref}\` |"$'\n'
         done
       fi
     fi
@@ -850,6 +850,8 @@ compose_nested() {
   mkdir -p "$TARGET/.agentic"
   local compose_mode="lean"
   [[ "$FULL_MODE" == "true" ]] && compose_mode="full"
+  local deploy_mode_str="copy"
+  [[ "$LINK_MODE" == "true" ]] && deploy_mode_str="link"
   {
     echo "# yaml-language-server: \$schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/config.schema.json"
     echo "# Managed by agentic library — do not edit manually"
@@ -860,6 +862,7 @@ compose_nested() {
     echo "composed_at: \"${GENERATED_AT}\""
     echo "mode: ${compose_mode}"
     echo "agentic_root: \"${LIBRARY}\""
+    echo "deploy_mode: ${deploy_mode_str}"
     echo "active_vendors: []"
     echo "structure: nested"
     echo "tiers:"

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -3046,6 +3046,78 @@ assert_file_not_contains "$TMP/t109/backend/AGENTS.md" ".agentic/fragments/next.
 assert_file_contains "$TMP/t109/ui/AGENTS.md" ".agentic/fragments/next.md" "T109"
 assert_file_not_contains "$TMP/t109/ui/AGENTS.md" ".agentic/fragments/hexagonal.md" "T109"
 
+# T109A — compose: nested --link uses symlinked fragments and grouped references
+run_test "T109A — compose: nested --link fragments symlink and grouped refs"
+T109A_EXIT=0
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-nuxt-vite-ui \
+  --target "$TMP/t109a" \
+  --link \
+  > /dev/null 2>&1 || T109A_EXIT=$?
+
+assert_exit_code 0 "$T109A_EXIT" "T109A"
+assert_symlink_exists "$TMP/t109a/.agentic/fragments" "T109A fragments symlink"
+assert_file_contains "$TMP/t109a/.agentic/config.yaml" "deploy_mode: link" "T109A deploy mode"
+assert_file_contains "$TMP/t109a/AGENTS.md" ".agentic/fragments/base/git-conventions.md" "T109A root grouped path"
+assert_file_contains "$TMP/t109a/backend/AGENTS.md" ".agentic/fragments/languages/go.md" "T109A backend grouped path"
+assert_file_contains "$TMP/t109a/ui/AGENTS.md" ".agentic/fragments/frameworks/nuxt.md" "T109A ui grouped path"
+
+# T109B — compose: nested copy mode uses copied fragments and flat references
+run_test "T109B — compose: nested copy mode uses flat refs"
+T109B_EXIT=0
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-nuxt-vite-ui \
+  --target "$TMP/t109b" \
+  > /dev/null 2>&1 || T109B_EXIT=$?
+
+assert_exit_code 0 "$T109B_EXIT" "T109B"
+assert_not_symlink "$TMP/t109b/.agentic/fragments" "T109B fragments copied dir"
+assert_file_contains "$TMP/t109b/.agentic/config.yaml" "deploy_mode: copy" "T109B deploy mode"
+assert_file_contains "$TMP/t109b/AGENTS.md" ".agentic/fragments/git-conventions.md" "T109B root flat path"
+assert_file_not_contains "$TMP/t109b/AGENTS.md" ".agentic/fragments/base/git-conventions.md" "T109B root grouped absent"
+assert_file_contains "$TMP/t109b/backend/AGENTS.md" ".agentic/fragments/go.md" "T109B backend flat path"
+assert_file_not_contains "$TMP/t109b/backend/AGENTS.md" ".agentic/fragments/languages/go.md" "T109B backend grouped absent"
+
+# T109C — compose: nested copy->link migration rewrites fragments layout
+run_test "T109C — compose: nested copy->link migration"
+mkdir -p "$TMP/t109c"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-nuxt-vite-ui \
+  --target "$TMP/t109c" \
+  > /dev/null 2>&1
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-nuxt-vite-ui \
+  --target "$TMP/t109c" \
+  --link \
+  > /dev/null 2>&1
+assert_symlink_exists "$TMP/t109c/.agentic/fragments" "T109C fragments symlink"
+assert_file_contains "$TMP/t109c/.agentic/config.yaml" "deploy_mode: link" "T109C deploy mode"
+assert_file_contains "$TMP/t109c/AGENTS.md" ".agentic/fragments/base/git-conventions.md" "T109C root grouped path"
+assert_file_not_contains "$TMP/t109c/AGENTS.md" ".agentic/fragments/git-conventions.md" "T109C root flat path removed"
+
+# T109D — compose: nested link->copy migration materializes fragments
+run_test "T109D — compose: nested link->copy migration"
+mkdir -p "$TMP/t109d"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-nuxt-vite-ui \
+  --target "$TMP/t109d" \
+  --link \
+  > /dev/null 2>&1
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile golang-hexagonal-nuxt-vite-ui \
+  --target "$TMP/t109d" \
+  > /dev/null 2>&1
+assert_not_symlink "$TMP/t109d/.agentic/fragments" "T109D fragments copied dir"
+assert_file_contains "$TMP/t109d/.agentic/config.yaml" "deploy_mode: copy" "T109D deploy mode"
+assert_file_contains "$TMP/t109d/backend/AGENTS.md" ".agentic/fragments/go.md" "T109D backend flat path"
+assert_file_not_contains "$TMP/t109d/backend/AGENTS.md" ".agentic/fragments/languages/go.md" "T109D backend grouped removed"
+
 # T110 — deploy-skills: all-skills deployment includes docker-compose-local-setup
 run_test "T110 — deploy-skills: all-skills includes docker-compose-local-setup"
 mkdir -p "$TMP/t110"


### PR DESCRIPTION
## Context
Nested profiles deployed with `--link` produced inconsistent and broken output:

- `.agentic/fragments` was copied as a real directory instead of symlinked.
- Nested `config.yaml` did not persist `deploy_mode`, so mode intent was not explicit.
- Root and tier AGENTS fragment references diverged by mode and were inconsistent for nested link mode.

Repro example:

```bash
agentic deploy golang-hexagonal-nuxt-vite-ui . opencode,codex --link
```

## Root cause
`compose_nested()` had copy-only fragment staging logic and did not share the same link/copy path semantics used by flat mode.

## Changes

### 1) Nested fragment materialization now honors `--link`
Updated `tooling/lib/compose.sh`:

- In nested mode:
  - `--link`: `.agentic/fragments` is symlinked to `${LIBRARY}/agents`
  - copy mode: `.agentic/fragments` is materialized as local copied files
- Added safe replacement logic so mode transitions do not write through stale symlinks.
- Ensured `.agentic/` exists before creating fragments symlink.

### 2) Unified fragment reference rendering
Added `fragment_reference_path()` helper in `tooling/lib/compose.sh` and reused it in both flat and nested table rendering.

Reference behavior is now deterministic:

- link mode: grouped paths (e.g. `.agentic/fragments/base/git-conventions.md`)
- copy mode: flat paths (e.g. `.agentic/fragments/git-conventions.md`)

This is now consistent for:

- root AGENTS conventions table
- tier AGENTS guideline tables

### 3) Persist deploy mode for nested config
Nested lock file generation now writes:

- `deploy_mode: link` when `--link` is used
- `deploy_mode: copy` otherwise

in `.agentic/config.yaml`.

### 4) Documentation clarification
Updated `docs/customization.md` to explicitly state that link mode behavior applies to both standalone and nested profiles.

## Test coverage
Added nested-specific regressions in `tooling/lib/test.sh`:

- `T109A`: nested `--link` produces symlinked fragments + grouped refs + `deploy_mode: link`
- `T109B`: nested copy mode keeps copied fragments + flat refs + `deploy_mode: copy`
- `T109C`: nested copy → link migration rewrites layout and references correctly
- `T109D`: nested link → copy migration materializes local fragments and rewrites refs

## Validation
Executed with Homebrew bash in PATH (`/opt/homebrew/bin/bash`) due macOS `/bin/bash` 3.2 incompatibility with existing `local -n` usage in tooling scripts.

- `just test` → **582/582 passed**
- `just lint` → **passed**

## Outcome
Nested profiles now follow the same deploy-mode contract as flat profiles, and `--link` produces consistent, valid symlink/reference/config behavior across root and tier AGENTS outputs.
