### PR TITLE
fix(fragments): add money and precision rules for TypeScript

### DIFF
--- a/agents/languages/typescript.md
+++ b/agents/languages/typescript.md
@@ -37,6 +37,45 @@ Always enable strict mode in `tsconfig.json`:
 - Use explicit `toPrimitives` / `fromSnapshot` mapping at boundaries.
 - Mapping code is acceptable when contexts have different semantics.
 
+### Money and Precision Rules
+
+- Mandatory: if the domain handles money/currency, taxes, fees, discounts, balances, rates,
+  or any precision-sensitive quantity, do not use native `number` arithmetic.
+- Mandatory: use `decimal.js` as the default decimal arithmetic library. If another decimal
+  library is chosen, document the rationale and keep usage consistent across the codebase.
+- Store/transport monetary values using explicit strategies only:
+  - integer minor units (`amountMinor: 1234`, `currency: 'USD'`), or
+  - canonical decimal strings (`amount: '12.34'`, `currency: 'USD'`).
+- Introduce a domain value object (for example `Money`) that owns parsing, scale normalization,
+  rounding mode, and serialization boundaries. Keep formatting/localization in adapters/UI.
+- Do not mix `number` and decimal instances in the same calculation chain.
+- Do not round implicitly at arbitrary steps; round only at explicit domain boundaries.
+
+```typescript
+// Do: decimal-safe domain operations
+import Decimal from 'decimal.js'
+class Money {
+  private constructor(private readonly amount: Decimal, readonly currency: string) {}
+  static fromDecimalString(amount: string, currency: string): Money {
+    return new Money(new Decimal(amount), currency)
+  }
+  add(other: Money): Money {
+    if (other.currency !== this.currency) throw new Error('Currency mismatch')
+    return new Money(this.amount.plus(other.amount), this.currency)
+  }
+  toDecimalString(): string {
+    return this.amount.toFixed(2)
+  }
+}
+```
+
+```typescript
+// Don't: floating-point money math
+const subtotal = 19.99
+const tax = 0.2
+const total = subtotal + subtotal * tax // precision risk
+```
+
 ### Naming Conventions
 
 | Construct | Convention | Example |

--- a/agents/languages/typescript.md
+++ b/agents/languages/typescript.md
@@ -56,6 +56,10 @@ Always enable strict mode in `tsconfig.json`:
   - fixed-currency products: keep scale/rounding/symbol metadata in code.
   - dynamic/multi-tenant currency catalogs: resolve metadata through a port/adaptor and pass
     normalized policy data into domain operations.
+- For complex financial/precision workloads (allocation engines, compound interest schedules,
+  tax/regulatory rules, cross-currency settlement, or long chained calculations), delegate to a
+  specialized precision port/service. Do not embed ad-hoc complex math in domain/application code
+  where language/runtime numeric behavior can leak into business outcomes.
 - For expected domain mismatches (for example currency mismatch), use one project-level convention
   consistently across the codebase (for example Result-union style or typed domain errors), and
   do not mix styles per module.

--- a/agents/languages/typescript.md
+++ b/agents/languages/typescript.md
@@ -43,38 +43,53 @@ Always enable strict mode in `tsconfig.json`:
   or any precision-sensitive quantity, do not use native `number` arithmetic.
 - Mandatory: use `decimal.js` as the default decimal arithmetic library. If another decimal
   library is chosen, document the rationale and keep usage consistent across the codebase.
-- Store/transport monetary values using explicit strategies only:
-  - integer minor units (`amountMinor: 1234`, `currency: 'USD'`), or
-  - canonical decimal strings (`amount: '12.34'`, `currency: 'USD'`).
+- Canonical money representation in domain and persistence is signed integer minor units
+  (`amountMinor: -1234`, `currency: 'USD'`). Negative values are valid when the domain allows
+  debts, refunds, credits, or reversals.
+- Use decimal strings only at explicit interoperability boundaries (external APIs, CSV/import,
+  UI formatting/parsing), then map to/from minor units.
 - Introduce a domain value object (for example `Money`) that owns parsing, scale normalization,
   rounding mode, and serialization boundaries. Keep formatting/localization in adapters/UI.
 - Keep decimal library types (for example `Decimal`) at infrastructure/application boundaries.
   Domain entities/value objects must not expose library-specific types in their public API.
+- Currency policy source:
+  - fixed-currency products: keep scale/rounding/symbol metadata in code.
+  - dynamic/multi-tenant currency catalogs: resolve metadata through a port/adaptor and pass
+    normalized policy data into domain operations.
+- For expected domain mismatches (for example currency mismatch), use one project-level convention
+  consistently across the codebase (for example Result-union style or typed domain errors), and
+  do not mix styles per module.
 - Do not mix `number` and decimal instances in the same calculation chain.
 - Do not round implicitly at arbitrary steps; round only at explicit domain boundaries.
 
 ```typescript
-// Do: keep the domain model library-agnostic and currency-scale aware
+// Do: canonical domain representation uses signed minor units.
 import Decimal from 'decimal.js'
 
-type Result<T, E> = { ok: true; value: T } | { ok: false; error: E }
+// Use your project's standard expected-error contract consistently.
+type DomainResult<T, E> = { ok: true; value: T } | { ok: false; error: E }
 type Currency = 'USD' | 'JPY' | 'KWD'
 type MoneyError = { type: 'CURRENCY_MISMATCH'; left: Currency; right: Currency }
 
-const CURRENCY_SCALE: Record<Currency, number> = { USD: 2, JPY: 0, KWD: 3 }
+type CurrencyPolicy = { scale: number; symbol: string }
+const CURRENCY_POLICY: Record<Currency, CurrencyPolicy> = {
+  USD: { scale: 2, symbol: 'USD' },
+  JPY: { scale: 0, symbol: 'JPY' },
+  KWD: { scale: 3, symbol: 'KWD' },
+}
 
 class Money {
   private constructor(
     readonly amountMinor: bigint,
     readonly currency: Currency,
-    readonly scale: number,
+    readonly policy: CurrencyPolicy,
   ) {}
 
   static fromMinor(amountMinor: bigint, currency: Currency): Money {
-    return new Money(amountMinor, currency, CURRENCY_SCALE[currency])
+    return new Money(amountMinor, currency, CURRENCY_POLICY[currency])
   }
 
-  add(other: Money): Result<Money, MoneyError> {
+  add(other: Money): DomainResult<Money, MoneyError> {
     if (other.currency !== this.currency) {
       return {
         ok: false,
@@ -91,7 +106,7 @@ class Money {
 
 // Boundary mapper: decimal.js stays outside the domain type.
 function moneyFromDecimalString(amount: string, currency: Currency): Money {
-  const scale = CURRENCY_SCALE[currency]
+  const scale = CURRENCY_POLICY[currency].scale
   const minor = new Decimal(amount).mul(new Decimal(10).pow(scale)).toDecimalPlaces(0)
   return Money.fromMinor(BigInt(minor.toString()), currency)
 }

--- a/agents/languages/typescript.md
+++ b/agents/languages/typescript.md
@@ -48,24 +48,52 @@ Always enable strict mode in `tsconfig.json`:
   - canonical decimal strings (`amount: '12.34'`, `currency: 'USD'`).
 - Introduce a domain value object (for example `Money`) that owns parsing, scale normalization,
   rounding mode, and serialization boundaries. Keep formatting/localization in adapters/UI.
+- Keep decimal library types (for example `Decimal`) at infrastructure/application boundaries.
+  Domain entities/value objects must not expose library-specific types in their public API.
 - Do not mix `number` and decimal instances in the same calculation chain.
 - Do not round implicitly at arbitrary steps; round only at explicit domain boundaries.
 
 ```typescript
-// Do: decimal-safe domain operations
+// Do: keep the domain model library-agnostic and currency-scale aware
 import Decimal from 'decimal.js'
+
+type Result<T, E> = { ok: true; value: T } | { ok: false; error: E }
+type Currency = 'USD' | 'JPY' | 'KWD'
+type MoneyError = { type: 'CURRENCY_MISMATCH'; left: Currency; right: Currency }
+
+const CURRENCY_SCALE: Record<Currency, number> = { USD: 2, JPY: 0, KWD: 3 }
+
 class Money {
-  private constructor(private readonly amount: Decimal, readonly currency: string) {}
-  static fromDecimalString(amount: string, currency: string): Money {
-    return new Money(new Decimal(amount), currency)
+  private constructor(
+    readonly amountMinor: bigint,
+    readonly currency: Currency,
+    readonly scale: number,
+  ) {}
+
+  static fromMinor(amountMinor: bigint, currency: Currency): Money {
+    return new Money(amountMinor, currency, CURRENCY_SCALE[currency])
   }
-  add(other: Money): Money {
-    if (other.currency !== this.currency) throw new Error('Currency mismatch')
-    return new Money(this.amount.plus(other.amount), this.currency)
+
+  add(other: Money): Result<Money, MoneyError> {
+    if (other.currency !== this.currency) {
+      return {
+        ok: false,
+        error: { type: 'CURRENCY_MISMATCH', left: this.currency, right: other.currency },
+      }
+    }
+    return { ok: true, value: Money.fromMinor(this.amountMinor + other.amountMinor, this.currency) }
   }
-  toDecimalString(): string {
-    return this.amount.toFixed(2)
+
+  toPrimitives(): { amountMinor: string; currency: Currency } {
+    return { amountMinor: this.amountMinor.toString(), currency: this.currency }
   }
+}
+
+// Boundary mapper: decimal.js stays outside the domain type.
+function moneyFromDecimalString(amount: string, currency: Currency): Money {
+  const scale = CURRENCY_SCALE[currency]
+  const minor = new Decimal(amount).mul(new Decimal(10).pow(scale)).toDecimalPlaces(0)
+  return Money.fromMinor(BigInt(minor.toString()), currency)
 }
 ```
 

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-19T23:50:29Z",
+  "generated_at": "2026-05-21T17:31:00Z",
   "fragments": [
     {
       "name": "bff",
@@ -224,7 +224,7 @@
       "group": "languages",
       "path": "agents/languages/typescript.md",
       "heading": "TypeScript",
-      "words": 1053
+      "words": 1095
     },
     {
       "name": "api-design",

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-16T17:45:02Z",
+  "generated_at": "2026-05-19T23:50:29Z",
   "fragments": [
     {
       "name": "bff",
@@ -224,7 +224,7 @@
       "group": "languages",
       "path": "agents/languages/typescript.md",
       "heading": "TypeScript",
-      "words": 937
+      "words": 1053
     },
     {
       "name": "api-design",

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-11T20:59:19Z",
+  "generated_at": "2026-05-16T17:15:10Z",
   "fragments": [
     {
       "name": "bff",
@@ -224,7 +224,7 @@
       "group": "languages",
       "path": "agents/languages/typescript.md",
       "heading": "TypeScript",
-      "words": 583
+      "words": 797
     },
     {
       "name": "api-design",

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-16T17:15:10Z",
+  "generated_at": "2026-05-16T17:45:02Z",
   "fragments": [
     {
       "name": "bff",
@@ -224,7 +224,7 @@
       "group": "languages",
       "path": "agents/languages/typescript.md",
       "heading": "TypeScript",
-      "words": 797
+      "words": 937
     },
     {
       "name": "api-design",


### PR DESCRIPTION
Summary
- Adds and refines Money and Precision Rules for shared TypeScript guidance.
- Keeps money domain modeling library-agnostic while constraining decimal usage to explicit boundaries.

Implemented decisions
- Canonical representation is signed integer minor units (negative values allowed when domain context permits).
- Decimal arithmetic is boundary-only for representation/interoperability mapping.
- Currency metadata policy is split by context: fixed currency sets can be code-defined; dynamic catalogs must come from a port/adaptor providing scale/rounding/symbol data.
- For complex precision-heavy financial calculations, delegate to a specialized precision port/service rather than embedding ad-hoc complex math in app/domain code.
- Expected domain mismatches must follow one consistent project-level convention (not mixed per module).

Validation
- just lint (pass)
- just index (pass)

Closes #150