### PR TITLE
feat(skills): add memory continuity hand-off skill

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -10,6 +10,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 - `configure-mcp` — Set up and configure MCP servers for agent tool access.
 - `deploy-config` — Deploy composed config, vendor files, and skills to a target project.
 - `github-issue-planning` — Issue-backed plan persistence on GitHub (prefer MCP, fallback to `gh` CLI).
+- `memory-continuity` — Maintain concise cross-session handoff memory with deterministic artifacts and pruning rules.
 - `persist-plan` — Save the current plan as a structured file under `.agentic/plans/`.
 - `write-plan` — Auto-persist generated plans and keep a local plans index updated.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -10,7 +10,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 - `configure-mcp` — Set up and configure MCP servers for agent tool access.
 - `deploy-config` — Deploy composed config, vendor files, and skills to a target project.
 - `github-issue-planning` — Issue-backed plan persistence on GitHub (prefer MCP, fallback to `gh` CLI).
-- `memory-continuity` — Maintain concise cross-session handoff memory with deterministic artifacts and pruning rules.
+- `memory-continuity` — Maintain concise cross-session handoff memory with explicit MEMORY/index templates, snapshot indexing, and multi-agent worktree coordination.
 - `persist-plan` — Save the current plan as a structured file under `.agentic/plans/`.
 - `write-plan` — Auto-persist generated plans and keep a local plans index updated.
 

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-16T17:15:20Z",
+  "generated_at": "2026-05-19T23:45:28Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -55,7 +55,7 @@
       "name": "memory-continuity",
       "group": "agentic",
       "path": "skills/agentic/memory-continuity/SKILL.md",
-      "description": "Maintains concise cross-session continuity by writing structured memory handoff artifacts under .agentic/memories/ and l",
+      "description": "Preserves cross-session continuity with deterministic MEMORY.md, index.md, and snapshot handoffs under .agentic/memories",
       "version": "1.0.0",
       "tags": [
         "agentic",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-15T22:59:45Z",
+  "generated_at": "2026-05-16T17:15:20Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -49,6 +49,19 @@
         "planning",
         "github",
         "issues"
+      ]
+    },
+    {
+      "name": "memory-continuity",
+      "group": "agentic",
+      "path": "skills/agentic/memory-continuity/SKILL.md",
+      "description": "Maintains concise cross-session continuity by writing structured memory handoff artifacts under .agentic/memories/ and l",
+      "version": "1.0.0",
+      "tags": [
+        "agentic",
+        "memory",
+        "continuity",
+        "workflow"
       ]
     },
     {

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -189,6 +189,7 @@
           "health-check-endpoints",
           "internationalization-i18n",
           "json-to-toon",
+          "memory-continuity",
           "microservices-architecture",
           "monorepo-management",
           "new-gh-issue-orchestration",

--- a/skills/agentic/memory-continuity/SKILL.md
+++ b/skills/agentic/memory-continuity/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: memory-continuity
 description: >
-  Maintains concise cross-session continuity by writing structured memory
-  handoff artifacts under .agentic/memories/ and loading only high-signal
-  entries at session start. Invoked when continuity is needed across fresh
-  context windows without replaying full chat history.
+  Preserves cross-session continuity with deterministic MEMORY.md, index.md,
+  and snapshot handoffs under .agentic/memories/.
 version: 1.0.0
 tags:
   - agentic
@@ -12,6 +10,8 @@ tags:
   - continuity
   - workflow
 resources:
+  - memory-current-template.md
+  - index-template.md
   - memory-template.md
 vendor_support:
   claude: native
@@ -44,24 +44,40 @@ Rules:
 - `MEMORY.md` is the current canonical continuity file.
 - `index.md` is a small pointer log to snapshots.
 - `snapshots/` stores timestamped continuity checkpoints.
+- Use `memory-current-template.md` for `MEMORY.md` initialization.
+- Use `index-template.md` for `index.md` initialization.
+
+### First-Run Initialization and Bootstrap Rules
+
+When `MEMORY.md` and `index.md` do not exist:
+
+1. If there is active iteration context (for example an open issue/PR, active branch work,
+   or already-decided next steps), initialize both files from templates immediately.
+2. If there is no active iteration context, inspect commit history for signal:
+- if history is rich enough to derive meaningful continuity, ask the user before generating
+  a brief bootstrap memory from commits;
+- if history is not rich enough, ask the user before leaving memory uninitialized.
+3. Never invent synthetic history. If signal is insufficient, state that explicitly.
 
 ### Start-of-Session Retrieval Workflow
 
-1. Read `.agentic/memories/MEMORY.md` if present.
-2. If `index.md` exists, read only the latest 1 to 3 snapshot pointers.
-3. Extract only high-signal items:
+1. If files are missing, apply First-Run Initialization and Bootstrap Rules.
+2. Read `.agentic/memories/MEMORY.md` if present.
+3. If `index.md` exists, read only the latest 1 to 3 snapshot pointers.
+4. Extract only high-signal items:
 - current objective
 - decisions made and rationale
 - open risks/questions
 - next concrete steps
-4. Do not import verbose logs, full transcripts, or resolved low-impact details.
+5. Do not import verbose logs, full transcripts, or resolved low-impact details.
 
 ### End-of-Session Update Workflow
 
 1. Create directories/files if missing:
 - `.agentic/memories/`
 - `.agentic/memories/snapshots/`
-- `.agentic/memories/index.md` (with header/table)
+- `.agentic/memories/MEMORY.md` (from `memory-current-template.md`)
+- `.agentic/memories/index.md` (from `index-template.md`)
 2. Build a new memory entry using `memory-template.md`.
 3. Update `MEMORY.md` additively:
 - keep existing unresolved items
@@ -70,6 +86,15 @@ Rules:
 4. Write a timestamped snapshot:
 - filename format: `YYYY-MM-DDTHH-MM-SSZ.md`
 5. Append one row in `index.md` pointing to the snapshot and objective.
+
+### Multi-Agent and Worktree Coordination Rules
+
+- Treat `MEMORY.md` as shared state: do not delete or rewrite another agent's active workstream
+  row or unresolved items.
+- Each agent should update only its own workstream row (keyed by worktree + branch + agent label)
+  and append decisions/risks with timestamps.
+- If multiple agents are active, preserve all active workstream rows and resolve conflicts by
+  appending a new decision note rather than overwriting history.
 
 ### Signal-Over-Noise Constraints
 
@@ -93,5 +118,6 @@ Prefer compact, testable statements and explicit decisions.
 When this skill runs, report:
 - files created or updated
 - snapshot filename written
+- whether first-run bootstrap was used (and whether user approval was requested)
 - whether compaction/pruning occurred
 - any unresolved risks carried forward

--- a/skills/agentic/memory-continuity/SKILL.md
+++ b/skills/agentic/memory-continuity/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: memory-continuity
+description: >
+  Maintains concise cross-session continuity by writing structured memory
+  handoff artifacts under .agentic/memories/ and loading only high-signal
+  entries at session start. Invoked when continuity is needed across fresh
+  context windows without replaying full chat history.
+version: 1.0.0
+tags:
+  - agentic
+  - memory
+  - continuity
+  - workflow
+resources:
+  - memory-template.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Memory Continuity Skill
+
+Use this skill to preserve high-value context between clean sessions while
+avoiding noisy or low-signal carryover.
+
+### Storage Layout (Hybrid Contract)
+
+Use this deterministic structure:
+
+```text
+.agentic/
+  memories/
+    MEMORY.md
+    index.md
+    snapshots/
+      YYYY-MM-DDTHH-MM-SSZ.md
+```
+
+Rules:
+- If `.agentic/memories/` does not exist, create it and required child paths.
+- `MEMORY.md` is the current canonical continuity file.
+- `index.md` is a small pointer log to snapshots.
+- `snapshots/` stores timestamped continuity checkpoints.
+
+### Start-of-Session Retrieval Workflow
+
+1. Read `.agentic/memories/MEMORY.md` if present.
+2. If `index.md` exists, read only the latest 1 to 3 snapshot pointers.
+3. Extract only high-signal items:
+- current objective
+- decisions made and rationale
+- open risks/questions
+- next concrete steps
+4. Do not import verbose logs, full transcripts, or resolved low-impact details.
+
+### End-of-Session Update Workflow
+
+1. Create directories/files if missing:
+- `.agentic/memories/`
+- `.agentic/memories/snapshots/`
+- `.agentic/memories/index.md` (with header/table)
+2. Build a new memory entry using `memory-template.md`.
+3. Update `MEMORY.md` additively:
+- keep existing unresolved items
+- append new high-signal updates
+- remove or compress resolved/noisy items
+4. Write a timestamped snapshot:
+- filename format: `YYYY-MM-DDTHH-MM-SSZ.md`
+5. Append one row in `index.md` pointing to the snapshot and objective.
+
+### Signal-Over-Noise Constraints
+
+Always exclude:
+- full command history
+- raw terminal dumps and repetitive logs
+- obvious or already-resolved implementation minutiae
+- speculative ideas with no immediate decision/value
+
+Prefer compact, testable statements and explicit decisions.
+
+### Pruning and Compaction Rules
+
+- Keep `MEMORY.md` under ~120 lines by compacting resolved sections.
+- Keep only the latest 20 snapshot files by default.
+- Preserve older snapshots only if tagged as milestone decisions.
+- On compaction, never drop unresolved risks or agreed next steps.
+
+### Output Requirements
+
+When this skill runs, report:
+- files created or updated
+- snapshot filename written
+- whether compaction/pruning occurred
+- any unresolved risks carried forward

--- a/skills/agentic/memory-continuity/index-template.md
+++ b/skills/agentic/memory-continuity/index-template.md
@@ -1,0 +1,5 @@
+# Memory Snapshot Index
+
+| Timestamp (UTC) | Session Scope | Objective | Owner Agent | Worktree | Branch | Snapshot File |
+|---|---|---|---|---|---|---|
+| YYYY-MM-DDTHH:MM:SSZ | {scope-label} | {brief objective} | {agent-name-or-id} | {/abs/path/to/worktree} | {branch-name} | [snapshots/YYYY-MM-DDTHH-MM-SSZ.md](snapshots/YYYY-MM-DDTHH-MM-SSZ.md) |

--- a/skills/agentic/memory-continuity/memory-current-template.md
+++ b/skills/agentic/memory-continuity/memory-current-template.md
@@ -1,0 +1,34 @@
+# Continuity Memory
+
+Last Updated (UTC): YYYY-MM-DDTHH:MM:SSZ
+Primary Repository: {owner/repo}
+Context Scope: {project or subsystem}
+
+## Active Workstreams
+
+| Workstream ID | Owner Agent | Worktree | Branch | Linked Issue/PR | Status | Last Update (UTC) |
+|---|---|---|---|---|---|---|
+| ws-001 | {agent-name-or-id} | {/abs/path/to/worktree} | {branch-name} | {issue/pr url or n/a} | active | YYYY-MM-DDTHH:MM:SSZ |
+
+## Current Objective
+
+- {single highest-priority objective across active workstreams}
+
+## Decisions (Most Recent First)
+
+- [YYYY-MM-DDTHH:MM:SSZ] Decision: {decision}
+  Rationale: {why}
+  Owner: {agent-name-or-id}
+
+## Open Risks / Questions
+
+- [owner={agent-name-or-id}] {risk or unresolved question}
+
+## Next Concrete Steps
+
+1. [owner={agent-name-or-id}] {next executable step}
+2. [owner={agent-name-or-id}] {next executable step}
+
+## Resolved / Compacted Notes
+
+- Keep short summaries of resolved items when useful for future context.

--- a/skills/agentic/memory-continuity/memory-template.md
+++ b/skills/agentic/memory-continuity/memory-template.md
@@ -1,0 +1,26 @@
+# Session Memory Handoff
+
+**Timestamp**: YYYY-MM-DDTHH:MM:SSZ
+**Session Scope**: {short scope label}
+
+## Current Objective
+
+- {single primary objective for next session}
+
+## Decisions Made
+
+- Decision: {what was decided}
+  Rationale: {why}
+
+## Open Risks / Questions
+
+- {risk or question that remains unresolved}
+
+## Next Concrete Steps
+
+1. {next executable step}
+2. {next executable step}
+
+## Excluded Noise
+
+- Full logs, repetitive output, and low-value details intentionally omitted.

--- a/skills/agentic/memory-continuity/memory-template.md
+++ b/skills/agentic/memory-continuity/memory-template.md
@@ -2,6 +2,10 @@
 
 **Timestamp**: YYYY-MM-DDTHH:MM:SSZ
 **Session Scope**: {short scope label}
+**Owner Agent**: {agent-name-or-id}
+**Worktree**: {/abs/path/to/worktree}
+**Branch**: {branch-name}
+**Linked Issue/PR**: {url or n/a}
 
 ## Current Objective
 


### PR DESCRIPTION
Summary
- Adds the memory-continuity skill and now formalizes deterministic templates and first-run bootstrap behavior.

Implemented decisions
- Added explicit templates for MEMORY.md and index.md with agent/worktree-oriented fields.
- First-run behavior is conditional: initialize when active iteration context exists; otherwise inspect commit history and ask user before bootstrap or before leaving memory uninitialized.
- Kept skill description author-side bounded (well under 300 words) to avoid awkward generated index output.

Validation
- rtk just lint (pass)
- rtk just index (pass)

Closes #148