### PR TITLE
feat(skills): add plan-memory-index skill for applied plans

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -10,7 +10,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 - `configure-mcp` — Set up and configure MCP servers for agent tool access.
 - `deploy-config` — Deploy composed config, vendor files, and skills to a target project.
 - `github-issue-planning` — Issue-backed plan persistence on GitHub (prefer MCP, fallback to `gh` CLI).
-- `plan-memory-index` — Keep indexed, concise memory entries for applied plans under `.agentic/plans/`.
+- `plan-memory-index` — Keep indexed, concise memory entries for applied plans under `.agentic/memories/plan-memory/`, while keeping `.agentic/plans/` as plan source of truth.
 - `persist-plan` — Save the current plan as a structured file under `.agentic/plans/`.
 - `write-plan` — Auto-persist generated plans and keep a local plans index updated.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -10,6 +10,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 - `configure-mcp` — Set up and configure MCP servers for agent tool access.
 - `deploy-config` — Deploy composed config, vendor files, and skills to a target project.
 - `github-issue-planning` — Issue-backed plan persistence on GitHub (prefer MCP, fallback to `gh` CLI).
+- `plan-memory-index` — Keep indexed, concise memory entries for applied plans under `.agentic/plans/`.
 - `persist-plan` — Save the current plan as a structured file under `.agentic/plans/`.
 - `write-plan` — Auto-persist generated plans and keep a local plans index updated.
 

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-16T17:15:24Z",
+  "generated_at": "2026-05-19T23:53:53Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -68,7 +68,7 @@
       "name": "plan-memory-index",
       "group": "agentic",
       "path": "skills/agentic/plan-memory-index/SKILL.md",
-      "description": "Maintains an indexed memory of applied plans under .agentic/plans/ so agents can retrieve relevant prior context quickly",
+      "description": "Maintains concise indexed memory entries for applied plans under .agentic/memories/ with clear boundaries between memory",
       "version": "1.0.0",
       "tags": [
         "agentic",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-15T22:59:45Z",
+  "generated_at": "2026-05-16T17:15:24Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -62,6 +62,19 @@
         "planning",
         "architecture",
         "multi-agent"
+      ]
+    },
+    {
+      "name": "plan-memory-index",
+      "group": "agentic",
+      "path": "skills/agentic/plan-memory-index/SKILL.md",
+      "description": "Maintains an indexed memory of applied plans under .agentic/plans/ so agents can retrieve relevant prior context quickly",
+      "version": "1.0.0",
+      "tags": [
+        "agentic",
+        "planning",
+        "memory",
+        "indexing"
       ]
     },
     {

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -195,6 +195,7 @@
           "next-application-structure",
           "nosql-database-design",
           "persist-plan",
+          "plan-memory-index",
           "pull-request-automation",
           "react-application-structure",
           "react-component-design",

--- a/skills/agentic/plan-memory-index/SKILL.md
+++ b/skills/agentic/plan-memory-index/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: plan-memory-index
+description: >
+  Maintains an indexed memory of applied plans under .agentic/plans/ so agents
+  can retrieve relevant prior context quickly before pulling full issue threads.
+  Stores concise per-plan memory entries with optional GitHub issue links and
+  status metadata, then supports list-first and select-first retrieval.
+version: 1.0.0
+tags:
+  - agentic
+  - planning
+  - memory
+  - indexing
+resources:
+  - index-template.md
+  - memory-entry-template.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Plan Memory Index Skill
+
+Keep a compact, queryable memory of plans that were already applied, so agents can
+recover only the right context first and fetch full external issue details later.
+
+Use this skill for concise continuity memory. Do not use it as a full session log.
+
+### Step 1 - Ensure Deterministic Storage Layout
+
+Ensure this directory structure exists:
+
+```text
+.agentic/
+  plans/
+    index.md
+    memory/
+```
+
+Rules:
+- Create `.agentic/plans/` and `.agentic/plans/memory/` when missing.
+- Keep the index filename exactly `index.md` (lowercase).
+- Keep all plan memory entries in `.agentic/plans/memory/`.
+
+### Step 2 - Create or Update a Memory Entry
+
+Create one Markdown file per memory entry:
+
+```text
+.agentic/plans/memory/YYYY-MM-DD-{plan-slug}.md
+```
+
+Example:
+```text
+.agentic/plans/memory/2026-05-16-issue-149-plan-memory-index.md
+```
+
+Frontmatter fields:
+- `id`: stable unique ID, e.g. `plan-memory-2026-05-16-001`
+- `plan_slug`: kebab-case plan identifier
+- `summary`: concise applied-plan excerpt
+- `linked_issues`: optional list of GitHub issue URLs
+- `status`: one of `draft`, `in-progress`, `done`, `superseded`
+- `last_used_at`: ISO-8601 UTC timestamp
+- `tags`: short list for retrieval
+
+Use `memory-entry-template.md`.
+
+### Step 3 - Enforce Summary Length Guidance
+
+Keep memory entries high signal and small:
+- `summary`: target 1 to 3 sentences.
+- Hard cap: 280 characters.
+- Do not copy full issue bodies, long logs, or full plans into memory entries.
+- If more detail is needed, store a short pointer in `summary` and defer deep fetch.
+
+### Step 4 - Upsert `.agentic/plans/index.md`
+
+Create `index.md` from `index-template.md` if missing. Then add or update a single row
+for the memory entry.
+
+Required columns:
+- `id`
+- `plan_slug`
+- `status`
+- `last_used_at`
+- `linked_issues`
+- `memory_file`
+
+Upsert behavior:
+- If `id` already exists, update that row in place.
+- Otherwise append one new row.
+- Keep rows sorted by `last_used_at` descending.
+
+### Step 5 - Retrieval Workflow (Select Before Deep Fetch)
+
+When context is needed:
+1. Read only `.agentic/plans/index.md`.
+2. Filter by `plan_slug`, `tags`, or `linked_issues`.
+3. Select one candidate memory entry.
+4. Read the selected memory file.
+5. Fetch full GitHub issue context only if still needed.
+
+This list-first workflow avoids loading unnecessary historical context.
+
+### Step 6 - Update and Prune Rules
+
+Update rules:
+- Update `last_used_at` every time a memory entry is used.
+- Update `status` when plan lifecycle changes.
+- Keep the same `id` and file path; do not create duplicates for the same applied plan
+  unless there is a materially new plan variant.
+
+Prune rules:
+- Prefer `status: superseded` over deletion.
+- If deletion is required, delete the memory file and remove its row from `index.md`
+  in the same change.
+- During periodic cleanup, archive or remove entries not used for 180+ days only when
+  they are `done` or `superseded` and have no active dependencies.

--- a/skills/agentic/plan-memory-index/SKILL.md
+++ b/skills/agentic/plan-memory-index/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: plan-memory-index
 description: >
-  Maintains an indexed memory of applied plans under .agentic/plans/ so agents
-  can retrieve relevant prior context quickly before pulling full issue threads.
-  Stores concise per-plan memory entries with optional GitHub issue links and
-  status metadata, then supports list-first and select-first retrieval.
+  Maintains concise indexed memory entries for applied plans under
+  .agentic/memories/ with clear boundaries between memory and plan sources.
+  Memory retrieval is prioritized before loading historical plan files.
 version: 1.0.0
 tags:
   - agentic
@@ -35,27 +34,30 @@ Ensure this directory structure exists:
 
 ```text
 .agentic/
+  memories/
+    plan-memory/
+      index.md
+      entries/
   plans/
-    index.md
-    memory/
+    INDEX.md
 ```
 
 Rules:
-- Create `.agentic/plans/` and `.agentic/plans/memory/` when missing.
-- Keep the index filename exactly `index.md` (lowercase).
-- Keep all plan memory entries in `.agentic/plans/memory/`.
+- Create `.agentic/memories/plan-memory/` and `.agentic/memories/plan-memory/entries/` when missing.
+- Keep the memory index filename exactly `.agentic/memories/plan-memory/index.md`.
+- Treat `.agentic/plans/INDEX.md` as the canonical plans index (do not create `.agentic/plans/index.md`).
 
 ### Step 2 - Create or Update a Memory Entry
 
 Create one Markdown file per memory entry:
 
 ```text
-.agentic/plans/memory/YYYY-MM-DD-{plan-slug}.md
+.agentic/memories/plan-memory/entries/YYYY-MM-DD-{plan-slug}.md
 ```
 
 Example:
 ```text
-.agentic/plans/memory/2026-05-16-issue-149-plan-memory-index.md
+.agentic/memories/plan-memory/entries/2026-05-16-issue-149-plan-memory-index.md
 ```
 
 Frontmatter fields:
@@ -63,6 +65,7 @@ Frontmatter fields:
 - `plan_slug`: kebab-case plan identifier
 - `summary`: concise applied-plan excerpt
 - `linked_issues`: optional list of GitHub issue URLs
+- `plan_file`: optional path to canonical plan file under `.agentic/plans/`
 - `status`: one of `draft`, `in-progress`, `done`, `superseded`
 - `last_used_at`: ISO-8601 UTC timestamp
 - `tags`: short list for retrieval
@@ -77,10 +80,10 @@ Keep memory entries high signal and small:
 - Do not copy full issue bodies, long logs, or full plans into memory entries.
 - If more detail is needed, store a short pointer in `summary` and defer deep fetch.
 
-### Step 4 - Upsert `.agentic/plans/index.md`
+### Step 4 - Upsert `.agentic/memories/plan-memory/index.md`
 
-Create `index.md` from `index-template.md` if missing. Then add or update a single row
-for the memory entry.
+Create `.agentic/memories/plan-memory/index.md` from `index-template.md` if missing.
+Then add or update a single row for the memory entry.
 
 Required columns:
 - `id`
@@ -89,6 +92,7 @@ Required columns:
 - `last_used_at`
 - `linked_issues`
 - `memory_file`
+- `plan_file`
 
 Upsert behavior:
 - If `id` already exists, update that row in place.
@@ -98,11 +102,12 @@ Upsert behavior:
 ### Step 5 - Retrieval Workflow (Select Before Deep Fetch)
 
 When context is needed:
-1. Read only `.agentic/plans/index.md`.
+1. Read only `.agentic/memories/plan-memory/index.md`.
 2. Filter by `plan_slug`, `tags`, or `linked_issues`.
 3. Select one candidate memory entry.
 4. Read the selected memory file.
-5. Fetch full GitHub issue context only if still needed.
+5. Load `.agentic/plans/INDEX.md` and specific plan files only if still needed.
+6. Fetch full GitHub issue context only if still needed.
 
 This list-first workflow avoids loading unnecessary historical context.
 
@@ -120,3 +125,10 @@ Prune rules:
   in the same change.
 - During periodic cleanup, archive or remove entries not used for 180+ days only when
   they are `done` or `superseded` and have no active dependencies.
+
+### Step 7 - Source-of-Truth Boundaries
+
+- `.agentic/memories/` is the source of truth for memory indexing and retrieval state.
+- `.agentic/plans/` is the source of truth for plan artifacts and plan lifecycle history.
+- Memory updates must not rewrite original plan artifacts; plan updates must not implicitly
+  mutate memory rows without an explicit memory update step.

--- a/skills/agentic/plan-memory-index/index-template.md
+++ b/skills/agentic/plan-memory-index/index-template.md
@@ -1,4 +1,4 @@
 # Plan Memory Index
 
-| id | plan_slug | status | last_used_at | linked_issues | memory_file |
-|----|-----------|--------|--------------|---------------|-------------|
+| id | plan_slug | status | last_used_at | linked_issues | memory_file | plan_file |
+|----|-----------|--------|--------------|---------------|-------------|-----------|

--- a/skills/agentic/plan-memory-index/index-template.md
+++ b/skills/agentic/plan-memory-index/index-template.md
@@ -1,0 +1,4 @@
+# Plan Memory Index
+
+| id | plan_slug | status | last_used_at | linked_issues | memory_file |
+|----|-----------|--------|--------------|---------------|-------------|

--- a/skills/agentic/plan-memory-index/memory-entry-template.md
+++ b/skills/agentic/plan-memory-index/memory-entry-template.md
@@ -1,0 +1,15 @@
+---
+id: plan-memory-YYYY-MM-DD-001
+plan_slug: issue-000-example-plan
+summary: "One to three sentence summary of the applied plan (max 280 chars)."
+linked_issues:
+  - https://github.com/org/repo/issues/000
+status: done
+last_used_at: "YYYY-MM-DDTHH:MM:SSZ"
+tags: ["plans", "example"]
+---
+
+## Notes
+
+- Keep this file concise and retrieval-oriented.
+- Record only high-signal implementation outcomes and follow-up pointers.

--- a/skills/agentic/plan-memory-index/memory-entry-template.md
+++ b/skills/agentic/plan-memory-index/memory-entry-template.md
@@ -4,6 +4,7 @@ plan_slug: issue-000-example-plan
 summary: "One to three sentence summary of the applied plan (max 280 chars)."
 linked_issues:
   - https://github.com/org/repo/issues/000
+plan_file: ".agentic/plans/YYYY-MM-DD-example-plan.md"
 status: done
 last_used_at: "YYYY-MM-DDTHH:MM:SSZ"
 tags: ["plans", "example"]


### PR DESCRIPTION
Summary
- Refines plan-memory-index to prioritize memory retrieval and remove prior index/schema ambiguity.

Implemented decisions
- Memory retrieval is now memory-first under .agentic/memories/plan-memory/.
- .agentic/plans/INDEX.md remains the canonical plans source; no conflicting .agentic/plans/index.md flow.
- Source-of-truth boundaries are explicit:
  - .agentic/memories/ -> memory indexing/retrieval state
  - .agentic/plans/ -> plan artifacts and lifecycle history

Validation
- rtk just lint (pass)
- rtk just index (pass)

Closes #149