### PR TITLE
feat: improve TS/Hono architecture guidance and add Effect CLI profile

### DIFF
--- a/agents/architecture/hexagonal.md
+++ b/agents/architecture/hexagonal.md
@@ -92,3 +92,6 @@ src/
    the application boundary (e.g., `ErrNotFound`, `ErrPermissionDenied`). Never let
    infrastructure-specific errors (SQL errors, HTTP status codes, driver errors) leak upward
    through the port interface.
+9. **Keep business rules cohesive**: do not spread domain logic across utility/helper functions
+   in unrelated packages. Place invariants and decisions in aggregates, value objects, or domain
+   services with explicit names.

--- a/agents/frameworks/effect-cli.md
+++ b/agents/frameworks/effect-cli.md
@@ -1,0 +1,32 @@
+## Effect CLI (TypeScript)
+
+### Command Modeling
+
+- Model each command as a dedicated module/class with a single responsibility.
+- Keep command handlers thin: parse inputs, call application use cases, render output.
+- Domain logic and business policies belong in domain/application layers, never inside CLI handlers.
+
+### Ports and Adapters Wiring
+
+- `@effect/cli` and `@effect/platform-node` are driving adapters around the application core.
+- Define ports/interfaces in domain/application for outbound dependencies (filesystem, HTTP, process, clock).
+- Implement those ports in infrastructure adapters using Effect services/layers.
+- Perform layer assembly in the composition root only (`main.ts` or equivalent), not in command modules.
+
+### Input and Validation
+
+- Parse and validate command options/arguments once at the edge.
+- Map validated CLI inputs into semantic command/query DTOs before invoking use cases.
+- Keep option names explicit and stable; treat them as a public contract.
+
+### Error Handling
+
+- Prefer domain-specific error types over generic `Error` values.
+- Translate typed domain/application errors into user-facing messages and exit codes in one error presenter.
+- Unexpected defects should be logged with context and surfaced as a generic failure message.
+
+### Testing
+
+- Test command modules by exercising parsing, validation, and output rendering with mocked ports.
+- Test application/domain logic independently from `@effect/cli` runtime concerns.
+- Include tests for typed error mapping to exit code and user-facing output.

--- a/agents/frameworks/hono.md
+++ b/agents/frameworks/hono.md
@@ -5,27 +5,33 @@
 - Define HTTP controllers as classes, not free-floating route functions.
 - One controller class per bounded context/resource (`UsersController`, `BillingController`).
 - Controller constructors receive application-layer ports/use cases only; no direct repository or SDK wiring.
-- Expose a semantic `build()` method that returns the configured route subtree and middleware stack.
+- Expose a semantic `register(app: Hono)` method that registers routes/middleware on a provided app instance.
 
 ```ts
 export class UsersController {
   constructor(private readonly getUser: GetUserUseCase) {}
 
-  build(): Hono {
-    const app = new Hono()
+  register(app: Hono): void {
     app.get("/:userId", this.getById)
-    return app
   }
 
   private getById = async (c: Context) => { ... }
 }
 ```
 
-### Semantic Builders
+### Semantic Registration
 
-- `build()` methods must be intent-revealing (`buildPublicRoutes()`, `buildAdminRoutes()`) when a controller exposes multiple route families.
-- Route registration order and middleware composition are owned by the controller builder, not scattered across bootstrap files.
-- Bootstrap/composition root mounts prebuilt controller route trees; it does not define business endpoints inline.
+- `register()` methods must be intent-revealing (`registerPublicRoutes(app)`, `registerAdminRoutes(app)`) when a controller exposes multiple route families.
+- Route registration order and middleware composition are owned by the composition root, not scattered across bootstrap files.
+- Bootstrap/composition root owns app instantiation and mounts controller registrations; it does not define business endpoints inline.
+
+### Middleware Dependency Injection
+
+- Middleware that depends on external resources (Redis, config, clients, feature flags) must be
+  created in the composition root and injected into controllers as ready handlers or factories.
+- Controllers may compose middleware, but must never initialize infrastructure clients directly.
+- Keep cross-cutting middleware order (auth, request ID, tracing, global rate-limit) in bootstrap;
+  keep resource-specific middleware registration inside the controller.
 
 ### Params and Input Contracts
 

--- a/agents/frameworks/hono.md
+++ b/agents/frameworks/hono.md
@@ -1,0 +1,47 @@
+## Hono API (TypeScript)
+
+### Controller Structure
+
+- Define HTTP controllers as classes, not free-floating route functions.
+- One controller class per bounded context/resource (`UsersController`, `BillingController`).
+- Controller constructors receive application-layer ports/use cases only; no direct repository or SDK wiring.
+- Expose a semantic `build()` method that returns the configured route subtree and middleware stack.
+
+```ts
+export class UsersController {
+  constructor(private readonly getUser: GetUserUseCase) {}
+
+  build(): Hono {
+    const app = new Hono()
+    app.get("/:userId", this.getById)
+    return app
+  }
+
+  private getById = async (c: Context) => { ... }
+}
+```
+
+### Semantic Builders
+
+- `build()` methods must be intent-revealing (`buildPublicRoutes()`, `buildAdminRoutes()`) when a controller exposes multiple route families.
+- Route registration order and middleware composition are owned by the controller builder, not scattered across bootstrap files.
+- Bootstrap/composition root mounts prebuilt controller route trees; it does not define business endpoints inline.
+
+### Params and Input Contracts
+
+- Parse and validate `param`, `query`, `header`, and `json` values at the controller boundary with explicit schemas.
+- Never pass raw `c.req.param()` or untyped payload objects into application/domain code.
+- Convert transport primitives into command/query objects before invoking use cases.
+- Keep parameter names semantic and domain-aligned (`orderId`, `tenantId`, `invoiceNumber`) over generic names (`id`, `value`).
+
+### Error Mapping
+
+- Controllers map domain/application errors to HTTP responses in one place (error mapper/presenter).
+- Use domain-specific error classes and type guards for branching; avoid string matching on message text.
+- Unknown/unexpected errors return a generic 500 payload while structured logs keep stack traces and context.
+
+### Testing
+
+- Unit-test controllers at the HTTP boundary with injected use-case doubles and real request/response assertions.
+- Verify: param parsing, schema validation failures, domain error to HTTP status mapping, and success serialization.
+- Keep domain tests framework-agnostic; Hono tests should not be required to validate domain invariants.

--- a/agents/languages/go.md
+++ b/agents/languages/go.md
@@ -18,6 +18,9 @@
 - Always wrap errors with context using `fmt.Errorf("context: %w", err)` so the call stack
   is reconstructable from the error message.
 - Define sentinel errors with `errors.New` for expected conditions that callers must handle.
+- Prefer custom domain error types over generic errors when modeling business failures.
+- Add explicit `IsXxxError(err error) bool` helper functions per domain error to centralize `errors.Is`
+  / `errors.As` checks and avoid duplicating matching logic at call sites.
 - Use custom error types (implementing `error`) when callers need to inspect error properties.
 - Never ignore errors. Use `_` only when the error is probably irrelevant (e.g., writing to
   an in-memory buffer that never fails).

--- a/agents/languages/typescript.md
+++ b/agents/languages/typescript.md
@@ -90,3 +90,6 @@ Always enable strict mode in `tsconfig.json`:
 - Prefer named exports over default exports for better refactoring support.
 - Keep functions small (fits on a screen). Extract when logic becomes layered.
 - Prefer dependency injection/composition in the app layer; avoid global singletons.
+- For HTTP adapters/middleware with infra dependencies (Redis, SDK clients, config), construct
+  those dependencies in the composition root and inject handlers/factories — never instantiate
+  infra clients inside controllers.

--- a/agents/languages/typescript.md
+++ b/agents/languages/typescript.md
@@ -68,7 +68,11 @@ Always enable strict mode in `tsconfig.json`:
   ```
 - Reserve `throw` for truly exceptional/unexpected conditions (programming errors, I/O failures).
 - Never `catch` an error and silently swallow it. At minimum, log it.
-- Use custom error classes with typed properties for domain errors.
+- Prefer custom domain/application error classes over generic `Error` for business failures.
+- Use explicit type guards for error branching (for example `isOrderAlreadyPaidError(err)`), never
+  `instanceof` chains spread across handlers.
+- Co-locate `isXxxError()` helpers with the corresponding error type and reuse them across controllers,
+  presenters, and tests.
 
 ### Boundary Validation and Webhooks
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -16,6 +16,7 @@ A profile is a named YAML preset that selects which fragments, tech stack detail
 | `typescript-hexagonal-react-vite-ui` | Hono backend + React SPA frontend (no SSR) | TypeScript |
 | `typescript-hexagonal-nuxt-vite-ui` | Hono backend + Nuxt 3 / Vue 3 frontend (SSR) | TypeScript |
 | `typescript-hexagonal-vue-vite-ui` | Hono backend + Vue 3 SPA frontend (no SSR) | TypeScript |
+| `typescript-hexagonal-effect-cli` | TypeScript CLI with @effect/cli + @effect/platform-node, hexagonal + DDD | TypeScript |
 | `go-hexagonal-microservice` | Go backend microservice, hexagonal + DDD | Go |
 | `golang-hexagonal-next-ui` | Go backend + Next.js frontend (SSR) | Go + TypeScript |
 | `golang-hexagonal-react-vite-ui` | Go backend + React SPA frontend (no SSR) | Go + TypeScript |

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-05T22:55:29Z",
+  "generated_at": "2026-05-11T20:26:49Z",
   "fragments": [
     {
       "name": "bff",
@@ -42,7 +42,7 @@
       "group": "architecture",
       "path": "agents/architecture/hexagonal.md",
       "heading": "Hexagonal Architecture",
-      "words": 568
+      "words": 598
     },
     {
       "name": "microservices",
@@ -92,6 +92,20 @@
       "path": "agents/frameworks/cobra.md",
       "heading": "Cobra CLI (Go)",
       "words": 363
+    },
+    {
+      "name": "effect-cli",
+      "group": "frameworks",
+      "path": "agents/frameworks/effect-cli.md",
+      "heading": "Effect CLI (TypeScript)",
+      "words": 220
+    },
+    {
+      "name": "hono",
+      "group": "frameworks",
+      "path": "agents/frameworks/hono.md",
+      "heading": "Hono API (TypeScript)",
+      "words": 297
     },
     {
       "name": "next-patterns",
@@ -189,7 +203,7 @@
       "group": "languages",
       "path": "agents/languages/go.md",
       "heading": "Go",
-      "words": 505
+      "words": 543
     },
     {
       "name": "php",
@@ -210,7 +224,7 @@
       "group": "languages",
       "path": "agents/languages/typescript.md",
       "heading": "TypeScript",
-      "words": 520
+      "words": 555
     },
     {
       "name": "api-design",

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-11T20:26:49Z",
+  "generated_at": "2026-05-11T20:59:19Z",
   "fragments": [
     {
       "name": "bff",
@@ -105,7 +105,7 @@
       "group": "frameworks",
       "path": "agents/frameworks/hono.md",
       "heading": "Hono API (TypeScript)",
-      "words": 297
+      "words": 357
     },
     {
       "name": "next-patterns",
@@ -224,7 +224,7 @@
       "group": "languages",
       "path": "agents/languages/typescript.md",
       "heading": "TypeScript",
-      "words": 555
+      "words": 583
     },
     {
       "name": "api-design",

--- a/profiles/typescript-hexagonal-effect-cli.yaml
+++ b/profiles/typescript-hexagonal-effect-cli.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
+meta:
+  name: "TypeScript Hexagonal Effect CLI"
+  description: >
+    TypeScript CLI application using @effect/cli and @effect/platform-node with
+    pnpm. Follows ports and adapters (hexagonal) so command handlers remain thin
+    adapters and domain/application logic stays framework-agnostic.
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+
+  languages:
+    - typescript
+
+  frameworks:
+    - effect-cli
+
+  architecture:
+    - hexagonal
+    - ddd
+
+  practices:
+    - tdd
+    - observability
+    - ci-cd
+
+  domains: []
+
+tech_stack:
+  language_runtime: "Node 24+"
+  package_manager: "pnpm"
+  cli_framework: "@effect/cli + @effect/platform-node"
+  test_framework: "Vitest"
+  additional:
+    - "Effect"
+
+skills:
+  - code-review
+  - add-tests
+  - ddd-aggregate-modeling
+  - write-adr
+  - write-changelog
+  - static-code-analysis
+  - github-actions-workflow
+
+output:
+  build_command: "pnpm build"
+  test_command: "pnpm test --run"
+  lint_command: "pnpm lint"
+  structure: flat
+  project_header: |
+    TypeScript CLI tool built with @effect/cli and @effect/platform-node.
+    Commands are adapters: parse input, call use cases, render output.
+    Keep domain/application logic framework-agnostic behind ports.
+    Use alias imports for cross-directory modules and ESM import/export syntax only.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/profiles/typescript-hexagonal-microservice.yaml
+++ b/profiles/typescript-hexagonal-microservice.yaml
@@ -17,7 +17,8 @@ fragments:
   languages:
     - typescript
 
-  frameworks: []
+  frameworks:
+    - hono
 
   architecture:
     - hexagonal

--- a/profiles/typescript-hexagonal-next-ui.yaml
+++ b/profiles/typescript-hexagonal-next-ui.yaml
@@ -34,7 +34,8 @@ tiers:
   backend:
     languages:
       - typescript
-    frameworks: []
+    frameworks:
+      - hono
     architecture:
       - hexagonal
       - ddd
@@ -67,7 +68,7 @@ tiers:
         description: "Design system tokens"
 
 tech_stack:
-  language_runtime: "Node 22+"
+  language_runtime: "Node 24+"
   package_manager: "pnpm"
   backend_framework: "Hono"
   frontend_framework: "Next.js"

--- a/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
@@ -34,7 +34,8 @@ tiers:
   backend:
     languages:
       - typescript
-    frameworks: []
+    frameworks:
+      - hono
     architecture:
       - hexagonal
       - ddd
@@ -67,7 +68,7 @@ tiers:
         description: "Design system tokens"
 
 tech_stack:
-  language_runtime: "Node 22+"
+  language_runtime: "Node 24+"
   package_manager: "pnpm"
   backend_framework: "Hono"
   frontend_framework: "Nuxt 3"

--- a/profiles/typescript-hexagonal-react-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-react-vite-ui.yaml
@@ -34,7 +34,8 @@ tiers:
   backend:
     languages:
       - typescript
-    frameworks: []
+    frameworks:
+      - hono
     architecture:
       - hexagonal
       - ddd
@@ -58,7 +59,7 @@ tiers:
       lint_command:  "pnpm --filter ui lint"
 
 tech_stack:
-  language_runtime: "Node 22+"
+  language_runtime: "Node 24+"
   package_manager: "pnpm"
   backend_framework: "Hono"
   frontend_framework: "React (SPA)"

--- a/profiles/typescript-hexagonal-vue-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-vue-vite-ui.yaml
@@ -34,7 +34,8 @@ tiers:
   backend:
     languages:
       - typescript
-    frameworks: []
+    frameworks:
+      - hono
     architecture:
       - hexagonal
       - ddd
@@ -58,7 +59,7 @@ tiers:
       lint_command:  "pnpm --filter ui lint"
 
 tech_stack:
-  language_runtime: "Node 22+"
+  language_runtime: "Node 24+"
   package_manager: "pnpm"
   backend_framework: "Hono"
   frontend_framework: "Vue 3 (SPA)"

--- a/profiles/typescript-library.yaml
+++ b/profiles/typescript-library.yaml
@@ -24,7 +24,7 @@ fragments:
   domains: []
 
 tech_stack:
-  language_runtime: "Node.js 20+ / browser-compatible"
+  language_runtime: "Node.js 24+ / browser-compatible"
   package_manager: "pnpm"
   test_framework: "Vitest"
   build_tool: "tsup / tsc"

--- a/profiles/typescript-next-app.yaml
+++ b/profiles/typescript-next-app.yaml
@@ -32,7 +32,7 @@ fragments:
   domains: []
 
 tech_stack:
-  language_runtime: "Node 22+"
+  language_runtime: "Node 24+"
   package_manager: "pnpm"
   frontend_framework: "Next.js"
   ui_component_library: "shadcn/ui"

--- a/profiles/typescript-nuxt-app.yaml
+++ b/profiles/typescript-nuxt-app.yaml
@@ -33,7 +33,7 @@ fragments:
   domains: []
 
 tech_stack:
-  language_runtime: "Node 22+"
+  language_runtime: "Node 24+"
   package_manager: "pnpm"
   frontend_framework: "Nuxt 3"
   ui_component_library: "shadcn/vue"

--- a/profiles/typescript-react-spa.yaml
+++ b/profiles/typescript-react-spa.yaml
@@ -30,7 +30,7 @@ fragments:
   domains: []
 
 tech_stack:
-  language_runtime: "Node 22+"
+  language_runtime: "Node 24+"
   package_manager: "pnpm"
   frontend_framework: "React (SPA)"
   ui_component_library: "shadcn/ui"

--- a/profiles/typescript-vue-spa.yaml
+++ b/profiles/typescript-vue-spa.yaml
@@ -30,7 +30,7 @@ fragments:
   domains: []
 
 tech_stack:
-  language_runtime: "Node 22+"
+  language_runtime: "Node 24+"
   package_manager: "pnpm"
   frontend_framework: "Vue 3 (SPA)"
   ui_component_library: "shadcn/vue"


### PR DESCRIPTION
## Why
This PR tightens our TypeScript-first guidance for API and CLI projects so generated AGENTS instructions are more consistent with hexagonal boundaries and domain-driven error handling.

The main gaps addressed were:
- Hono usage was implicit in profiles but not represented as an explicit framework fragment with concrete controller patterns.
- Domain logic placement rules were present but not strong enough to prevent business rules from drifting into helpers/adapters.
- TypeScript CLI guidance lacked an Effect-based profile aligned with ports-and-adapters.
- Error guidance did not consistently push typed, domain-specific errors and reusable IsXxxError / isXxxError helpers.
- TypeScript runtime targets were behind the current Node LTS line.

## What Changed
### 1) New framework fragments
- Added agents/frameworks/hono.md
  - Class-based controllers
  - `register(app: Hono)`-style semantic route registration
  - Typed/validated params at the boundary
  - Centralized domain-to-HTTP error mapping
  - Middleware DI guidance: external deps are created in composition root and injected as handlers/factories
- Added agents/frameworks/effect-cli.md
  - @effect/cli + @effect/platform-node command patterns
  - Thin command handlers as adapters
  - Composition-root layer wiring
  - Typed error-to-exit/output mapping

### 2) Stronger architecture and language rules
- Updated agents/architecture/hexagonal.md
  - Added explicit rule to keep business rules cohesive and out of scattered utility functions
- Updated agents/languages/typescript.md
  - Prefer domain/application custom errors over generic Error for business failures
  - Add/reuse isXxxError helpers for branching
  - Explicit DI rule for middleware with infra dependencies (Redis/SDK/config)
- Updated agents/languages/go.md
  - Prefer custom domain errors for business failures
  - Add/reuse IsXxxError(err) helpers to centralize errors.Is/errors.As logic

### 3) New TypeScript Effect CLI profile
- Added profiles/typescript-hexagonal-effect-cli.yaml
  - @effect/cli + @effect/platform-node
  - Hexagonal + DDD composition
  - pnpm + Node 24+

### 4) Hono explicitly declared in TS hexagonal backend profiles
- Updated TypeScript hexagonal backend/fullstack profiles to include framework: hono where backend fragments are declared.

### 5) Node runtime alignment (TypeScript profiles)
- Updated TypeScript profile runtime metadata from Node 22+ / Node.js 20+ to Node 24+ (current LTS line).

### 6) Essential docs/index updates
- Updated docs/profiles.md to include the new TypeScript Effect CLI profile
- Regenerated index/fragments.json

## Scope Notes
- No README.md changes (intentionally, per request).
- This PR updates configuration guidance and profile metadata only; no runtime application code is changed.

## Validation
- just lint
- just index

## Reviewer Checklist
- Confirm new fragments are self-contained and follow heading/size rules
- Confirm new profile validates against profile schema
- Confirm TS profile runtime updates are consistent across all TypeScript profiles
- Confirm docs/profiles.md and index/fragments.json reflect the new profile/fragments

## Follow-up (Optional)
- Align Node runtime strings in mixed Go + frontend profiles to Node 24+ for full cross-profile consistency.