### PR TITLE
feat(skills): add AWS Terraform IaC skill suite and profile (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ agentic list profiles|skills|vendors          # list available resources
 
 ## Profiles
 
-21 ready-made profiles covering TypeScript, Go, Python, PHP — frontend SPAs, microservices, CLIs, full-stack.
+23 ready-made profiles covering TypeScript, Go, Python, PHP, HCL — frontend SPAs, microservices, CLIs, full-stack, and AWS Terraform modules.
 
 → [Browse all profiles](https://agentic.soulcodex.link/profiles)
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -28,6 +28,7 @@ A profile is a named YAML preset that selects which fragments, tech stack detail
 | `php-hexagonal-ddd` | PHP 8.3+ Symfony application, hexagonal + DDD + CQRS | PHP |
 | `go-library` | Go reusable library/package with stable public API and minimal transitive dependencies | Go |
 | `typescript-library` | TypeScript reusable library for npm/private registry, ESM-first, zero framework dependencies | TypeScript |
+| `hcl-aws-terraform-module` | AWS-focused Terraform module development with design, module scaffolding, and test guardrails | HCL |
 
 ## Nested Output Mode
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -47,7 +47,11 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 
 ### Devops
 
+- `create-terraform-module` — Create AWS-oriented Terraform module scaffolding with explicit interfaces, provider constraints, and reusable layout guardrails.
+- `create-terraform-tests` — Design and implement risk-focused Terraform module tests (`terraform test`) with CI-friendly validation flow.
+- `design-aws-terraform-iac` — Plan AWS Terraform architecture, service/module boundaries, state strategy, and acceptance criteria before implementation.
 - `docker-compose-local-setup` — Configure local multi-service `docker compose` stacks with readiness, envs, volumes, migrations, and verification.
+- `use-aws-mini-stack-emulator` — Use lightweight AWS emulation safely for local Terraform feedback loops, with explicit handoff to real AWS checks.
 - `write-dockerfile` — Generate production-ready Dockerfiles with secure, efficient build patterns.
 
 ### Documentation

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-10T19:45:09Z",
+  "generated_at": "2026-05-15T22:59:45Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -376,6 +376,46 @@
       ]
     },
     {
+      "name": "create-terraform-module",
+      "group": "devops",
+      "path": "skills/devops/create-terraform-module/SKILL.md",
+      "description": "Creates or updates AWS-oriented Terraform module structure and implementation scaffolding. Focuses on file layout, varia",
+      "version": "1.0.0",
+      "tags": [
+        "devops",
+        "terraform",
+        "aws",
+        "modules"
+      ]
+    },
+    {
+      "name": "create-terraform-tests",
+      "group": "devops",
+      "path": "skills/devops/create-terraform-tests/SKILL.md",
+      "description": "Designs and implements Terraform module tests for AWS-targeted modules. Covers terraform-native tests, validation gates,",
+      "version": "1.0.0",
+      "tags": [
+        "devops",
+        "terraform",
+        "testing",
+        "aws"
+      ]
+    },
+    {
+      "name": "design-aws-terraform-iac",
+      "group": "devops",
+      "path": "skills/devops/design-aws-terraform-iac/SKILL.md",
+      "description": "Designs AWS-targeted Terraform infrastructure plans before implementation. Focuses on service selection, module boundari",
+      "version": "1.0.0",
+      "tags": [
+        "devops",
+        "terraform",
+        "aws",
+        "iac",
+        "architecture"
+      ]
+    },
+    {
       "name": "docker-compose-local-setup",
       "group": "devops",
       "path": "skills/devops/docker-compose-local-setup/SKILL.md",
@@ -386,6 +426,19 @@
         "docker",
         "compose",
         "local-development"
+      ]
+    },
+    {
+      "name": "use-aws-mini-stack-emulator",
+      "group": "devops",
+      "path": "skills/devops/use-aws-mini-stack-emulator/SKILL.md",
+      "description": "Uses lightweight AWS stack emulation for faster local Terraform iteration. Defines what can be safely validated locally,",
+      "version": "1.0.0",
+      "tags": [
+        "devops",
+        "terraform",
+        "aws",
+        "local-testing"
       ]
     },
     {

--- a/profiles/hcl-aws-terraform-module.yaml
+++ b/profiles/hcl-aws-terraform-module.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
+meta:
+  name: "HCL AWS Terraform Module"
+  description: >
+    AWS-focused Terraform module profile for designing, implementing, and testing
+    reusable infrastructure modules with explicit state, security, and validation
+    guardrails.
+  version: "1.0.0"
+
+fragments:
+  base:
+    - git-conventions
+    - security
+    - code-review
+    - testing-philosophy
+    - documentation
+  languages: []
+  frameworks: []
+  architecture: []
+  practices:
+    - ci-cd
+  domains: []
+
+tech_stack:
+  language_runtime: "Terraform CLI 1.7+"
+  backend_framework: "AWS Provider (hashicorp/aws)"
+  test_framework: "terraform test"
+  build_tool: "terraform fmt/validate/plan"
+
+skills:
+  - design-aws-terraform-iac
+  - create-terraform-module
+  - create-terraform-tests
+  - use-aws-mini-stack-emulator
+  - code-review
+
+output:
+  build_command: "terraform fmt -check -recursive"
+  test_command: "terraform test"
+  lint_command: "terraform validate"
+  project_header: |
+    This project manages AWS infrastructure modules in Terraform (HCL).
+    Keep modules reusable, keep environment values outside modules, and enforce
+    security and state-management guardrails.
+
+vendors:
+  enabled:
+    - claude
+    - copilot
+    - codex
+    - gemini
+    - opencode

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -4,12 +4,21 @@
   "title": "Composition Profile",
   "description": "Declares which agent fragments to combine into a single AGENTS.md",
   "type": "object",
-  "required": ["meta", "fragments", "output", "vendors"],
+  "required": [
+    "meta",
+    "fragments",
+    "output",
+    "vendors"
+  ],
   "additionalProperties": false,
   "properties": {
     "meta": {
       "type": "object",
-      "required": ["name", "description", "version"],
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
       "additionalProperties": false,
       "properties": {
         "name": {
@@ -33,37 +42,49 @@
       "properties": {
         "base": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Fragment names from agents/base/ (without .md extension)",
           "default": []
         },
         "languages": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Fragment names from agents/languages/ (without .md extension)",
           "default": []
         },
         "frameworks": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Fragment names from agents/frameworks/ (without .md, with subdir: frontend/react)",
           "default": []
         },
         "architecture": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Fragment names from agents/architecture/ (without .md extension)",
           "default": []
         },
         "practices": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Fragment names from agents/practices/ (without .md extension)",
           "default": []
         },
         "domains": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Fragment names from agents/domains/ (without .md extension)",
           "default": []
         }
@@ -74,20 +95,44 @@
       "description": "Optional tech stack metadata used to generate a Technical Stack section in AGENTS.md",
       "additionalProperties": false,
       "properties": {
-        "language_runtime": { "type": "string" },
-        "package_manager": { "type": "string" },
-        "backend_framework": { "type": "string" },
-        "frontend_framework": { "type": "string" },
-        "ui_component_library": { "type": "string" },
-        "css_framework": { "type": "string" },
-        "build_tool": { "type": "string" },
-        "test_framework": { "type": "string" },
-        "cli_framework": { "type": "string" },
-        "database": { "type": "string" },
-        "messaging": { "type": "string" },
+        "language_runtime": {
+          "type": "string"
+        },
+        "package_manager": {
+          "type": "string"
+        },
+        "backend_framework": {
+          "type": "string"
+        },
+        "frontend_framework": {
+          "type": "string"
+        },
+        "ui_component_library": {
+          "type": "string"
+        },
+        "css_framework": {
+          "type": "string"
+        },
+        "build_tool": {
+          "type": "string"
+        },
+        "test_framework": {
+          "type": "string"
+        },
+        "cli_framework": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "messaging": {
+          "type": "string"
+        },
         "additional": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Extra libraries or tools not covered by the named fields"
         },
         "proprietary_libraries": {
@@ -95,12 +140,24 @@
           "description": "Internal/private packages — listed with context in the Proprietary Libraries section",
           "items": {
             "type": "object",
-            "required": ["name", "description"],
+            "required": [
+              "name",
+              "description"
+            ],
             "additionalProperties": false,
             "properties": {
-              "name":        { "type": "string", "description": "Package identifier (e.g. @acme/core)" },
-              "description": { "type": "string", "description": "What this package provides" },
-              "url_doc":     { "type": "string", "description": "URL to the package documentation (optional)" }
+              "name": {
+                "type": "string",
+                "description": "Package identifier (e.g. @acme/core)"
+              },
+              "description": {
+                "type": "string",
+                "description": "What this package provides"
+              },
+              "url_doc": {
+                "type": "string",
+                "description": "URL to the package documentation (optional)"
+              }
             }
           }
         }
@@ -116,8 +173,11 @@
           "code-review",
           "compose-agents-md",
           "configure-mcp",
+          "create-terraform-module",
+          "create-terraform-tests",
           "ddd-aggregate-modeling",
           "deploy-config",
+          "design-aws-terraform-iac",
           "diagram-design",
           "docker-compose-local-setup",
           "fix-bug",
@@ -147,6 +207,7 @@
           "sync-confluence",
           "technical-roadmap-planning",
           "terraform-infrastructure",
+          "use-aws-mini-stack-emulator",
           "vue-application-structure",
           "vue-component-design",
           "vue-component-testing",
@@ -169,17 +230,41 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "languages":    { "type": "array", "items": { "type": "string" }, "default": [] },
-          "frameworks":   { "type": "array", "items": { "type": "string" }, "default": [] },
-          "architecture": { "type": "array", "items": { "type": "string" }, "default": [] },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "frameworks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "architecture": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
           "commands": {
             "type": "object",
             "additionalProperties": false,
             "description": "Per-tier build/test/lint commands emitted into this tier's AGENTS.md",
             "properties": {
-              "build_command": { "type": "string" },
-              "test_command":  { "type": "string" },
-              "lint_command":  { "type": "string" }
+              "build_command": {
+                "type": "string"
+              },
+              "test_command": {
+                "type": "string"
+              },
+              "lint_command": {
+                "type": "string"
+              }
             }
           },
           "proprietary_libraries": {
@@ -187,12 +272,21 @@
             "description": "Tier-specific private packages",
             "items": {
               "type": "object",
-              "required": ["name", "description"],
+              "required": [
+                "name",
+                "description"
+              ],
               "additionalProperties": false,
               "properties": {
-                "name":        { "type": "string" },
-                "description": { "type": "string" },
-                "url_doc":     { "type": "string" }
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "url_doc": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -221,13 +315,19 @@
         },
         "structure": {
           "type": "string",
-          "enum": ["flat", "nested"],
+          "enum": [
+            "flat",
+            "nested"
+          ],
           "default": "flat",
           "description": "Output structure: flat (single AGENTS.md) or nested (reserved for future use)"
         },
         "mode": {
           "type": "string",
-          "enum": ["lean", "full"],
+          "enum": [
+            "lean",
+            "full"
+          ],
           "description": "lean (default): slim AGENTS.md with fragment refs copied to .agentic/fragments/; full: all content inlined"
         },
         "custom_rules": {
@@ -237,7 +337,11 @@
           "properties": {
             "placement": {
               "type": "string",
-              "enum": ["append", "prepend", "after_section"],
+              "enum": [
+                "append",
+                "prepend",
+                "after_section"
+              ],
               "default": "append",
               "description": "Where to inject AGENTS.local.md content: append (default), prepend (after header), or after_section"
             },
@@ -251,7 +355,11 @@
             },
             "import_strategy": {
               "type": "string",
-              "enum": ["adopt", "skip", "overwrite"],
+              "enum": [
+                "adopt",
+                "skip",
+                "overwrite"
+              ],
               "default": "adopt",
               "description": "How to handle existing user-authored AGENTS.md on first compose"
             }
@@ -261,14 +369,22 @@
     },
     "vendors": {
       "type": "object",
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["claude", "copilot", "codex", "gemini", "opencode"]
+            "enum": [
+              "claude",
+              "copilot",
+              "codex",
+              "gemini",
+              "opencode"
+            ]
           },
           "description": "Which vendor adapter files to generate"
         }
@@ -281,7 +397,10 @@
       "properties": {
         "strategy": {
           "type": "string",
-          "enum": ["merge", "replace"],
+          "enum": [
+            "merge",
+            "replace"
+          ],
           "default": "merge",
           "description": "merge: profile servers are added without removing existing ones. replace: all vendor MCP files are fully replaced by the profile declaration."
         },
@@ -290,13 +409,35 @@
           "description": "MCP server entries. Keys are server names; values follow the .mcp.json entry shape.",
           "additionalProperties": {
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
-              "type":    { "type": "string", "enum": ["stdio", "http"] },
-              "command": { "type": "string" },
-              "args":    { "type": "array", "items": { "type": "string" } },
-              "url":     { "type": "string" },
-              "env":     { "type": "object", "additionalProperties": { "type": "string" } }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "stdio",
+                  "http"
+                ]
+              },
+              "command": {
+                "type": "string"
+              },
+              "args": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "url": {
+                "type": "string"
+              },
+              "env": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/skills/devops/create-terraform-module/SKILL.md
+++ b/skills/devops/create-terraform-module/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: create-terraform-module
+description: >
+  Creates or updates AWS-oriented Terraform module structure and implementation
+  scaffolding. Focuses on file layout, variable/output contracts, provider and
+  version constraints, tagging standards, and safe composition patterns.
+version: 1.0.0
+tags:
+  - devops
+  - terraform
+  - aws
+  - modules
+resources:
+  - module-skeleton.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Create Terraform Module Skill
+
+Create or revise Terraform module implementation details for AWS workloads.
+
+Authoritative precedence: when this skill and `terraform-infrastructure` are both
+active, this skill is authoritative for module layout, file set, and module
+interface details.
+
+### Step 1 - Define Module Contract
+
+Define module inputs/outputs first:
+- required vs optional variables
+- typed structures (`object`, `list(object)`) where appropriate
+- sensitive inputs marked with `sensitive = true`
+- outputs scoped to consumer needs only
+
+### Step 2 - Create Module Structure
+
+Use `module-skeleton.md` as the required baseline layout.
+
+Rules:
+- include `README.md`, `versions.tf`, `providers.tf`, `main.tf`, `variables.tf`, `outputs.tf`
+- keep environment-specific values outside reusable modules
+- avoid hidden dependencies on caller-side locals/naming
+
+### Step 3 - Implement AWS Resources Safely
+
+Apply consistent tagging and naming conventions.
+
+Implementation guardrails:
+- explicit `required_providers` and Terraform version constraints
+- `lifecycle` usage only when justified and documented
+- stable resource addressing to reduce churn in plans
+- no plaintext secrets in code or defaults
+
+### Step 4 - Add Example Consumer and Validation Steps
+
+Include a minimal example usage block and required validate/fmt checks.
+
+### Step 5 - Handoff
+
+Provide:
+- module purpose and public interface summary
+- migration notes if refactoring existing resources
+- known limits and follow-up test requirements
+
+For test-case authoring and `terraform test` implementation, hand off to
+`create-terraform-tests`.

--- a/skills/devops/create-terraform-module/module-skeleton.md
+++ b/skills/devops/create-terraform-module/module-skeleton.md
@@ -1,0 +1,41 @@
+## Terraform Module Skeleton
+
+```text
+modules/
+  {module_name}/
+    README.md
+    versions.tf
+    providers.tf
+    main.tf
+    variables.tf
+    outputs.tf
+    examples/
+      basic/
+        main.tf
+        terraform.tfvars.example
+```
+
+### Required File Intent
+
+- `README.md`: module purpose, input/output tables, usage example.
+- `versions.tf`: `terraform` and provider version constraints.
+- `providers.tf`: provider configuration requirements and aliases contract.
+- `main.tf`: resource definitions and local composition only.
+- `variables.tf`: typed inputs with descriptions and sensible defaults.
+- `outputs.tf`: intentional public outputs, no secret leakage.
+- `examples/basic/main.tf`: runnable consumer example for validation.
+
+### Recommended `versions.tf` baseline
+
+```hcl
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+```

--- a/skills/devops/create-terraform-tests/SKILL.md
+++ b/skills/devops/create-terraform-tests/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: create-terraform-tests
+description: >
+  Designs and implements Terraform module tests for AWS-targeted modules.
+  Covers terraform-native tests, validation gates, fixture composition, and
+  risk-focused assertions for regressions and unsafe changes.
+version: 1.0.0
+tags:
+  - devops
+  - terraform
+  - testing
+  - aws
+resources:
+  - tftest-patterns.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Create Terraform Tests Skill
+
+Author Terraform test coverage for AWS modules.
+
+Authoritative precedence: when this skill and `terraform-infrastructure` are both
+active, this skill is authoritative for module testing strategy, test layout,
+and assertion patterns.
+
+### Step 1 - Identify Risk-Critical Behaviors
+
+Prioritize tests for:
+- security controls (encryption, public exposure prevention)
+- destructive change prevention for stateful resources
+- required inputs and invalid configuration rejection
+- output contract stability
+
+### Step 2 - Implement Terraform-Native Test Layout
+
+Use `tftest-patterns.md` for baseline structure and pattern selection.
+
+Minimum coverage:
+- happy path apply/plan expectations
+- invalid input validation checks
+- policy/security checks for sensitive resources
+
+### Step 3 - Add CI-Friendly Validation Chain
+
+Ensure deterministic checks in CI:
+1. `terraform fmt -check -recursive`
+2. `terraform init -backend=false`
+3. `terraform validate`
+4. `terraform test`
+
+### Step 4 - Keep Tests Bounded
+
+Use minimal fixtures and avoid long-running integration behavior unless explicitly
+requested. Document emulator vs real-AWS assumptions clearly.
+
+### Step 5 - Report Coverage Gaps
+
+Summarize what is covered, known blind spots, and next highest-value tests.

--- a/skills/devops/create-terraform-tests/tftest-patterns.md
+++ b/skills/devops/create-terraform-tests/tftest-patterns.md
@@ -1,0 +1,35 @@
+## Terraform Test Patterns
+
+Suggested module test layout:
+
+```text
+modules/
+  {module_name}/
+    tests/
+      basic.tftest.hcl
+      validation.tftest.hcl
+      security.tftest.hcl
+```
+
+### `basic.tftest.hcl`
+
+Use for baseline resource creation and output checks.
+
+### `validation.tftest.hcl`
+
+Use for negative-path assertions (invalid CIDR, missing required input,
+unsupported enum value).
+
+### `security.tftest.hcl`
+
+Use for controls such as:
+- encryption enabled
+- public access blocked
+- retention/lifecycle policy defaults
+
+### Pattern Guidance
+
+- Prefer focused assertions over snapshot-style bulk checks.
+- Keep fixtures minimal and deterministic.
+- Make test names reflect intended risk (`s3_blocks_public_access`).
+- Separate test data from secrets; never hardcode credentials.

--- a/skills/devops/design-aws-terraform-iac/SKILL.md
+++ b/skills/devops/design-aws-terraform-iac/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: design-aws-terraform-iac
+description: >
+  Designs AWS-targeted Terraform infrastructure plans before implementation.
+  Focuses on service selection, module boundaries, state/backends, environment
+  separation, security/compliance guardrails, and acceptance criteria.
+version: 1.0.0
+tags:
+  - devops
+  - terraform
+  - aws
+  - iac
+  - architecture
+resources:
+  - aws-service-matrix.md
+  - acceptance-checklist.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Design AWS Terraform IaC Skill
+
+Design AWS Terraform infrastructure before writing module code.
+
+### Step 1 - Confirm Scope and Constraints
+
+Capture required outcomes:
+- workloads and critical paths
+- regions, environments, and compliance constraints
+- cost boundaries and availability targets
+
+Capture non-goals to prevent accidental over-design.
+
+### Step 2 - Map Services and Responsibility Boundaries
+
+Use `aws-service-matrix.md` to map each capability to:
+- primary AWS service(s)
+- related Terraform module boundary
+- key operational risks and ownership notes
+
+Design composable modules with explicit interfaces between network, security,
+platform, and workload layers.
+
+### Step 3 - Define State and Environment Strategy
+
+Decide and document:
+- remote backend (`s3` + `dynamodb` locking)
+- state key strategy per environment and region
+- promotion model (`dev` -> `staging` -> `prod`)
+- drift and rollback expectations
+
+### Step 4 - Define Security and Policy Baselines
+
+Specify minimum required controls:
+- IAM least privilege for CI and runtime roles
+- encryption at rest and in transit
+- tag standards for ownership, cost, and data classification
+- log/audit coverage and retention
+
+### Step 5 - Produce a Design Brief and Acceptance Criteria
+
+Output a compact design brief with:
+- service choices and tradeoffs
+- module map and dependency order
+- state strategy and CI plan/apply gate strategy
+- measurable acceptance checks from `acceptance-checklist.md`
+
+This skill is planning-first. For module file layout and implementation details,
+use `create-terraform-module`. For test strategy and `terraform test` patterns,
+use `create-terraform-tests`.

--- a/skills/devops/design-aws-terraform-iac/acceptance-checklist.md
+++ b/skills/devops/design-aws-terraform-iac/acceptance-checklist.md
@@ -1,0 +1,14 @@
+## Acceptance Checklist
+
+Use these checks before module implementation begins.
+
+- [ ] Architecture scope, non-goals, and assumptions are documented.
+- [ ] AWS service selection includes rationale and known alternatives.
+- [ ] Module boundaries and ownership are explicit.
+- [ ] Remote state backend and locking strategy are documented.
+- [ ] Environment/region strategy is documented with naming convention.
+- [ ] CI plan/apply gate strategy includes manual approval for production.
+- [ ] IAM baseline and encryption requirements are documented.
+- [ ] Logging, metrics, and alerting ownership are documented.
+- [ ] Rollback path and operational runbook entry points are identified.
+- [ ] Cost visibility tags and budget guardrails are defined.

--- a/skills/devops/design-aws-terraform-iac/aws-service-matrix.md
+++ b/skills/devops/design-aws-terraform-iac/aws-service-matrix.md
@@ -1,0 +1,18 @@
+## AWS Service Matrix
+
+Use this matrix to keep service choice and Terraform ownership explicit.
+
+| Capability | Preferred AWS Service(s) | Typical Module Boundary | Notes |
+|---|---|---|---|
+| Network foundation | VPC, Subnets, NAT Gateway, Route Tables | `network` | Keep CIDR and AZ strategy centrally managed. |
+| Identity and authz | IAM, IAM Identity Center, KMS | `security-identity` | Separate human/admin and workload role policies. |
+| Edge and DNS | Route 53, CloudFront, ACM, WAF | `edge-dns` | ACM for CloudFront must be in `us-east-1`. |
+| Compute (container) | ECS Fargate, ECR, ALB | `compute-ecs` | Isolate service/task from shared cluster/network resources. |
+| Compute (serverless) | Lambda, API Gateway, EventBridge | `compute-serverless` | Keep event contracts and IAM perms explicit per function. |
+| Data (relational) | RDS / Aurora, RDS Proxy | `data-rds` | Encrypt, back up, and parameterize maintenance windows. |
+| Data (NoSQL) | DynamoDB, DAX (optional) | `data-dynamodb` | Model capacity/autoscaling per access pattern. |
+| Object storage | S3, S3 Lifecycle, S3 Replication | `storage-s3` | Block public access by default and enforce encryption. |
+| Secrets/config | Secrets Manager, SSM Parameter Store | `secrets-config` | Do not put secrets in tfvars/state outputs. |
+| Observability | CloudWatch Logs/Metrics/Alarms, X-Ray | `observability` | Define alarm routing and actionable thresholds. |
+| Eventing/queues | SQS, SNS, EventBridge | `messaging` | Preserve DLQ and retry semantics by design. |
+| Access controls at perimeter | WAF, Shield | `security-edge` | Tie rules to app risk model and rollout safely. |

--- a/skills/devops/use-aws-mini-stack-emulator/SKILL.md
+++ b/skills/devops/use-aws-mini-stack-emulator/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: use-aws-mini-stack-emulator
+description: >
+  Uses lightweight AWS stack emulation for faster local Terraform iteration.
+  Defines what can be safely validated locally, compatibility caveats, and the
+  handoff boundary to real-AWS verification.
+version: 1.0.0
+tags:
+  - devops
+  - terraform
+  - aws
+  - local-testing
+resources:
+  - emulator-compatibility-matrix.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Use AWS Mini Stack Emulator Skill
+
+Use local AWS emulation to accelerate Terraform feedback loops where appropriate.
+
+### Step 1 - Select Emulator Scope
+
+Use `emulator-compatibility-matrix.md` to decide what is safe to validate locally.
+
+Classify each planned check as:
+- emulator-suitable
+- partial confidence only
+- requires real AWS
+
+### Step 2 - Configure Provider and Endpoints for Local Runs
+
+Keep local endpoint wiring isolated from production configuration. Use explicit
+variables or per-environment override files for emulator endpoint settings.
+
+### Step 3 - Validate Fast Feedback Cases
+
+Good emulator targets:
+- syntax and interpolation mistakes
+- module wiring and basic dependencies
+- selected resource contract checks where behavior is reliably emulated
+
+### Step 4 - Document Gaps and Escalate
+
+Always document unsupported services/behaviors and escalate those tests to real
+AWS validation before merge.
+
+### Step 5 - Keep Scope Boundary Explicit
+
+This skill is for local acceleration only. It does not replace real AWS plan/apply
+verification for production-impacting infrastructure.
+
+Avoid overlap with `docker-compose-local-setup`: this skill covers Terraform + AWS
+emulation behavior, not generic multi-service compose orchestration design.

--- a/skills/devops/use-aws-mini-stack-emulator/emulator-compatibility-matrix.md
+++ b/skills/devops/use-aws-mini-stack-emulator/emulator-compatibility-matrix.md
@@ -1,0 +1,20 @@
+## Emulator Compatibility Matrix
+
+Use this matrix as planning guidance for local Terraform validation confidence.
+
+| Service/Capability | Local Confidence | Notes |
+|---|---|---|
+| S3 basic buckets/policies | Medium | Good for structure checks; policy nuance may differ. |
+| DynamoDB table basics | Medium | Validate schema and throughput config intent only. |
+| SQS/SNS/EventBridge basics | Low-Medium | API surface may be partial depending on emulator. |
+| IAM policies/assume-role behavior | Low | Validate syntax locally, semantics in real AWS. |
+| Lambda packaging + wiring | Low-Medium | Basic resource graph checks only. |
+| API Gateway integration | Low | Route behavior and auth should be verified in AWS. |
+| CloudFront/ACM/WAF | Low | Treat as real-AWS-only for release confidence. |
+| RDS/Aurora lifecycle | Low | Use real AWS for stateful and engine-specific behavior. |
+| CloudWatch alarms and metrics | Low | Local behavior is not representative for alerting correctness. |
+
+Confidence legend:
+- High: trustworthy for merge-blocking checks
+- Medium: useful guardrail but still requires targeted AWS confirmation
+- Low: local-only smoke signal; always verify in AWS


### PR DESCRIPTION
## Summary
- add four new AWS/Terraform devops skills:
  - `design-aws-terraform-iac`
  - `create-terraform-module`
  - `create-terraform-tests`
  - `use-aws-mini-stack-emulator`
- add new profile `hcl-aws-terraform-module`
- update docs for new profile/skills and refresh index/schema artifacts

## Changed files
- `skills/devops/design-aws-terraform-iac/*`
- `skills/devops/create-terraform-module/*`
- `skills/devops/create-terraform-tests/*`
- `skills/devops/use-aws-mini-stack-emulator/*`
- `profiles/hcl-aws-terraform-module.yaml`
- `docs/skills.md`
- `docs/profiles.md`
- `README.md`
- `index/skills.json`
- `schemas/profile.schema.json`

## Validation
- `just lint` ✅
- `just index` ✅
- `just dry-run hcl-aws-terraform-module` ✅

## Notes
- profile intentionally excludes `terraform-infrastructure` to avoid conflicting module-layout guidance with the new module/test-focused skills.

Closes #88
