### PR TITLE
fix(fragments): prefer TypeScript satisfies over unsafe as assertions

### DIFF
--- a/agents/languages/typescript.md
+++ b/agents/languages/typescript.md
@@ -22,12 +22,31 @@ Always enable strict mode in `tsconfig.json`:
   Use `interface` for object shapes that may be extended (especially public APIs).
 - Never use `any`. Use `unknown` for genuinely unknown values and narrow with guards.
 - Avoid type assertions (`as Foo`) except at system boundaries with validation.
+- Prefer `satisfies` for object literals/config maps when you need type conformance checks
+  without widening away useful inferred literal types.
 - Use discriminated unions for modeling state:
   ```typescript
   type Result<T> = { ok: true; value: T } | { ok: false; error: Error }
   ```
 - Prefer `readonly` for all data that should not be mutated.
 - Use template literal types for string-constrained values: `type EventName = `${string}.${string}``
+
+```typescript
+// Do: validate shape with `satisfies` and keep literal precision.
+type RetryPolicy = { maxRetries: number; strategy: 'linear' | 'exponential' }
+const RETRY_POLICY = {
+  maxRetries: 3,
+  strategy: 'exponential',
+} satisfies RetryPolicy
+```
+
+```typescript
+// Avoid: `as` hides incompatibilities and can mask mistakes.
+const RETRY_POLICY = {
+  maxRetries: 3,
+  strategy: 'expo', // typo could be forced through with `as RetryPolicy`
+} as RetryPolicy
+```
 
 ### Domain Modeling Conventions
 

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-21T17:31:00Z",
+  "generated_at": "2026-05-21T18:41:10Z",
   "fragments": [
     {
       "name": "bff",
@@ -224,7 +224,7 @@
       "group": "languages",
       "path": "agents/languages/typescript.md",
       "heading": "TypeScript",
-      "words": 1095
+      "words": 1180
     },
     {
       "name": "api-design",


### PR DESCRIPTION
## Summary
- Updates shared TypeScript guidance to prefer `satisfies` when validating object-literal conformance.
- Keeps existing boundary-only allowance for `as` assertions.
- Adds clear do/don't examples showing why `satisfies` is safer and more robust.

## Validation
- rtk just lint (pass)
- rtk just index (pass)

## Files Changed
- agents/languages/typescript.md
- index/fragments.json