### PR TITLE
feat(tooling): support output.custom_index.element[] and normalize AGENTS spacing

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -182,6 +182,33 @@ tiers:
 
 `url_doc` is optional. When omitted the Docs column in `AGENTS.md` shows `—`.
 
+## Add Custom Markdown Context Index
+
+If your project has critical markdown documents agents should read first, declare them in:
+`output.custom_index.element[]` inside `.agentic/profile.yaml`.
+
+```yaml
+output:
+  custom_index:
+    title: "Project Knowledge Base"
+    description: "Read these docs before changing architecture, infra, or release workflow."
+    element:
+      - path: "docs/architecture.md"
+        why: "Defines bounded contexts and dependency rules."
+        when: "Before touching domain or service boundaries."
+      - path: "docs/runbooks/release.md"
+        why: "Contains release gates and rollback procedure."
+        when: "Before CI/CD or versioning changes."
+```
+
+Then run:
+
+```bash
+agentic sync
+```
+
+This adds a dedicated markdown context table to generated `AGENTS.md`.
+
 ## When to Use What
 
 | Need | Solution |

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -79,6 +79,7 @@ tiers:
 | `fragments.*` | ✓ | Fragment lists per layer |
 | `tech_stack` | — | Generates `## Technical Stack` table |
 | `tech_stack.proprietary_libraries` | — | Internal packages with doc links |
+| `output.custom_index.element[]` | — | Custom markdown context table entries in generated `AGENTS.md` |
 | `skills` | — | On-demand agent task skill names |
 | `output.structure` | — | `flat` (default) or `nested` |
 | `tiers` | — | Per-tier fragment + command declarations (nested only) |

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -367,6 +367,46 @@
               "description": "How to handle existing user-authored AGENTS.md on first compose"
             }
           }
+        },
+        "custom_index": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Custom markdown context index rendered into AGENTS.md so agents can load important project docs early.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Optional section title. Defaults to 'Additional Markdown Context'."
+            },
+            "description": {
+              "type": "string",
+              "description": "Optional short intro shown above the index table."
+            },
+            "element": {
+              "type": "array",
+              "description": "Markdown context entries.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "path"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "Path to markdown file relative to target repo root."
+                  },
+                  "why": {
+                    "type": "string",
+                    "description": "Why this file matters."
+                  },
+                  "when": {
+                    "type": "string",
+                    "description": "When to read this file."
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/tooling/lib/common.sh
+++ b/tooling/lib/common.sh
@@ -5,6 +5,7 @@
 # Provides:
 # - ANSI color constants
 # - Output helpers (die, warn, info, ok, fail)
+# - normalize_markdown_spacing() — lightweight newline normalization for generated markdown
 # - format_markdown() — canonical markdown formatter
 # - safe_rm_rf() — guarded path removal
 # - require_arg() — argument validation
@@ -68,6 +69,23 @@ fail() {
 # ══════════════════════════════════════════════════════════════════════════════
 # Markdown formatter
 # ══════════════════════════════════════════════════════════════════════════════
+
+# Normalizes generated markdown spacing without changing semantic content:
+# - collapse 3+ consecutive blank lines into a single blank line separator
+# - ensure file ends with a newline
+normalize_markdown_spacing() {
+  local file="$1"
+  [[ ! -f "$file" ]] && return
+
+  local content
+  content=$(cat "$file")
+
+  while [[ "$content" == *$'\n\n\n'* ]]; do
+    content="${content//$'\n\n\n'/$'\n\n'}"
+  done
+
+  printf '%s\n' "$content" > "$file"
+}
 
 # Formats markdown files if mdformat is available (optional, silent if missing)
 format_markdown() {

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -297,6 +297,40 @@ build_proprietary_libraries_section() {
   printf '%s' "$section"
 }
 
+# ── Custom markdown index section ─────────────────────────────────────────────
+build_custom_index_section() {
+  local count
+  count=$(yq '.output.custom_index.element | length' "$PROFILE_FILE" 2>/dev/null || echo "0")
+  [[ "$count" == "0" || "$count" == "null" ]] && return
+
+  local title intro section
+  title=$(yq '.output.custom_index.title // "Additional Markdown Context"' "$PROFILE_FILE")
+  intro=$(yq '.output.custom_index.description // ""' "$PROFILE_FILE")
+
+  section+=$'\n## '"${title}"$'\n\n'
+  if [[ -n "$intro" && "$intro" != "null" ]]; then
+    section+="${intro}"$'\n\n'
+  else
+    section+="Load these markdown files before making changes in the related areas."$'\n\n'
+  fi
+
+  section+="| File | Why It Matters | When To Read |"$'\n'
+  section+="|------|----------------|--------------|"$'\n'
+
+  local i=0
+  while [[ $i -lt $count ]]; do
+    local path why when
+    path=$(yq ".output.custom_index.element[$i].path" "$PROFILE_FILE")
+    why=$(yq ".output.custom_index.element[$i].why // \"—\"" "$PROFILE_FILE")
+    when=$(yq ".output.custom_index.element[$i].when // \"—\"" "$PROFILE_FILE")
+    [[ -z "$path" || "$path" == "null" ]] && path="(missing-path)"
+    section+="| \`${path}\` | ${why} | ${when} |"$'\n'
+    i=$(( i + 1 ))
+  done
+
+  printf '%s' "$section"
+}
+
 # ── Skills section ────────────────────────────────────────────────────────────
 build_skills_section() {
   local full_mode="$1"  # "true" or "false"
@@ -553,6 +587,7 @@ compose_flat() {
   fi
 
   OUTPUT+=$(build_commands_block "$BUILD_CMD" "$TEST_CMD" "$LINT_CMD")
+  OUTPUT+=$(build_custom_index_section)
 
   if [[ "$FULL_MODE" == "true" ]]; then
     OUTPUT+=$(inline_fragments)
@@ -576,6 +611,7 @@ compose_flat() {
     printf '%s\n' "$OUTPUT" > "$tmp_agents"
     mv "$tmp_agents" "$TARGET/AGENTS.md"
     tmp_agents=""  # clear so RETURN trap is a no-op
+    normalize_markdown_spacing "$TARGET/AGENTS.md"
     format_markdown "$TARGET/AGENTS.md"
 
     LOCK_DIR="$TARGET/.agentic"
@@ -753,6 +789,8 @@ compose_nested() {
     done
   fi
 
+  root_out+=$(build_custom_index_section)
+
   # Tier listing (always a reference table regardless of --full)
   root_out+=$'\n## Tiers\n\n'
   root_out+="> Load the relevant tier file for tier-specific language, framework, and architecture guidelines."$'\n\n'
@@ -775,6 +813,7 @@ compose_nested() {
   printf '%s\n' "$root_out" > "$tmp_agents"
   mv "$tmp_agents" "$TARGET/AGENTS.md"
   tmp_agents=""  # clear so RETURN trap is a no-op
+  normalize_markdown_spacing "$TARGET/AGENTS.md"
   format_markdown "$TARGET/AGENTS.md"
 
   # ── Per-tier AGENTS.md ──────────────────────────────────────────────────────
@@ -842,6 +881,7 @@ compose_nested() {
     printf '%s\n' "$tier_out" > "$tmp_tier_agents"
     mv "$tmp_tier_agents" "$TARGET/$tier/AGENTS.md"
     tmp_tier_agents=""  # clear so RETURN trap is a no-op
+    normalize_markdown_spacing "$TARGET/$tier/AGENTS.md"
     format_markdown "$TARGET/$tier/AGENTS.md"
     echo "Composed ${tier}/AGENTS.md → $TARGET/${tier}/AGENTS.md"
   done

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -110,6 +110,24 @@ assert_json_min_count() {
   fi
 }
 
+assert_no_triple_blank_lines() {
+  local file="$1" label="$2"
+  if awk '
+    BEGIN { blank = 0 }
+    /^[[:space:]]*$/ {
+      blank++
+      if (blank >= 3) exit 1
+      next
+    }
+    { blank = 0 }
+    END { exit 0 }
+  ' "$file"; then
+    pass "$label — no triple blank-line runs in $file"
+  else
+    fail "$label — found 3+ consecutive blank lines in $file"
+  fi
+}
+
 assert_symlink_exists() {
   local path="$1" label="$2"
   if [[ -L "$path" ]]; then
@@ -3640,6 +3658,56 @@ assert_symlink_exists "$TMP/t136/CLAUDE.md" "T136 claude restored"
 assert_file_not_exists "$TMP/t136/.cursor/rules" "T136 root cursor link removed"
 assert_file_not_exists "$TMP/t136/backend/.cursor/rules" "T136 backend cursor link removed"
 assert_file_contains "$TMP/t136/ui/.cursor" "blocker" "T136 blocker file preserved"
+
+# T154 — compose: output.custom_index.element[] renders markdown context table
+run_test "T154 — compose: custom markdown context index section"
+mkdir -p "$TMP/t154"
+cat > "$TMP/t154-profile.yaml" <<'EOF'
+meta:
+  name: Test Custom Index
+  description: Test profile with custom markdown context index
+  version: "1.0.0"
+fragments:
+  base:
+    - git-conventions
+output:
+  custom_index:
+    title: "Project Context Docs"
+    description: "Important markdown references for this project."
+    element:
+      - path: "docs/architecture.md"
+        why: "Core boundaries and decisions"
+        when: "Before editing architecture or service boundaries"
+      - path: "docs/runbooks/release.md"
+        why: "Release and rollback runbook"
+        when: "Before CI/CD or release pipeline changes"
+vendors:
+  enabled: []
+EOF
+
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile-file "$TMP/t154-profile.yaml" \
+  --target "$TMP/t154" \
+  > /dev/null 2>&1
+
+assert_file_contains "$TMP/t154/AGENTS.md" "## Project Context Docs" "T154"
+assert_file_contains "$TMP/t154/AGENTS.md" "docs/architecture.md" "T154"
+assert_file_contains "$TMP/t154/AGENTS.md" "Core boundaries and decisions" "T154"
+assert_file_contains "$TMP/t154/AGENTS.md" "docs/runbooks/release.md" "T154"
+
+# T155 — compose: generated AGENTS markdown has stable section spacing
+run_test "T155 — compose: no triple blank-line runs in generated AGENTS"
+mkdir -p "$TMP/t155"
+bash "$COMPOSE" \
+  --library "$LIBRARY" \
+  --profile typescript-hexagonal-next-ui \
+  --target "$TMP/t155" \
+  > /dev/null 2>&1
+
+assert_no_triple_blank_lines "$TMP/t155/AGENTS.md" "T155 root"
+assert_no_triple_blank_lines "$TMP/t155/backend/AGENTS.md" "T155 backend"
+assert_no_triple_blank_lines "$TMP/t155/ui/AGENTS.md" "T155 ui"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary
- Adds profile support for `output.custom_index.element[]` to render a markdown context index table in generated `AGENTS.md`.
- Adds lightweight spacing normalization for generated markdown to reduce section-spacing drift during compose/sync.
- Documents the new profile field and usage examples.
- Adds compose tests for custom index rendering and blank-line stability.

## Contract
```yaml
output:
  custom_index:
    title: "Project Context Docs"        # optional
    description: "..."                   # optional
    element:
      - path: "docs/architecture.md"     # required
        why: "Core boundaries"           # optional
        when: "Before refactors"         # optional
```

## Validation
- `rtk just lint` (pass)
- `rtk just index` (pass)
- `rtk just test` (pass)

## Files Changed
- docs/customization.md
- docs/profiles.md
- schemas/profile.schema.json
- tooling/lib/common.sh
- tooling/lib/compose.sh
- tooling/lib/test.sh