### PR TITLE
fix(tooling): stop managing opencode.json

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -74,9 +74,10 @@ servers:
 `agentic sync` and `agentic compose` seed vendor MCP outputs from this file:
 
 - `.mcp.json` (Claude shape)
-- `opencode.json` (`mcp` block translation)
 - `.gemini/settings.json` (`mcpServers` translation)
 - `.cursor/mcp.json` (`mcpServers` translation)
+- existing `opencode.json`, if present in the project (`mcp` block
+  translation)
 
 If `.agentic/mcp.yaml` is missing, MCP outputs are not seeded.
 

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -99,9 +99,10 @@ Source file:
 Generated targets:
 
 - `.mcp.json` uses `mcpServers` (Claude-compatible shape)
-- `opencode.json` uses `mcp` with translated transport keys
 - `.gemini/settings.json` uses `mcpServers` with Gemini-specific field mapping
 - `.cursor/mcp.json` uses `mcpServers` (Cursor-compatible project shape)
+- existing `opencode.json`, if present, uses `mcp` with translated transport
+  keys
 
 Source of truth:
 

--- a/tooling/lib/compose.sh
+++ b/tooling/lib/compose.sh
@@ -949,7 +949,6 @@ $MARKER_START
 # Vendor entry-point files — recreated by \`agentic switch\` / \`agentic sync\`
 CLAUDE.md
 GEMINI.md
-opencode.json
 .github/copilot-instructions.md
 .github/instructions/
 .gemini/system.md
@@ -971,7 +970,6 @@ $MARKER_START
 # Vendor entry-point files — recreated by \`agentic switch\` / \`agentic sync\`
 CLAUDE.md
 GEMINI.md
-opencode.json
 .github/copilot-instructions.md
 .github/instructions/
 .gemini/system.md

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -1023,6 +1023,7 @@ assert_file_not_contains "$TMP/t41/.gitignore" "AGENTS.md" "T41"
 assert_file_not_contains "$TMP/t41/.gitignore" "config.yaml" "T41"
 assert_file_not_contains "$TMP/t41/.gitignore" "profile.yaml" "T41"
 assert_file_not_contains "$TMP/t41/.gitignore" "project-skills" "T41"
+assert_file_not_contains "$TMP/t41/.gitignore" "opencode.json" "T41"
 # Copy mode: runtime dirs must NOT be ignored (they are real committed files in copy mode)
 assert_file_not_contains "$TMP/t41/.gitignore" ".agentic/skills/" "T41"
 assert_file_not_contains "$TMP/t41/.gitignore" ".agentic/fragments/" "T41"
@@ -1092,6 +1093,7 @@ assert_file_contains "$TMP/t_gu/.gitignore" "*.log" "T_GITIGNORE_UPDATE_BLOCK"
 assert_file_contains "$TMP/t_gu/.gitignore" "node_modules/" "T_GITIGNORE_UPDATE_BLOCK"
 # New entry from current canonical block must be present
 assert_file_contains "$TMP/t_gu/.gitignore" "GEMINI.md" "T_GITIGNORE_UPDATE_BLOCK"
+assert_file_not_contains "$TMP/t_gu/.gitignore" "opencode.json" "T_GITIGNORE_UPDATE_BLOCK"
 
 # T_GITIGNORE_STRIP_STALE_LINK_TAIL — stale legacy link-mode tail is folded into managed block
 run_test "T_GITIGNORE_STRIP_STALE_LINK_TAIL — stale link-mode tail is removed"


### PR DESCRIPTION
## Summary
- stop treating opencode.json as an agentic-managed gitignore entry
- clarify in docs that agentic only seeds an existing opencode.json when projects already own one
- add a regression so the managed block cannot reintroduce opencode.json

## Testing
- shellcheck -x tooling/lib/compose.sh tooling/lib/test.sh
- just test