### PR TITLE
feat(skills): add terraform safety core

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -25,7 +25,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 - `serverless-architecture` — Design and implement serverless workloads with operational guardrails.
 - `sql-query-optimization` — Diagnose and optimize SQL performance using plans, indexes, and rewrites.
 - `technical-roadmap-planning` — Build prioritized engineering roadmaps with dependencies and milestones.
-- `terraform-infrastructure` — Structure and review Terraform IaC modules, state, and pipelines.
+- `terraform-infrastructure` — Structure Terraform repo/stack layout, state topology, CI flow, and multi-region composition.
 - `webhook-development` — Build secure, reliable webhook receivers/senders with retries and idempotency.
 
 ### Data
@@ -58,6 +58,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 - `create-terraform-module` — Create AWS-oriented Terraform module scaffolding with explicit interfaces, provider constraints, and reusable layout guardrails.
 - `create-terraform-tests` — Design and implement risk-focused Terraform module tests (`terraform test`) with CI-friendly validation flow.
 - `design-aws-terraform-iac` — Plan AWS Terraform architecture, service/module boundaries, state strategy, and acceptance criteria before implementation.
+- `terraform-risk-playbook` — Diagnose Terraform/OpenTofu risk first, enforce response contract, version guards, validation, and rollback expectations.
 - `docker-compose-local-setup` — Configure local multi-service `docker compose` stacks with readiness, envs, volumes, migrations, and verification.
 - `use-aws-mini-stack-emulator` — Use lightweight AWS emulation safely for local Terraform feedback loops, with explicit handoff to real AWS checks.
 - `write-dockerfile` — Generate production-ready Dockerfiles with secure, efficient build patterns.

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-30T18:21:40Z",
+  "generated_at": "2026-06-27T19:20:55Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -214,7 +214,7 @@
       "group": "backend",
       "path": "skills/backend/terraform-infrastructure/SKILL.md",
       "description": "Structures, writes, and reviews Terraform infrastructure code. Covers module layout, remote state, workspace strategy, v",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "tags": [
         "devops",
         "terraform",
@@ -486,7 +486,7 @@
       "group": "devops",
       "path": "skills/devops/create-terraform-module/SKILL.md",
       "description": "Creates or updates AWS-oriented Terraform module structure and implementation scaffolding. Focuses on file layout, varia",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "tags": [
         "devops",
         "terraform",
@@ -499,7 +499,7 @@
       "group": "devops",
       "path": "skills/devops/create-terraform-tests/SKILL.md",
       "description": "Designs and implements Terraform module tests for AWS-targeted modules. Covers terraform-native tests, validation gates,",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "tags": [
         "devops",
         "terraform",
@@ -512,7 +512,7 @@
       "group": "devops",
       "path": "skills/devops/design-aws-terraform-iac/SKILL.md",
       "description": "Designs AWS-targeted Terraform infrastructure plans before implementation. Focuses on service selection, module boundari",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "tags": [
         "devops",
         "terraform",
@@ -535,11 +535,25 @@
       ]
     },
     {
+      "name": "terraform-risk-playbook",
+      "group": "devops",
+      "path": "skills/devops/terraform-risk-playbook/SKILL.md",
+      "description": "Diagnoses Terraform/OpenTofu risk before generating changes. Defines the response contract, failure-mode routing, versio",
+      "version": "1.0.0",
+      "tags": [
+        "devops",
+        "terraform",
+        "opentofu",
+        "safety",
+        "iac"
+      ]
+    },
+    {
       "name": "use-aws-mini-stack-emulator",
       "group": "devops",
       "path": "skills/devops/use-aws-mini-stack-emulator/SKILL.md",
       "description": "Uses lightweight AWS stack emulation for faster local Terraform iteration. Defines what can be safely validated locally,",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "tags": [
         "devops",
         "terraform",

--- a/profiles/hcl-aws-terraform-module.yaml
+++ b/profiles/hcl-aws-terraform-module.yaml
@@ -5,7 +5,7 @@ meta:
     AWS-focused Terraform module profile for designing, implementing, and testing
     reusable infrastructure modules with explicit state, security, and validation
     guardrails.
-  version: "1.0.1"
+  version: "1.0.2"
 
 fragments:
   base:
@@ -29,6 +29,7 @@ tech_stack:
 
 skills:
   - project-map
+  - terraform-risk-playbook
   - design-aws-terraform-iac
   - create-terraform-module
   - create-terraform-tests

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -216,6 +216,7 @@
           "sync-confluence",
           "technical-roadmap-planning",
           "terraform-infrastructure",
+          "terraform-risk-playbook",
           "use-aws-mini-stack-emulator",
           "vue-application-structure",
           "vue-component-design",

--- a/skills/backend/terraform-infrastructure/SKILL.md
+++ b/skills/backend/terraform-infrastructure/SKILL.md
@@ -4,9 +4,11 @@ description: >
   Structures, writes, and reviews Terraform infrastructure code. Covers module
   layout, remote state, workspace strategy, variable and secrets handling, CI
   plan/apply pipeline, naming conventions, and multi-region deployment patterns
-  (provider aliases, per-region state, failover strategies). Invoked when the
-  user asks to write Terraform, set up infrastructure as code, or review IaC.
-version: 1.1.0
+  (provider aliases, per-region state, failover strategies), while delegating
+  shared risk classification, version guards, and rollback contract to
+  `terraform-risk-playbook`. Invoked when the user asks to write Terraform, set
+  up infrastructure as code, or review IaC.
+version: 1.2.0
 tags:
   - devops
   - terraform
@@ -22,6 +24,14 @@ vendor_support:
 ---
 
 ## Terraform Infrastructure Skill
+
+Always use `terraform-risk-playbook` first when this skill is active. That
+skill is authoritative for the response contract, risk classification,
+runtime/version assumptions, validation commands, and rollback notes.
+
+Authoritative precedence: when this skill and other Terraform skills are both
+active, this skill is authoritative for repo and stack layout, backend topology,
+CI composition, and multi-region deployment structure.
 
 ### Step 1 — Module Structure
 
@@ -60,7 +70,8 @@ Rules:
 
 ### Step 2 — Remote State
 
-Use S3 + DynamoDB for state locking (AWS):
+Use S3 remote state for AWS. Prefer native S3 lock files on Terraform 1.10+ and
+fall back to DynamoDB locking only for older runtime compatibility:
 
 ```hcl
 # environments/staging/backend.tf
@@ -69,8 +80,8 @@ terraform {
     bucket         = "acme-terraform-state"
     key            = "staging/terraform.tfstate"
     region         = "us-east-1"
-    dynamodb_table = "acme-terraform-locks"
     encrypt        = true
+    use_lockfile   = true
   }
 }
 ```
@@ -80,6 +91,10 @@ State bucket requirements:
 - Server-side encryption enabled (SSE-S3 or SSE-KMS).
 - Block all public access.
 - Access restricted to CI role and infrastructure team.
+
+If the runtime is older than Terraform 1.10, replace `use_lockfile = true` with
+`dynamodb_table = "acme-terraform-locks"` and state that compatibility choice
+explicitly.
 
 ### Step 3 — Workspace Strategy
 
@@ -117,6 +132,9 @@ Rules:
 - Never commit `*.tfvars` files that contain secrets to version control.
 
 ### Step 5 — CI Plan / Apply Pipeline
+
+This reviewed-plan-artifact pattern is the default for production-impacting
+changes. Do not re-run plan inside the apply job.
 
 ```yaml
 # .github/workflows/terraform.yml
@@ -377,6 +395,10 @@ resource "aws_cloudwatch_metric_alarm" "replication_lag" {
 
 ### Step 11 — Multi-Region CI Pipeline
 
+Use the dependency order below for global -> primary region -> secondary
+regions. Keep the reviewed-plan-artifact and approval model from Step 5 for each
+stage rather than applying unreviewed changes directly.
+
 Apply global resources first, then the primary region, then secondary regions in parallel:
 
 ```yaml
@@ -426,6 +448,8 @@ jobs:
 - `configuration_aliases` must be declared inside `terraform { required_providers { ... } }` in the child module.
 - Always set `region` explicitly in `terraform_remote_state` config blocks.
 - Do not store all state in one region — use per-region S3 buckets to avoid a regional outage blocking applies elsewhere.
+- Do not bypass the reviewed plan artifact pattern for production-impacting
+  multi-region changes.
 
 ### Verify
 

--- a/skills/devops/create-terraform-module/SKILL.md
+++ b/skills/devops/create-terraform-module/SKILL.md
@@ -3,8 +3,9 @@ name: create-terraform-module
 description: >
   Creates or updates AWS-oriented Terraform module structure and implementation
   scaffolding. Focuses on file layout, variable/output contracts, provider and
-  version constraints, tagging standards, and safe composition patterns.
-version: 1.0.0
+  version constraints, tagging standards, safe composition patterns, and
+  address-stability guardrails.
+version: 1.1.0
 tags:
   - devops
   - terraform
@@ -23,6 +24,10 @@ vendor_support:
 ## Create Terraform Module Skill
 
 Create or revise Terraform module implementation details for AWS workloads.
+
+Always pair this skill with `terraform-risk-playbook`. That skill is
+authoritative for the response contract, risk category, version/runtime floor,
+validation expectations, and rollback notes.
 
 Authoritative precedence: when this skill and `terraform-infrastructure` are both
 active, this skill is authoritative for module layout, file set, and module
@@ -57,6 +62,12 @@ Implementation guardrails:
 - explicit `required_providers` and Terraform version constraints
 - `lifecycle` usage only when justified and documented
 - stable resource addressing to reduce churn in plans
+- prefer `for_each` over `count` when item identity must survive reordering or
+  selective removal
+- when refactoring addresses, emit `moved` blocks or explicit migration notes
+  instead of rename-only changes
+- verify runtime floor before suggesting `import`, `moved`, `optional()`, mock
+  providers, or `write_only` patterns
 - no plaintext secrets in code or defaults
 
 ### Step 4 - Add Example Consumer and Validation Steps

--- a/skills/devops/create-terraform-tests/SKILL.md
+++ b/skills/devops/create-terraform-tests/SKILL.md
@@ -3,8 +3,9 @@ name: create-terraform-tests
 description: >
   Designs and implements Terraform module tests for AWS-targeted modules.
   Covers terraform-native tests, validation gates, fixture composition, and
-  risk-focused assertions for regressions and unsafe changes.
-version: 1.0.0
+  risk-focused assertions for regressions, address migration, and unsafe
+  changes.
+version: 1.1.0
 tags:
   - devops
   - terraform
@@ -24,6 +25,10 @@ vendor_support:
 
 Author Terraform test coverage for AWS modules.
 
+Always pair this skill with `terraform-risk-playbook`. That skill is
+authoritative for the response contract, risk classification, version/runtime
+guards, validation chain, and rollback notes.
+
 Authoritative precedence: when this skill and `terraform-infrastructure` are both
 active, this skill is authoritative for module testing strategy, test layout,
 and assertion patterns.
@@ -35,6 +40,8 @@ Prioritize tests for:
 - destructive change prevention for stateful resources
 - required inputs and invalid configuration rejection
 - output contract stability
+- identity and address migration safety (`count`/`for_each`, `moved` flows)
+- provider/runtime upgrade compatibility when version constraints change
 
 ### Step 2 - Implement Terraform-Native Test Layout
 
@@ -44,6 +51,8 @@ Minimum coverage:
 - happy path apply/plan expectations
 - invalid input validation checks
 - policy/security checks for sensitive resources
+- choose `command = apply` when assertions depend on computed values or set-type
+  nested blocks
 
 ### Step 3 - Add CI-Friendly Validation Chain
 
@@ -57,6 +66,8 @@ CI safety guardrails:
 - do not point tests at production/shared backends
 - use ephemeral credentials/accounts for apply-capable tests
 - skip or scope tests when required cloud credentials are not present
+- if the risk category includes compliance or secret exposure, include the
+  repo's existing policy/security checks where applicable
 
 ### Step 4 - Keep Tests Bounded
 
@@ -66,3 +77,5 @@ requested. Document emulator vs real-AWS assumptions clearly.
 ### Step 5 - Report Coverage Gaps
 
 Summarize what is covered, known blind spots, and next highest-value tests.
+Call out whether each scenario is plan-only confidence, emulator confidence, or
+real-cloud confidence.

--- a/skills/devops/design-aws-terraform-iac/SKILL.md
+++ b/skills/devops/design-aws-terraform-iac/SKILL.md
@@ -3,8 +3,9 @@ name: design-aws-terraform-iac
 description: >
   Designs AWS-targeted Terraform infrastructure plans before implementation.
   Focuses on service selection, module boundaries, state/backends, environment
-  separation, security/compliance guardrails, and acceptance criteria.
-version: 1.0.0
+  separation, security/compliance guardrails, acceptance criteria, and explicit
+  risk/validation assumptions.
+version: 1.1.0
 tags:
   - devops
   - terraform
@@ -26,12 +27,18 @@ vendor_support:
 
 Design AWS Terraform infrastructure before writing module code.
 
+Always pair this skill with `terraform-risk-playbook`. That skill is
+authoritative for the response contract, failure-mode classification,
+version/runtime guards, validation chain, and rollback notes.
+
 ### Step 1 - Confirm Scope and Constraints
 
 Capture required outcomes:
 - workloads and critical paths
 - regions, environments, and compliance constraints
 - cost boundaries and availability targets
+- runtime and version assumptions
+- backend and execution path assumptions (local, CI, Terraform Cloud, Atlantis)
 
 Capture non-goals to prevent accidental over-design.
 
@@ -71,6 +78,8 @@ Output a compact design brief with:
 - service choices and tradeoffs
 - module map and dependency order
 - state strategy and CI plan/apply gate strategy
+- explicit risk categories and validation expectations
+- rollback notes for destructive or state-mutating steps
 - measurable acceptance checks from `acceptance-checklist.md`
 
 This skill is planning-first. For module file layout and implementation details,

--- a/skills/devops/terraform-risk-playbook/SKILL.md
+++ b/skills/devops/terraform-risk-playbook/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: terraform-risk-playbook
+description: >
+  Diagnoses Terraform/OpenTofu risk before generating changes. Defines the
+  response contract, failure-mode routing, version/runtime guards, validation
+  commands, and rollback expectations for modules, tests, CI, and state work.
+version: 1.0.0
+tags:
+  - devops
+  - terraform
+  - opentofu
+  - safety
+  - iac
+resources:
+  - risk-routing.md
+  - version-runtime-matrix.md
+  - llm-mistake-checklist.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Terraform Risk Playbook Skill
+
+Use this skill first for any Terraform or OpenTofu task that plans changes,
+reviews risk, debugs drift/state/CI issues, or proposes destructive or
+state-mutating operations.
+
+### Step 1 - Emit the Response Contract
+
+Every response must include:
+- assumptions and version floor:
+  runtime (`terraform` or `tofu`), exact or assumed version, providers,
+  backend, execution path (local, CI, Cloud, Atlantis), environment criticality
+- risk category addressed
+- chosen remediation and tradeoffs
+- validation plan with exact commands tailored to the risk tier
+- rollback notes for destructive or state-mutating changes
+
+Mandatory rules:
+- never recommend direct production apply without a reviewed plan artifact and
+  explicit approval
+- never recommend `destroy` before `plan -destroy` has been reviewed
+- never use `-auto-approve` for destroy guidance
+
+### Step 2 - Diagnose Before You Generate
+
+Use `risk-routing.md` to classify the failure mode before suggesting code,
+module changes, test strategy, CI updates, or state operations.
+
+If the task spans multiple failure modes, cover each one explicitly instead of
+collapsing them into a single generic fix.
+
+### Step 3 - Apply Version and Runtime Guards
+
+Use `version-runtime-matrix.md` before recommending:
+- `moved`, `import`, `removed`, `check`, mock providers, `write_only`
+- S3 `use_lockfile`
+- native `terraform test` / `tofu test`
+
+If the runtime/version is unknown, state the assumption before suggesting
+version-sensitive patterns.
+
+### Step 4 - Run the LLM Mistake Checklist
+
+Use `llm-mistake-checklist.md` before finalizing guidance that touches:
+- resource identity or address changes
+- secrets handling
+- provider/runtime upgrades
+- plan/apply workflow
+- set-type assertions or computed values in tests
+
+### Step 5 - Handoff to the Right Terraform Skill
+
+This skill is the shared safety layer. It does not own implementation details.
+
+Use:
+- `design-aws-terraform-iac` for architecture, service boundaries, backend
+  strategy, and acceptance criteria
+- `create-terraform-module` for module layout, variables/outputs, examples, and
+  implementation scaffolding
+- `create-terraform-tests` for `terraform test`, fixtures, and risk-focused test
+  coverage
+- `terraform-infrastructure` for repo/stack structure, CI composition, and
+  multi-region patterns
+- `use-aws-mini-stack-emulator` for local AWS emulation limits and handoff to
+  real-cloud validation

--- a/skills/devops/terraform-risk-playbook/llm-mistake-checklist.md
+++ b/skills/devops/terraform-risk-playbook/llm-mistake-checklist.md
@@ -1,0 +1,23 @@
+## Terraform LLM Mistake Checklist
+
+Check these before finalizing Terraform or OpenTofu guidance.
+
+- Do not use list index as long-lived identity if item order can change.
+  Prefer `for_each` when address stability matters.
+- Do not rename resources/modules textually without discussing `moved` blocks or
+  equivalent migration steps.
+- Do not treat `sensitive = true` as state protection. It masks display only.
+- Do not suggest storing secrets in defaults, committed `.tfvars`, outputs, or
+  long-lived CI artifacts.
+- Do not mix provider/runtime upgrades with functional changes unless the user
+  explicitly asks for both and the upgrade risk is called out.
+- Do not recommend re-running `plan` inside apply jobs for production-impacting
+  workflows when a reviewed artifact should be applied.
+- Do not assume computed values are available in plan-time tests; switch to
+  apply-capable tests when needed.
+- Do not index set-type nested blocks with `[0]`; use expressions that do not
+  depend on set ordering.
+- Do not recommend `terraform destroy` without `plan -destroy`, explicit review,
+  and rollback notes.
+- Do not recommend shared production and non-production state or local state for
+  team or production workflows.

--- a/skills/devops/terraform-risk-playbook/risk-routing.md
+++ b/skills/devops/terraform-risk-playbook/risk-routing.md
@@ -1,0 +1,22 @@
+## Terraform Risk Routing
+
+Classify the task before proposing changes.
+
+| Risk category | Common symptoms | Mandatory guardrails | Primary handoff |
+|---|---|---|---|
+| Identity churn | `count` index reshuffle, renamed resources/modules, missing `moved` blocks | explain address migration path, avoid blind rename, validate zero unexpected destroy | `create-terraform-module` |
+| Secret exposure | secrets in defaults, outputs, state, CI logs, `.tfvars` | do not rely on `sensitive = true` as state protection, prefer references/runtime lookup, check state/log exposure | `design-aws-terraform-iac` |
+| Blast radius | oversized stacks, shared state, risky prod apply, unclear destroy impact | reviewed `plan -out`, explicit approval, split state if lifecycle differs | `terraform-infrastructure` |
+| CI drift | local plan differs from CI, apply reruns plan, unpinned versions | pin runtime/providers, apply reviewed artifact, record execution-path assumptions | `terraform-infrastructure` |
+| Compliance gaps | missing policy stage, weak approvals, no evidence retention | add policy/security checks and approval model where applicable | `design-aws-terraform-iac` |
+| Testing blind spots | plan-only assertions for computed values, mock/real confusion, set indexing mistakes | choose `plan` vs `apply` tests intentionally, state confidence limits | `create-terraform-tests` |
+| State corruption / recovery | stuck lock, backend migration, drift reconciliation | protect evidence, document rollback and recovery sequence before mutation | `terraform-infrastructure` |
+| Provider upgrade risk | breaking provider bump, runtime bump mixed with functional changes | isolate upgrade diff, pin versions, validate migration notes | `create-terraform-module` |
+| Provider lifecycle | removing provider with live state, orphaned resources, `removed` usage | require explicit state transition or removal plan | `terraform-infrastructure` |
+| Provisioner misuse | `null_resource`, `local-exec`, `remote-exec` for durable workflows | treat as last resort, call out secret/logging risk and lifecycle drift | `create-terraform-module` |
+
+Default validation expectations by risk tier:
+- low: `terraform fmt -check -recursive`, `terraform validate`
+- medium: add `terraform plan -out=tfplan` or `terraform test`
+- high: reviewed plan artifact, approval gate, rollback notes, and any policy or
+  security checks the repo already uses

--- a/skills/devops/terraform-risk-playbook/version-runtime-matrix.md
+++ b/skills/devops/terraform-risk-playbook/version-runtime-matrix.md
@@ -1,0 +1,25 @@
+## Terraform and OpenTofu Version Guard Matrix
+
+Use this matrix before suggesting version-sensitive features.
+
+| Feature or pattern | Minimum Terraform version | Guidance |
+|---|---|---|
+| `moved` blocks | 1.1+ | use for safe address refactors instead of rename-only edits |
+| `nullable = false` | 1.1+ | prevent silent `null` override of defaults |
+| `optional()` with typed defaults | 1.3+ | prefer over loose `map(any)` interfaces |
+| `import` blocks | 1.5+ | prefer declarative import flow when runtime supports it |
+| `check` blocks | 1.5+ | use for runtime assertions where applicable |
+| native `terraform test` | 1.6+ | prefer for module-level validation before heavier integration tests |
+| mock providers | 1.7+ | useful for low-cost unit-style tests; still keep real-cloud validation for final confidence |
+| `removed` blocks | 1.7+ | use for explicit lifecycle/removal transitions |
+| cross-variable validation | 1.9+ | call out runtime floor before referencing other vars in `validation` |
+| S3 `use_lockfile` | 1.10+ | preferred default for new S3 backends; older runtimes may still need DynamoDB locking |
+| `write_only` arguments | 1.11+ | use when supported to keep secret values out of state |
+
+Runtime assumptions:
+- if the user does not specify runtime, state whether guidance assumes
+  `terraform` or `tofu`
+- if the runtime is OpenTofu and the feature is newer or provider-specific,
+  instruct the user to verify exact feature parity before adoption
+- if runtime and backend are both unknown, assume the lowest safe guidance path
+  and disclose that assumption explicitly

--- a/skills/devops/use-aws-mini-stack-emulator/SKILL.md
+++ b/skills/devops/use-aws-mini-stack-emulator/SKILL.md
@@ -3,8 +3,8 @@ name: use-aws-mini-stack-emulator
 description: >
   Uses lightweight AWS stack emulation for faster local Terraform iteration.
   Defines what can be safely validated locally, compatibility caveats, and the
-  handoff boundary to real-AWS verification.
-version: 1.0.0
+  handoff boundary to real-AWS verification and reviewed plan/apply flows.
+version: 1.1.0
 tags:
   - devops
   - terraform
@@ -23,6 +23,10 @@ vendor_support:
 ## Use AWS Mini Stack Emulator Skill
 
 Use local AWS emulation to accelerate Terraform feedback loops where appropriate.
+
+Always pair this skill with `terraform-risk-playbook`. That skill is
+authoritative for the response contract, failure-mode classification,
+version/runtime guards, validation chain, and rollback notes.
 
 ### Step 1 - Select Emulator Scope
 
@@ -56,6 +60,12 @@ AWS validation before merge.
 
 This skill is for local acceleration only. It does not replace real AWS plan/apply
 verification for production-impacting infrastructure.
+
+It cannot prove:
+- production backend locking or state migration behavior
+- IAM or service semantics that emulators do not model faithfully
+- reviewed plan artifact and approval parity in CI
+- final confidence for production-impacting provider/runtime upgrades
 
 Avoid overlap with `docker-compose-local-setup`: this skill covers Terraform + AWS
 emulation behavior, not generic multi-service compose orchestration design.


### PR DESCRIPTION
## Summary

This PR strengthens the Terraform skill set by adding a shared safety and
diagnostics layer, then wiring the existing Terraform skills to use it
explicitly.

The goal is to keep the current split by intent (design, module authoring,
testing, infrastructure structure, emulator usage) while importing the
strongest parts of Anton Babenko's Terraform skill: response contract
discipline, diagnose-first routing, version-aware guards, and common LLM
mistake prevention.

## Why

Our Terraform skills were already strong on AWS-focused structure, module
authoring, and terraform-native testing, but the safety guidance was spread
across multiple skills and not expressed as one consistent contract.

This created a few gaps:
- runtime and version assumptions were not always explicit
- risk categories like identity churn, CI drift, blast radius, and state
  recovery were not routed consistently
- rollback expectations for destructive or state-mutating guidance were not
  centralized
- version-sensitive recommendations like moved blocks, import blocks, mock
  providers, write_only, and S3 use_lockfile were not governed by one shared
  runtime matrix

## What changed

### New shared Terraform skill

Added `terraform-risk-playbook` as a new shared Terraform safety core.

It defines:
- the response contract every Terraform/OpenTofu answer should follow
- a diagnose-first routing table for common Terraform failure modes
- a version/runtime guard matrix for feature-sensitive guidance
- an LLM mistake checklist for common Terraform errors and unsafe
  recommendations

### Existing Terraform skills now delegate shared safety behavior

Updated the existing Terraform skills so they explicitly treat
`terraform-risk-playbook` as the shared safety layer instead of each one
partially reinventing it.

That means:
- `design-aws-terraform-iac` now emphasizes explicit runtime/backend
  assumptions, risk categories, validation expectations, and rollback notes in
  the design brief
- `create-terraform-module` now calls out address-stability guardrails, prefers
  `for_each` over `count` where identity matters, and requires migration notes
  or `moved` blocks for address refactors
- `create-terraform-tests` now maps risk categories to test coverage more
  explicitly, including identity churn, provider/runtime upgrade compatibility,
  computed-value assertions, and confidence-level reporting
- `terraform-infrastructure` now states its authoritative scope more clearly,
  delegates shared safety concerns to the new playbook, and updates its backend
  guidance to prefer `use_lockfile` on Terraform 1.10+ with DynamoDB locking
  framed as an older-runtime compatibility path
- `use-aws-mini-stack-emulator` now makes the emulator boundary more explicit by
  documenting what local emulation cannot prove for production-impacting
  changes

### Profile and catalog updates

- added `terraform-risk-playbook` to the
  `hcl-aws-terraform-module` profile so Terraform-focused projects receive the
  shared safety layer by default
- updated `docs/skills.md` to describe the new skill and to tighten the wording
  for `terraform-infrastructure`
- rebuilt `index/skills.json`
- updated `schemas/profile.schema.json` so the new skill is part of the allowed
  profile skill enum

## Design intent

This PR does not collapse the Terraform skills into one monolithic skill.

Instead, it keeps the existing separation of concerns and makes it safer:
- the new playbook owns shared safety, routing, runtime/version assumptions,
  validation contract, and rollback expectations
- the existing skills continue to own their specific implementation domains

This keeps the skill family modular while removing duplicated or inconsistent
safety guidance.

## Validation

Ran:
- `just index`
- `just lint`

## Files touched

Primary changes are limited to:
- Terraform skill docs under `skills/devops/` and `skills/backend/`
- `profiles/hcl-aws-terraform-module.yaml`
- `docs/skills.md`
- generated metadata: `index/skills.json`, `schemas/profile.schema.json`

No runtime tooling behavior changed in this PR.
