### PR TITLE
docs: align project narrative with vendor-agnostic, production-minded positioning

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to agentic
 
-Thank you for your interest in contributing to agentic! This library serves as a vendor-agnostic foundation for AI agent configurations, and we welcome contributions that improve its quality, coverage, and usability.
+Thank you for your interest in contributing to agentic. We build vendor-agnostic configs with production-minded architecture, and we welcome contributions that improve clarity, quality, and usability.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # 🧩 agentic
 
-A centralized, vendor-agnostic library for composing AI agent instructions — pick a profile, run one command, and every AI tool in your project reads the same source of truth.
+**Vendor-agnostic configs. Production-minded architecture.**
+
+An opinionated library of composable AGENTS, profiles, skills, and vendor adapters.
+Pick a profile, run one command, and every AI tool in your project reads the same
+clear, maintainable source of truth.
 
 ![CI](https://github.com/soulcodex/agentic/actions/workflows/validate.yml/badge.svg)
 ![Coverage](https://codecov.io/gh/soulcodex/agentic/graph/badge.svg?branch=main)

--- a/docs/.mkdocs/mkdocs.yml
+++ b/docs/.mkdocs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Agentic
-site_description: One library. All your AI tools stay in sync.
+site_description: Vendor-agnostic configs. Production-minded architecture.
 site_url: https://agentic.soulcodex.link/
 repo_url: https://github.com/soulcodex/agentic
 repo_name: soulcodex/agentic

--- a/docs/.mkdocs/overrides/main.html
+++ b/docs/.mkdocs/overrides/main.html
@@ -3,8 +3,8 @@
 <link rel="icon" type="image/png" sizes="32x32" href="{{ config.site_url }}assets/favicons/favicon-32x32.png" />
 <link rel="icon" type="image/png" sizes="16x16" href="{{ config.site_url }}assets/favicons/favicon-16x16.png" />
 <link rel="manifest" href="{{ config.site_url }}assets/favicons/site.webmanifest" />
-{% set title = config.site_name ~ " - One command, all your AI tools in sync." %} {% if page and page.title and not
-page.is_homepage %} {% set title = page.title ~ " - One command, all your AI tools in sync. - " ~ config.site_name %} {%
+{% set title = config.site_name ~ " - Vendor-agnostic configs, production-minded architecture." %} {% if page and page.title and not
+page.is_homepage %} {% set title = page.title ~ " - Vendor-agnostic configs, production-minded architecture. - " ~ config.site_name %} {%
 endif %} {% set description = config.site_description %} {% if page and page.meta and page.meta.description %} {% set
 description = page.meta.description %} {% endif %}
 <meta property="og:type" content="website" />

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 # Agentic
 
-**One library. One deploy. All your AI tools stay in sync.**
+**Vendor-agnostic configs. Production-minded architecture.**
 
-A centralized, vendor-agnostic library for composing AI agent instructions.
-Pick a profile, run one command, and every AI tool in your project reads the
-same `AGENTS.md` source of truth — automatically.
+An opinionated library of composable AGENTS, profiles, skills, and vendor adapters.
+Pick a profile, run one command, and every AI tool in your project reads the same
+`AGENTS.md` source of truth — with a clear baseline you can evolve.
 
 ---
 


### PR DESCRIPTION
## Summary
- align top-level messaging across README, docs home, and docs metadata with the new punch-line:
  - "Vendor-agnostic configs. Production-minded architecture."
- tighten supporting copy to emphasize: opinionated baseline, composability, clarity, and maintainability
- update contributor intro language to match the same positioning

## Repo Description Analysis
Current messaging is clear but split between multiple slogans ("One library...", "One command...").
This PR consolidates the narrative around a single positioning line and keeps the supporting sentence focused on practical value (composable, maintainable source of truth).

### Proposed GitHub repo description (About field)
Vendor-agnostic configs. Production-minded architecture for AI agent workflows.

## Files Updated
- README.md
- docs/index.md
- docs/.mkdocs/mkdocs.yml
- docs/.mkdocs/overrides/main.html
- .github/CONTRIBUTING.md

## Validation
- just lint