### PR TITLE
fix(skills): clarify authorization placement in architecture and PHP checklists

### DIFF
--- a/skills/development/code-review-architecture/checklist.md
+++ b/skills/development/code-review-architecture/checklist.md
@@ -29,7 +29,8 @@ Extends the generic checklist. Apply every item to architectural concerns.
   *Ref: [Domain Events — Martin Fowler](https://martinfowler.com/eaaDev/DomainEvent.html)*
 - [ ] No cross-context direct import: bounded contexts communicate via domain events or ACL, not shared domain models
   *Ref: [DDD — Bounded Context, Eric Evans, 2003, ch. 14](https://www.domainlanguage.com/ddd/reference/)*
-- [ ] Authorization checks NOT inside aggregate methods or domain services
+- [ ] Authorization is handled in the application layer (command/query handlers, middleware, policy services) — not inside aggregate methods or domain services, unless: (a) authorization *is* the core business domain (e.g. an IAM or permission-management service), or (b) the team has made an explicit, documented architectural trade-off to encode access rules inside the domain
+  *Ref: [Domain-Driven Design — Eric Evans, 2003, ch. 4 — Isolating the Domain](https://www.domainlanguage.com/ddd/reference/); [Hexagonal Architecture — Alistair Cockburn, 2005](https://alistair.cockburn.us/hexagonal-architecture/)*
 - [ ] Domain objects not leaked to transport or persistence adapters — `ToPrimitives`/`FromPrimitives` mappers used
 
 ## CQRS

--- a/skills/development/code-review-php/checklist.md
+++ b/skills/development/code-review-php/checklist.md
@@ -37,8 +37,8 @@ Extends the generic checklist. Apply every item to PHP-specific concerns.
   *Ref: [Refactoring — Replace Primitive with Object, Martin Fowler](https://refactoring.com/catalog/replacePrimitiveWithObject.html)*
 - [ ] No `static` methods in domain services — static methods cannot be mocked or overridden
   *Ref: [PHPUnit docs — Test doubles](https://phpunit.de/documentation.html)*
-- [ ] Authorization checks NOT inside domain entities or aggregates (keep domain ignorant of permissions)
-  *Ref: [Hexagonal Architecture, Alistair Cockburn](https://alistair.cockburn.us/hexagonal-architecture/)*
+- [ ] Authorization is handled in the application layer (controllers, middleware, command handlers) — not inside domain entities or aggregates, unless: (a) authorization *is* the core business domain, or (b) the team has an explicit, documented trade-off to encode access rules inside the domain
+  *Ref: [Hexagonal Architecture — Alistair Cockburn, 2005](https://alistair.cockburn.us/hexagonal-architecture/)*
 - [ ] No direct `$_GET`/`$_POST`/`$_REQUEST`/`$_SERVER` access outside adapter/controller layer
 
 ## PSR Compliance


### PR DESCRIPTION
## Summary

Clarifies the authorization placement rule in two checklists that contained an overly broad prohibition.

### The problem with the original wording

```
- [ ] Authorization checks NOT inside aggregate methods or domain services
```

This is a blanket rule that ignores two legitimate cases where authorization *belongs* in the domain:

1. **Authorization is the core business domain** — an IAM product, a permission-management service, or an RBAC/ABAC engine has access rules as its primary business concept. Pushing those rules out of the domain would be the actual architecture violation.
2. **Explicit documented trade-off** — a team may consciously decide to encode certain access invariants inside the domain (e.g. an aggregate enforcing ownership rules as a business invariant). That is a valid design decision when it is deliberate and documented.

### The fix

Both items now read:

> Authorization is handled in the application layer (command/query handlers, middleware, policy services) — not inside aggregate methods or domain services, **unless**: (a) authorization *is* the core business domain, or (b) the team has an explicit, documented trade-off to encode access rules inside the domain.

This preserves the default guidance (application layer) while surfacing the two exceptions so the agent flags a *missing justification* rather than a blanket violation.

### Files changed

- `skills/development/code-review-architecture/checklist.md` — DDD section
- `skills/development/code-review-php/checklist.md` — Domain Modeling section

---

## Verification

```
just lint  →  PASSED
just test  →  589/589 PASSED
```