### PR TITLE
chore(deps): consolidate 4 Dependabot workflow action updates

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: semgrep.sarif
 
@@ -76,6 +76,6 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           sarif_file: trivy.sarif

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install kcov
         id: cache-kcov
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.2
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v4.2.2
         with:
           path: /tmp/kcov-install
           key: kcov-${{ runner.os }}-v43
@@ -105,14 +105,14 @@ jobs:
           echo "Coverage: ${coverage_percent}%"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa # v6.0.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ steps.coverage.outputs.cobertura_file }}
           fail_ci_if_error: true
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kcov-html-report
           path: coverage/


### PR DESCRIPTION
## Context
PRs #139, #140, #141, and #142 (Dependabot workflow action updates) were closed and their source branches are no longer available for direct merge.

This PR consolidates those four updates into a single mergeable change set.

## Included updates

### From #139
- `.github/workflows/validate.yml`
  - `actions/cache`
    - `0057852bfaa89a56745cba8c7296529d2fc39830` -> `27d5ce7f107fe9357f9df03efb73ab90386fccae`

### From #140
- `.github/workflows/sast.yml`
  - `github/codeql-action/upload-sarif` (Semgrep SARIF upload step)
    - `95e58e9a2cdfd71adc6e0353d5c52f41a045d225` -> `68bde559dea0fdcac2102bfdf6230c5f70eb485e`
  - `github/codeql-action/upload-sarif` (Trivy SARIF upload step)
    - `95e58e9a2cdfd71adc6e0353d5c52f41a045d225` -> `68bde559dea0fdcac2102bfdf6230c5f70eb485e`

### From #141
- `.github/workflows/validate.yml`
  - `codecov/codecov-action`
    - `3f20e214133d0983f9a10f3d63b0faf9241a3daa` -> `57e3a136b779b570ffcdbf80b3bdc90e7fab3de2`

### From #142
- `.github/workflows/validate.yml`
  - `actions/upload-artifact`
    - `65462800fd760344b1a7b4382951275a0abb4808` -> `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`

## Notes
- Scope is intentionally limited to the same line-level workflow action pin updates from those four Dependabot PRs.
- No functional workflow structure changes beyond these dependency pin bumps.
