### PR TITLE
feat(profiles): add rsbuild module federation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ agentic list profiles|skills|vendors          # list available resources
 
 ## Profiles
 
-23 ready-made profiles covering TypeScript, Go, Python, PHP, HCL — frontend SPAs, microservices, CLIs, full-stack, and AWS Terraform modules.
+24 ready-made profiles covering TypeScript, Go, Python, PHP, HCL — frontend SPAs, microservices, CLIs, full-stack, Module Federation, and AWS Terraform modules.
 
 → [Browse all profiles](https://agentic.soulcodex.link/profiles)
 

--- a/agents/architecture/module-federation.md
+++ b/agents/architecture/module-federation.md
@@ -2,11 +2,14 @@
 
 ### Default Stack
 
-- Use Rsbuild as the default build tool for new Module Federation hosts and remotes.
+- Separate client-rendered federation from SSR federation before choosing tools.
+- Use Rsbuild as the default build tool for new client-rendered Module Federation hosts and remotes.
 - Use `@module-federation/rsbuild-plugin` for Rsbuild integration.
 - Keep Module Federation configuration in a dedicated `module-federation.config.ts` file.
 - Register Module Federation from the application build config with `pluginModuleFederation(...)`.
 - Use Vitest for unit and component tests. Use Playwright for routed host/remote smoke checks.
+- For new SSR Module Federation applications, prefer an officially supported full-stack path such as Modern.js. Use Rslib for remotes that must publish both browser and Node artifacts.
+- Treat Nuxt SSR federation as beta until the target deployment, cache, and server entry constraints are proven in the project. Treat Next.js Module Federation as legacy Pages Router maintenance only.
 
 ### Host And Remote Boundaries
 
@@ -16,6 +19,17 @@
 - Keep `remotes` owned by the host that consumes the module.
 - Do not let a remote reach into host internals. Shared state, routing, analytics, auth, and design-system contracts should cross through explicit APIs, shared packages, or documented runtime contracts.
 - Prefer small, feature-level exposed entry points over exposing broad folders or application roots.
+
+### SSR Boundaries
+
+- Decide whether an SSR app only contains client-rendered federated islands, or whether the remote must participate in server render and hydration. These are different architectures.
+- For true SSR federation, the host server must be able to resolve the remote manifest, load the server entry, render the exposed module, and hydrate the same component graph in the browser.
+- Publish and promote matching server and browser artifacts together. Do not rebuild a remote separately for each environment.
+- Keep per-request data, auth, cookies, locale, and tracing context host-owned. Pass only explicit request-scoped inputs to remotes.
+- Do not let SSR remotes depend on mutable process globals, browser-only APIs during server render, or hidden host state.
+- Make fallback behavior explicit. A server-render failure may fail the route, render a known fallback, or switch to a client-only island only when product requirements accept that behavior.
+- Do not use `@module-federation/nextjs-mf` for new Next.js App Router SSR work. It is a legacy Pages Router path and needs a documented exception.
+- Do not use beta Nuxt SSR federation on read-only or serverless runtimes unless SSR federation is disabled or the cache/write behavior is handled intentionally.
 
 ### Shared Dependencies
 
@@ -38,10 +52,13 @@
 - Prefer manifest-based remotes such as `mf-manifest.json` for Rsbuild projects.
 - Keep runtime plugin behavior isolated from domain or feature logic.
 - For loading failures, inspect the remote manifest or remote entry URL first, then use Module Federation observability data when the failure needs phase-level evidence.
+- For SSR failures, collect both server-side and browser-side evidence. Check the server entry, client entry, request trace, hydration result, shared dependency negotiation, and any generated `.mf/observability/*` reports.
 - Redact captured DOM, storage, cookies, tokens, and application state from reports and handoffs unless the user explicitly asks to share them.
 
 ### CI Gates
 
 - Run lint/static analysis first, then Vitest, then the Rsbuild production build.
+- Use Rslint for new TypeScript/JavaScript linting when its rule coverage fits the project. Keep commitlint in Node-capable repositories that enforce Conventional Commits.
 - Add a host/remote smoke check when a change touches public exposes, remote URLs, shared dependency policy, runtime plugins, or deployment paths.
+- For SSR federation, add a route-level smoke check that verifies rendered HTML, hydration, remote fallback behavior, and server reachability for the remote manifest or entry.
 - Validate published artifacts once and promote the same build output through environments. Do not rebuild host and remote artifacts differently for staging and production.

--- a/agents/architecture/module-federation.md
+++ b/agents/architecture/module-federation.md
@@ -1,0 +1,47 @@
+## Module Federation
+
+### Default Stack
+
+- Use Rsbuild as the default build tool for new Module Federation hosts and remotes.
+- Use `@module-federation/rsbuild-plugin` for Rsbuild integration.
+- Keep Module Federation configuration in a dedicated `module-federation.config.ts` file.
+- Register Module Federation from the application build config with `pluginModuleFederation(...)`.
+- Use Vitest for unit and component tests. Use Playwright for routed host/remote smoke checks.
+
+### Host And Remote Boundaries
+
+- Name each federated app explicitly. Use snake_case names and avoid hyphens in Module Federation names.
+- Treat exposed modules as public runtime contracts. Changing an exposed key, module shape, or exported component API is a consumer-facing change.
+- Keep `exposes` owned by the remote that publishes the module.
+- Keep `remotes` owned by the host that consumes the module.
+- Do not let a remote reach into host internals. Shared state, routing, analytics, auth, and design-system contracts should cross through explicit APIs, shared packages, or documented runtime contracts.
+- Prefer small, feature-level exposed entry points over exposing broad folders or application roots.
+
+### Shared Dependencies
+
+- Share framework singletons deliberately. React apps should share `react` and `react-dom` as singletons. Vue apps should share `vue` as a singleton.
+- Do not configure the same package as both `shared` and `externals`.
+- Keep singleton dependency versions aligned across host and remotes. Use aliases or workspace constraints when resolution would otherwise install multiple physical copies.
+- Disable import rewriting for shared UI libraries when it prevents the shared dependency from being recognized. In Rsbuild and Modern.js, check `source.transformImport` before sharing libraries such as antd or Arco.
+
+### Type Contracts
+
+- Keep federated TypeScript contracts generated and consumed through Module Federation type support.
+- Producers should emit remote type artifacts as part of the build.
+- Consumers should pull remote types and configure `@mf-types` resolution only when the project needs remote type imports.
+- Do not patch remote imports with local hand-written declarations unless the producer cannot emit types yet. Treat temporary declarations as migration debt with an owner.
+- Run the narrowest type check that proves the affected host or remote contract. For producer type failures, reproduce against the temporary TypeScript config emitted by Module Federation diagnostics when available.
+
+### Runtime And Observability
+
+- Verify a federated change from both sides: the remote must publish the manifest and exposed module, and the host must load it from the configured URL.
+- Prefer manifest-based remotes such as `mf-manifest.json` for Rsbuild projects.
+- Keep runtime plugin behavior isolated from domain or feature logic.
+- For loading failures, inspect the remote manifest or remote entry URL first, then use Module Federation observability data when the failure needs phase-level evidence.
+- Redact captured DOM, storage, cookies, tokens, and application state from reports and handoffs unless the user explicitly asks to share them.
+
+### CI Gates
+
+- Run lint/static analysis first, then Vitest, then the Rsbuild production build.
+- Add a host/remote smoke check when a change touches public exposes, remote URLs, shared dependency policy, runtime plugins, or deployment paths.
+- Validate published artifacts once and promote the same build output through environments. Do not rebuild host and remote artifacts differently for staging and production.

--- a/agents/base/git-conventions.md
+++ b/agents/base/git-conventions.md
@@ -17,6 +17,9 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`, `ci`, `build`
 - Summary is imperative, lowercase, no period, max 72 characters.
 - Body wraps at 100 characters. Explain *why*, not *what*.
 - Reference issue numbers in footer: `Closes #123`, `Refs #456`.
+- In Node-capable repositories, enforce this format with commitlint
+  (`@commitlint/cli` plus `@commitlint/config-conventional`) from a `commit-msg`
+  hook or CI commit-range check.
 
 Examples:
 ```

--- a/agents/languages/typescript.md
+++ b/agents/languages/typescript.md
@@ -189,8 +189,20 @@ const total = subtotal + subtotal * tax // precision risk
 
 ### Code Style
 
-- Use `pnpm` as the package manager.
-- Format with Prettier (`.prettierrc` in repo root); lint with ESLint (flat config `eslint.config.ts`).
+- Use pnpm 12 as the package manager baseline for new TypeScript projects.
+- Do not use Corepack to install pnpm. For pnpm 12, install or update with
+  `pnpm self-update next-12`, `npx get-pnpm next-12`, or the standalone installer
+  with `PNPM_VERSION=next-12`.
+- Use Rsbuild as the default build tool for React/Vue SPA applications and
+  micro-frontend hosts/remotes. Framework-owned stacks such as Next.js and Nuxt
+  keep their framework build layer unless project instructions say otherwise.
+- Use Vitest as the default unit and component test runner.
+- Format with Prettier when the repo has a Prettier config.
+- Lint TypeScript and JavaScript with Rslint (`@rslint/core`) for new projects
+  or when replacing lint tooling is in scope. If a repo already has ESLint,
+  inspect its config and migration cost before replacing it.
+- Use commitlint in Node-capable repositories to enforce Conventional Commit
+  messages in a `commit-msg` hook or CI commit-range check.
 - Prefer `const` over `let`; never use `var`.
 - Prefer named exports over default exports for better refactoring support.
 - Keep functions small (fits on a screen). Extract when logic becomes layered.

--- a/agents/practices/ci-cd.md
+++ b/agents/practices/ci-cd.md
@@ -9,6 +9,14 @@ Every push to a feature branch must trigger:
 4. **Integration tests** — against real dependencies in containers (testcontainers, docker-compose)
 5. **Security scan** — dependency audit, SAST (fail on critical/high severity)
 
+For TypeScript projects, lint should run the repository's JS/TS static analysis
+tool before tests. New Rsbuild projects should use Rslint when its rule coverage
+fits the repo. Conventional Commit enforcement belongs in a commitlint hook or a
+CI commit-range check.
+
+For pnpm 12 projects, install pnpm directly in CI. Do not use Corepack to install
+or prepare pnpm.
+
 The total CI time for a feature branch should be under 10 minutes. If it exceeds this,
 parallelize steps or investigate slow tests.
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -6,22 +6,23 @@ A profile is a named YAML preset that selects which fragments, tech stack detail
 
 | Profile | What it's for | Language(s) |
 |---|---|---|
-| `typescript-react-spa` | Standalone React SPA with Vite, React Router. No SSR. | TypeScript |
+| `typescript-react-spa` | Standalone React SPA with Rsbuild, React Router. No SSR. | TypeScript |
+| `typescript-react-module-federation-rsbuild` | React Module Federation app with Rsbuild for host, remote, or mixed roles | TypeScript |
 | `typescript-next-app` | Standalone Next.js app with SSR, App Router | TypeScript |
-| `typescript-vue-spa` | Standalone Vue 3 SPA with Vite, Pinia, Vue Router. No SSR. | TypeScript |
+| `typescript-vue-spa` | Standalone Vue 3 SPA with Rsbuild, Pinia, Vue Router. No SSR. | TypeScript |
 | `typescript-nuxt-app` | Standalone Nuxt 3 app with SSR, file-based routing, Nitro | TypeScript |
 | `typescript-hexagonal-microservice` | TypeScript backend service with Hono, hexagonal architecture, DDD | TypeScript |
 | `typescript-bff` | Backend-for-Frontend aggregation layer | TypeScript |
 | `typescript-hexagonal-next-ui` | Hono backend + Next.js frontend (SSR) | TypeScript |
-| `typescript-hexagonal-react-vite-ui` | Hono backend + React SPA frontend (no SSR) | TypeScript |
+| `typescript-hexagonal-react-vite-ui` | Hono backend + React SPA frontend with Rsbuild (no SSR) | TypeScript |
 | `typescript-hexagonal-nuxt-vite-ui` | Hono backend + Nuxt 3 / Vue 3 frontend (SSR) | TypeScript |
-| `typescript-hexagonal-vue-vite-ui` | Hono backend + Vue 3 SPA frontend (no SSR) | TypeScript |
+| `typescript-hexagonal-vue-vite-ui` | Hono backend + Vue 3 SPA frontend with Rsbuild (no SSR) | TypeScript |
 | `typescript-hexagonal-effect-cli` | TypeScript CLI with @effect/cli + @effect/platform-node, hexagonal + DDD | TypeScript |
 | `go-hexagonal-microservice` | Go backend microservice, hexagonal + DDD | Go |
 | `golang-hexagonal-next-ui` | Go backend + Next.js frontend (SSR) | Go + TypeScript |
-| `golang-hexagonal-react-vite-ui` | Go backend + React SPA frontend (no SSR) | Go + TypeScript |
+| `golang-hexagonal-react-vite-ui` | Go backend + React SPA frontend with Rsbuild (no SSR) | Go + TypeScript |
 | `golang-hexagonal-nuxt-vite-ui` | Go backend + Nuxt 3 / Vue 3 frontend (SSR) | Go + TypeScript |
-| `golang-hexagonal-vue-vite-ui` | Go backend + Vue 3 SPA frontend (no SSR) | Go + TypeScript |
+| `golang-hexagonal-vue-vite-ui` | Go backend + Vue 3 SPA frontend with Rsbuild (no SSR) | Go + TypeScript |
 | `golang-hexagonal-cobra-cli` | Go CLI tool with Cobra + Viper, hexagonal + DDD | Go |
 | `python-fastapi-microservice` | FastAPI service with uv + Pydantic, hexagonal | Python |
 | `python-hexagonal-typer-cli` | Python CLI tool with Typer + Rich, hexagonal | Python |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -74,6 +74,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 ### UI
 
 - `internationalization-i18n` — Add or improve i18n/l10n architecture, messages, and workflows.
+- `module-federation` — Add, review, or debug Module Federation in Rsbuild-first TypeScript applications.
 - `next-application-structure` — Define scalable Next.js App Router project structure and conventions.
 - `react-application-structure` — Define scalable React application architecture and folder layout.
 - `react-component-design` — Design maintainable React component APIs and composition boundaries.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -75,6 +75,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 
 - `internationalization-i18n` — Add or improve i18n/l10n architecture, messages, and workflows.
 - `module-federation` — Add, review, or debug Module Federation in Rsbuild-first TypeScript applications.
+- `module-federation-ssr` — Add, review, or debug SSR Module Federation across Modern.js, Nuxt, Next.js legacy Pages Router, Vinext, Vite SSR, and dual remote artifacts.
 - `next-application-structure` — Define scalable Next.js App Router project structure and conventions.
 - `react-application-structure` — Define scalable React application architecture and folder layout.
 - `react-component-design` — Design maintainable React component APIs and composition boundaries.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -75,6 +75,7 @@ This page indexes all shared skills in this library, grouped by top-level skill 
 
 - `internationalization-i18n` — Add or improve i18n/l10n architecture, messages, and workflows.
 - `module-federation` — Add, review, or debug Module Federation in Rsbuild-first TypeScript applications.
+- `module-federation-debugging` — Diagnose Module Federation failures across manifests, runtime errors, shared dependencies, types, browser loading, SSR loading, and hydration.
 - `module-federation-ssr` — Add, review, or debug SSR Module Federation across Modern.js, Nuxt, Next.js legacy Pages Router, Vinext, Vite SSR, and dual remote artifacts.
 - `next-application-structure` — Define scalable Next.js App Router project structure and conventions.
 - `react-application-structure` — Define scalable React application architecture and folder layout.

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-08-28T22:48:49Z",
+  "generated_at": "2026-08-30T22:23:05Z",
   "fragments": [
     {
       "name": "bff",
@@ -56,7 +56,7 @@
       "group": "architecture",
       "path": "agents/architecture/module-federation.md",
       "heading": "Module Federation",
-      "words": 526
+      "words": 870
     },
     {
       "name": "code-review",

--- a/index/fragments.json
+++ b/index/fragments.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-05-21T18:41:10Z",
+  "generated_at": "2026-08-28T22:48:49Z",
   "fragments": [
     {
       "name": "bff",
@@ -52,6 +52,13 @@
       "words": 391
     },
     {
+      "name": "module-federation",
+      "group": "architecture",
+      "path": "agents/architecture/module-federation.md",
+      "heading": "Module Federation",
+      "words": 526
+    },
+    {
       "name": "code-review",
       "group": "base",
       "path": "agents/base/code-review.md",
@@ -70,7 +77,7 @@
       "group": "base",
       "path": "agents/base/git-conventions.md",
       "heading": "Git Conventions",
-      "words": 268
+      "words": 288
     },
     {
       "name": "security",
@@ -224,7 +231,7 @@
       "group": "languages",
       "path": "agents/languages/typescript.md",
       "heading": "TypeScript",
-      "words": 1180
+      "words": 1306
     },
     {
       "name": "api-design",
@@ -238,7 +245,7 @@
       "group": "practices",
       "path": "agents/practices/ci-cd.md",
       "heading": "CI/CD",
-      "words": 444
+      "words": 502
     },
     {
       "name": "go-standard-layout",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-08-28T22:48:49Z",
+  "generated_at": "2026-08-30T22:23:04Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -662,10 +662,24 @@
       ]
     },
     {
+      "name": "module-federation-ssr",
+      "group": "ui",
+      "path": "skills/ui/module-federation-ssr/SKILL.md",
+      "description": "Add, review, or debug server-side rendered Module Federation applications, including Modern.js, Nuxt, Next.js legacy Pag",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "module-federation",
+        "ssr",
+        "micro-frontends",
+        "typescript"
+      ]
+    },
+    {
       "name": "module-federation",
       "group": "ui",
       "path": "skills/ui/module-federation/SKILL.md",
-      "description": "Add, review, or debug Module Federation support in Rsbuild-first TypeScript applications. Covers host/remote roles, expo",
+      "description": "Add, review, or debug client-rendered Module Federation support in Rsbuild-first TypeScript applications. Covers host/re",
       "version": "1.0.0",
       "tags": [
         "ui",

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-08-30T22:23:04Z",
+  "generated_at": "2026-08-30T22:56:38Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -659,6 +659,20 @@
         "i18n",
         "l10n",
         "frontend"
+      ]
+    },
+    {
+      "name": "module-federation-debugging",
+      "group": "ui",
+      "path": "skills/ui/module-federation-debugging/SKILL.md",
+      "description": "Diagnose Module Federation failures with evidence-first triage across manifests, remote entries, runtime errors, shared ",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "module-federation",
+        "debugging",
+        "observability",
+        "typescript"
       ]
     },
     {

--- a/index/skills.json
+++ b/index/skills.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-06-27T19:20:55Z",
+  "generated_at": "2026-08-28T22:48:49Z",
   "skills": [
     {
       "name": "compose-agents-md",
@@ -659,6 +659,20 @@
         "i18n",
         "l10n",
         "frontend"
+      ]
+    },
+    {
+      "name": "module-federation",
+      "group": "ui",
+      "path": "skills/ui/module-federation/SKILL.md",
+      "description": "Add, review, or debug Module Federation support in Rsbuild-first TypeScript applications. Covers host/remote roles, expo",
+      "version": "1.0.0",
+      "tags": [
+        "ui",
+        "module-federation",
+        "micro-frontends",
+        "rsbuild",
+        "typescript"
       ]
     },
     {

--- a/profiles/golang-hexagonal-next-ui.yaml
+++ b/profiles/golang-hexagonal-next-ui.yaml
@@ -5,7 +5,7 @@ meta:
     Full-stack application with a Go hexagonal backend and a Next.js
     frontend. Go handles all business logic and HTTP APIs; Next.js delivers
     SSR-capable pages with modern build performance and Vitest for unit tests.
-  version: "1.1.1"
+  version: "1.1.2"
 
 fragments:
   base:
@@ -56,8 +56,8 @@ tiers:
       lint_command:  "pnpm lint"
 
 tech_stack:
-  language_runtime: "Go 1.26+ (backend) / Node 22+ (frontend)"
-  package_manager: "Go modules (backend) / pnpm (frontend)"
+  language_runtime: "Go 1.26+ (backend) / Node 24+ (frontend)"
+  package_manager: "Go modules (backend) / pnpm 12 (frontend)"
   backend_framework: "gorilla/mux"
   frontend_framework: "Next.js"
   ui_component_library: "shadcn/ui"
@@ -66,6 +66,8 @@ tech_stack:
   test_framework: "Vitest (frontend) / testify (backend)"
   additional:
     - "React"
+    - "Rslint"
+    - "commitlint"
     - "App Router"
 
 skills:

--- a/profiles/golang-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/golang-hexagonal-nuxt-vite-ui.yaml
@@ -4,8 +4,8 @@ meta:
   description: >
     Full-stack application with a Go hexagonal backend and a Nuxt 3 / Vue 3
     frontend. Go handles all business logic and HTTP APIs; Nuxt delivers
-    SSR-capable pages with Vite for fast builds and Vitest for unit tests.
-  version: "1.1.1"
+    SSR-capable pages with Nuxt's Vite-backed build layer and Vitest for unit tests.
+  version: "1.1.2"
 
 fragments:
   base:
@@ -56,18 +56,20 @@ tiers:
       lint_command:  "pnpm lint"
 
 tech_stack:
-  language_runtime: "Go 1.26+ (backend) / Node 22+ (frontend)"
-  package_manager: "Go modules (backend) / pnpm (frontend)"
+  language_runtime: "Go 1.26+ (backend) / Node 24+ (frontend)"
+  package_manager: "Go modules (backend) / pnpm 12 (frontend)"
   backend_framework: "gorilla/mux"
   frontend_framework: "Nuxt 3"
   ui_component_library: "shadcn/vue"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Vite 6"
+  build_tool: "Vite 6 (via Nuxt)"
   test_framework: "Vitest (frontend) / testify (backend)"
   additional:
     - "Vue 3"
     - "pinia"
     - "VueRouter"
+    - "Rslint"
+    - "commitlint"
 
 skills:
   - project-map

--- a/profiles/golang-hexagonal-react-vite-ui.yaml
+++ b/profiles/golang-hexagonal-react-vite-ui.yaml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
 meta:
-  name: "Go Hexagonal + React/Vite SPA"
+  name: "Go Hexagonal + React/Rsbuild SPA"
   description: >
     Full-stack application with a Go hexagonal backend and a React SPA
     frontend. Go handles all business logic and HTTP APIs; React delivers a
-    client-side single-page application with Vite for fast builds and Vitest
+    client-side single-page application with Rsbuild for builds and Vitest
     for unit tests. No SSR.
-  version: "1.1.1"
+  version: "1.1.2"
 
 fragments:
   base:
@@ -59,16 +59,18 @@ tiers:
       lint_command:  "pnpm lint"
 
 tech_stack:
-  language_runtime: "Go 1.26+ (backend) / Node 22+ (frontend)"
-  package_manager: "Go modules (backend) / pnpm (frontend)"
+  language_runtime: "Go 1.26+ (backend) / Node 24+ (frontend)"
+  package_manager: "Go modules (backend) / pnpm 12 (frontend)"
   backend_framework: "gorilla/mux"
   frontend_framework: "React (SPA)"
   ui_component_library: "shadcn/ui"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Vite 6"
+  build_tool: "Rsbuild"
   test_framework: "Vitest (frontend) / testify (backend)"
   additional:
     - "React Router"
+    - "Rslint"
+    - "commitlint"
 
 skills:
   - project-map
@@ -99,6 +101,7 @@ output:
     Full-stack project: Go hexagonal backend + React SPA frontend (no SSR).
     Backend domain package must have zero external dependencies.
     Frontend uses strict TypeScript with functional components and hooks.
+    Frontend builds use Rsbuild and tests use Vitest.
     Frontend TS convention: alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 

--- a/profiles/golang-hexagonal-vue-vite-ui.yaml
+++ b/profiles/golang-hexagonal-vue-vite-ui.yaml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
 meta:
-  name: "Go Hexagonal + Vue/Vite SPA"
+  name: "Go Hexagonal + Vue/Rsbuild SPA"
   description: >
     Full-stack application with a Go hexagonal backend and a Vue 3 SPA
     frontend. Go handles all business logic and HTTP APIs; Vue delivers a
-    client-side single-page application with Vite for fast builds and Vitest
+    client-side single-page application with Rsbuild for builds and Vitest
     for unit tests. No SSR.
-  version: "1.1.1"
+  version: "1.1.2"
 
 fragments:
   base:
@@ -59,17 +59,19 @@ tiers:
       lint_command:  "pnpm lint"
 
 tech_stack:
-  language_runtime: "Go 1.26+ (backend) / Node 22+ (frontend)"
-  package_manager: "Go modules (backend) / pnpm (frontend)"
+  language_runtime: "Go 1.26+ (backend) / Node 24+ (frontend)"
+  package_manager: "Go modules (backend) / pnpm 12 (frontend)"
   backend_framework: "gorilla/mux"
   frontend_framework: "Vue 3 (SPA)"
   ui_component_library: "shadcn/vue"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Vite 6"
+  build_tool: "Rsbuild"
   test_framework: "Vitest (frontend) / testify (backend)"
   additional:
     - "pinia"
     - "VueRouter"
+    - "Rslint"
+    - "commitlint"
 
 skills:
   - project-map
@@ -102,6 +104,7 @@ output:
     Full-stack project: Go hexagonal backend + Vue 3 SPA frontend (no SSR).
     Backend domain package must have zero external dependencies.
     Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    Frontend builds use Rsbuild and tests use Vitest.
     Frontend TS convention: alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 

--- a/profiles/typescript-hexagonal-effect-cli.yaml
+++ b/profiles/typescript-hexagonal-effect-cli.yaml
@@ -3,9 +3,9 @@ meta:
   name: "TypeScript Hexagonal Effect CLI"
   description: >
     TypeScript CLI application using @effect/cli and @effect/platform-node with
-    pnpm. Follows ports and adapters (hexagonal) so command handlers remain thin
+    pnpm 12. Follows ports and adapters (hexagonal) so command handlers remain thin
     adapters and domain/application logic stays framework-agnostic.
-  version: "1.0.1"
+  version: "1.0.2"
 
 fragments:
   base:
@@ -34,11 +34,13 @@ fragments:
 
 tech_stack:
   language_runtime: "Node 24+"
-  package_manager: "pnpm"
+  package_manager: "pnpm 12"
   cli_framework: "@effect/cli + @effect/platform-node"
   test_framework: "Vitest"
   additional:
     - "Effect"
+    - "Rslint"
+    - "commitlint"
 
 skills:
   - project-map

--- a/profiles/typescript-hexagonal-next-ui.yaml
+++ b/profiles/typescript-hexagonal-next-ui.yaml
@@ -6,7 +6,7 @@ meta:
     Next.js frontend. Hono handles all business logic and HTTP APIs;
     Next.js delivers SSR-capable pages with modern build performance and Vitest
     for unit tests. Monorepo or split-repo — same language end to end.
-  version: "1.1.1"
+  version: "1.1.2"
 
 fragments:
   base:
@@ -69,7 +69,7 @@ tiers:
 
 tech_stack:
   language_runtime: "Node 24+"
-  package_manager: "pnpm"
+  package_manager: "pnpm 12"
   backend_framework: "Hono"
   frontend_framework: "Next.js"
   ui_component_library: "shadcn/ui"
@@ -78,6 +78,8 @@ tech_stack:
   test_framework: "Vitest"
   additional:
     - "React"
+    - "Rslint"
+    - "commitlint"
     - "App Router"
   proprietary_libraries:
     - name: "@acme/core"

--- a/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-nuxt-vite-ui.yaml
@@ -4,9 +4,9 @@ meta:
   description: >
     Full-stack TypeScript application with a Hono hexagonal backend and a
     Nuxt 3 / Vue 3 frontend. Hono handles all business logic and HTTP APIs;
-    Nuxt delivers SSR-capable pages with Vite for fast builds and Vitest for
+    Nuxt delivers SSR-capable pages with its Vite-backed build layer and Vitest for
     unit tests. Monorepo or split-repo — same language end to end.
-  version: "1.1.1"
+  version: "1.1.2"
 
 fragments:
   base:
@@ -69,17 +69,19 @@ tiers:
 
 tech_stack:
   language_runtime: "Node 24+"
-  package_manager: "pnpm"
+  package_manager: "pnpm 12"
   backend_framework: "Hono"
   frontend_framework: "Nuxt 3"
   ui_component_library: "shadcn/vue"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Vite 6"
+  build_tool: "Vite 6 (via Nuxt)"
   test_framework: "Vitest"
   additional:
     - "Vue 3"
     - "pinia"
     - "VueRouter"
+    - "Rslint"
+    - "commitlint"
   proprietary_libraries:
     - name: "@acme/core"
       description: "Core domain primitives shared across all services"

--- a/profiles/typescript-hexagonal-react-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-react-vite-ui.yaml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
 meta:
-  name: "TypeScript Hexagonal + React/Vite SPA"
+  name: "TypeScript Hexagonal + React/Rsbuild SPA"
   description: >
     Full-stack TypeScript application with a Hono hexagonal backend and a React
     SPA frontend. Hono handles all business logic and HTTP APIs; React delivers a
-    client-side single-page application with Vite for fast builds and Vitest
+    client-side single-page application with Rsbuild for builds and Vitest
     for unit tests. No SSR.
-  version: "1.1.1"
+  version: "1.1.2"
 
 fragments:
   base:
@@ -60,15 +60,17 @@ tiers:
 
 tech_stack:
   language_runtime: "Node 24+"
-  package_manager: "pnpm"
+  package_manager: "pnpm 12"
   backend_framework: "Hono"
   frontend_framework: "React (SPA)"
   ui_component_library: "shadcn/ui"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Vite 6"
+  build_tool: "Rsbuild"
   test_framework: "Vitest"
   additional:
     - "React Router"
+    - "Rslint"
+    - "commitlint"
 
 skills:
   - project-map
@@ -100,6 +102,7 @@ output:
     Full-stack TypeScript project: Hono hexagonal backend + React SPA frontend (no SSR).
     Backend domain layer must have zero framework dependencies.
     Frontend uses strict TypeScript with functional components and hooks.
+    Frontend builds use Rsbuild and tests use Vitest.
     Use alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 

--- a/profiles/typescript-hexagonal-vue-vite-ui.yaml
+++ b/profiles/typescript-hexagonal-vue-vite-ui.yaml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
 meta:
-  name: "TypeScript Hexagonal + Vue/Vite SPA"
+  name: "TypeScript Hexagonal + Vue/Rsbuild SPA"
   description: >
     Full-stack TypeScript application with a Hono hexagonal backend and a Vue 3
     SPA frontend. Hono handles all business logic and HTTP APIs; Vue delivers a
-    client-side single-page application with Vite for fast builds and Vitest
+    client-side single-page application with Rsbuild for builds and Vitest
     for unit tests. No SSR.
-  version: "1.1.1"
+  version: "1.1.2"
 
 fragments:
   base:
@@ -60,16 +60,18 @@ tiers:
 
 tech_stack:
   language_runtime: "Node 24+"
-  package_manager: "pnpm"
+  package_manager: "pnpm 12"
   backend_framework: "Hono"
   frontend_framework: "Vue 3 (SPA)"
   ui_component_library: "shadcn/vue"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Vite 6"
+  build_tool: "Rsbuild"
   test_framework: "Vitest"
   additional:
     - "pinia"
     - "VueRouter"
+    - "Rslint"
+    - "commitlint"
 
 skills:
   - project-map
@@ -103,6 +105,7 @@ output:
     Full-stack TypeScript project: Hono hexagonal backend + Vue 3 SPA frontend (no SSR).
     Backend domain layer must have zero framework dependencies.
     Frontend uses Vue 3 <script setup> exclusively — no Options API.
+    Frontend builds use Rsbuild and tests use Vitest.
     Use alias imports for cross-directory modules and ESM import/export syntax only.
     All dependencies are injected via interfaces defined in the domain or application layer.
 

--- a/profiles/typescript-library.yaml
+++ b/profiles/typescript-library.yaml
@@ -5,7 +5,7 @@ meta:
     TypeScript reusable library/package for publishing to npm or a private registry.
     Prioritises strict typing, ESM-first output, tree-shakability, zero framework
     dependencies, and semantic versioning discipline.
-  version: "1.0.1"
+  version: "1.0.2"
 
 fragments:
   base:
@@ -25,9 +25,12 @@ fragments:
 
 tech_stack:
   language_runtime: "Node.js 24+ / browser-compatible"
-  package_manager: "pnpm"
+  package_manager: "pnpm 12"
   test_framework: "Vitest"
-  build_tool: "tsup / tsc"
+  build_tool: "Rslib (Rsbuild-based) / tsc"
+  additional:
+    - "Rslint"
+    - "commitlint"
 
 skills:
   - project-map

--- a/profiles/typescript-nuxt-app.yaml
+++ b/profiles/typescript-nuxt-app.yaml
@@ -7,7 +7,7 @@ meta:
     error handling, plugins, runtime config, Nitro caching, Layers), Vue component
     design, composition patterns, prop drilling prevention, styling discipline, and
     a three-tier test strategy (unit / component / acceptance).
-  version: "1.0.1"
+  version: "1.0.2"
 
 fragments:
   base:
@@ -34,7 +34,7 @@ fragments:
 
 tech_stack:
   language_runtime: "Node 24+"
-  package_manager: "pnpm"
+  package_manager: "pnpm 12"
   frontend_framework: "Nuxt 3"
   ui_component_library: "shadcn/vue"
   css_framework: "Tailwind CSS v4"
@@ -45,6 +45,8 @@ tech_stack:
     - "Pinia"
     - "Vue Router 4 (via Nuxt)"
     - "Nitro"
+    - "Rslint"
+    - "commitlint"
     - "Playwright (acceptance)"
 
 skills:

--- a/profiles/typescript-react-module-federation-rsbuild.yaml
+++ b/profiles/typescript-react-module-federation-rsbuild.yaml
@@ -1,13 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/soulcodex/agentic/main/schemas/profile.schema.json
 meta:
-  name: "TypeScript Next App"
+  name: "TypeScript React Module Federation Rsbuild"
   description: >
-    Standalone Next.js application with React, Tailwind CSS v4, and Vitest.
-    SSR-capable with App Router. Covers Next-specific patterns (Server Components,
-    route handlers, caching, middleware, runtime config), React component design,
-    hooks patterns, styling discipline, and a three-tier test strategy
-    (unit / component / acceptance).
-  version: "1.0.2"
+    React single-page application built with Rsbuild and Module Federation.
+    Supports host, remote, or mixed host/remote roles with strict TypeScript,
+    Vitest, shared dependency discipline, and federated type contracts.
+  version: "1.0.0"
 
 fragments:
   base:
@@ -19,12 +17,12 @@ fragments:
   languages:
     - typescript
   frameworks:
-    - next
+    - react
     - react-component-design
     - react-testing
     - react-styling
-    - next-patterns
-  architecture: []
+  architecture:
+    - module-federation
   practices:
     - tdd
     - api-design
@@ -34,22 +32,23 @@ fragments:
 tech_stack:
   language_runtime: "Node 24+"
   package_manager: "pnpm 12"
-  frontend_framework: "Next.js"
+  frontend_framework: "React (SPA)"
   ui_component_library: "shadcn/ui"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Turbopack (Next.js)"
+  build_tool: "Rsbuild"
   test_framework: "Vitest + @testing-library/react"
   additional:
-    - "React"
-    - "App Router"
+    - "@module-federation/rsbuild-plugin"
+    - "React Router"
     - "Rslint"
     - "commitlint"
-    - "Playwright (acceptance)"
+    - "Playwright (host/remote smoke)"
 
 skills:
   - project-map
   - code-review
   - add-tests
+  - module-federation
   - react-application-structure
   - react-component-design
   - react-component-testing
@@ -66,14 +65,12 @@ output:
   test_command: "pnpm test"
   lint_command: "pnpm lint"
   project_header: |
-    Standalone Next.js application with SSR via App Router.
+    React Module Federation application built with Rsbuild.
+    This app may act as a host, a remote, or both, but its federated role must be explicit in module-federation.config.ts.
+    Exposed modules are public runtime contracts. Remote URLs and shared dependency policy are host-owned contracts.
     Components and hooks use TypeScript strictly, with functional components only.
     Use alias imports for cross-directory modules and ESM import/export syntax only.
-    Server/client boundaries must be explicit and intentional.
-    Styling via Tailwind CSS v4; shadcn/ui for UI primitives.
-    API endpoints via route handlers. SSR safety rules apply everywhere.
-    Three-tier testing: Vitest unit tests for hooks/utils, @testing-library/react
-    for component behaviour, Playwright for acceptance tests.
+    Vitest covers unit and component behavior; Playwright covers host/remote smoke checks.
 
 vendors:
   enabled:

--- a/profiles/typescript-react-module-federation-rsbuild.yaml
+++ b/profiles/typescript-react-module-federation-rsbuild.yaml
@@ -49,6 +49,7 @@ skills:
   - code-review
   - add-tests
   - module-federation
+  - module-federation-debugging
   - react-application-structure
   - react-component-design
   - react-component-testing

--- a/profiles/typescript-react-spa.yaml
+++ b/profiles/typescript-react-spa.yaml
@@ -2,11 +2,11 @@
 meta:
   name: "TypeScript React SPA"
   description: >
-    Standalone React single-page application with Vite, React Router,
+    Standalone React single-page application with Rsbuild, React Router,
     and Vitest. No server-side rendering. Covers component design, hooks
     patterns, prop drilling prevention, Tailwind v4 styling discipline, and a
     three-tier test strategy (unit / component / acceptance).
-  version: "1.0.1"
+  version: "1.0.2"
 
 fragments:
   base:
@@ -31,14 +31,16 @@ fragments:
 
 tech_stack:
   language_runtime: "Node 24+"
-  package_manager: "pnpm"
+  package_manager: "pnpm 12"
   frontend_framework: "React (SPA)"
   ui_component_library: "shadcn/ui"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Vite 6"
+  build_tool: "Rsbuild"
   test_framework: "Vitest + @testing-library/react"
   additional:
     - "React Router"
+    - "Rslint"
+    - "commitlint"
     - "Playwright (acceptance)"
 
 skills:
@@ -64,7 +66,7 @@ output:
     Components and hooks use TypeScript strictly, with functional components only.
     Use alias imports for cross-directory modules and ESM import/export syntax only.
     Routing via React Router with explicit route ownership and boundaries.
-    Styling via Tailwind CSS v4 utility classes; shadcn/ui for UI primitives.
+    Build with Rsbuild. Styling via Tailwind CSS v4 utility classes; shadcn/ui for UI primitives.
     Three-tier testing: Vitest unit tests for hooks/utils, @testing-library/react
     for component behaviour, Playwright for acceptance tests.
 

--- a/profiles/typescript-vue-spa.yaml
+++ b/profiles/typescript-vue-spa.yaml
@@ -2,11 +2,11 @@
 meta:
   name: "TypeScript Vue 3 SPA"
   description: >
-    Standalone Vue 3 single-page application with Vite, Pinia, Vue Router,
+    Standalone Vue 3 single-page application with Rsbuild, Pinia, Vue Router,
     and Vitest. No server-side rendering. Covers component design, composition
     patterns, prop drilling prevention, Tailwind v4 styling discipline, and a
     three-tier test strategy (unit / component / acceptance).
-  version: "1.0.1"
+  version: "1.0.2"
 
 fragments:
   base:
@@ -31,15 +31,17 @@ fragments:
 
 tech_stack:
   language_runtime: "Node 24+"
-  package_manager: "pnpm"
+  package_manager: "pnpm 12"
   frontend_framework: "Vue 3 (SPA)"
   ui_component_library: "shadcn/vue"
   css_framework: "Tailwind CSS v4"
-  build_tool: "Vite 6"
+  build_tool: "Rsbuild"
   test_framework: "Vitest + @testing-library/vue"
   additional:
     - "Pinia"
     - "Vue Router 4"
+    - "Rslint"
+    - "commitlint"
     - "Playwright (acceptance)"
 
 skills:
@@ -65,7 +67,7 @@ output:
     All components use <script setup lang="ts"> exclusively — no Options API.
     Use alias imports for cross-directory modules and ESM import/export syntax only.
     State management via Pinia setup stores. Routing via Vue Router 4 with typed routes.
-    Styling via Tailwind CSS v4 utility classes; shadcn/vue for UI primitives.
+    Build with Rsbuild. Styling via Tailwind CSS v4 utility classes; shadcn/vue for UI primitives.
     Three-tier testing: Vitest unit tests for composables/stores, @testing-library/vue
     for component behaviour, Playwright for acceptance tests.
 

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -197,6 +197,7 @@
           "json-to-toon",
           "memory-continuity",
           "microservices-architecture",
+          "module-federation",
           "monorepo-management",
           "new-gh-issue-orchestration",
           "next-application-structure",

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -198,6 +198,7 @@
           "memory-continuity",
           "microservices-architecture",
           "module-federation",
+          "module-federation-debugging",
           "module-federation-ssr",
           "monorepo-management",
           "new-gh-issue-orchestration",

--- a/schemas/profile.schema.json
+++ b/schemas/profile.schema.json
@@ -198,6 +198,7 @@
           "memory-continuity",
           "microservices-architecture",
           "module-federation",
+          "module-federation-ssr",
           "monorepo-management",
           "new-gh-issue-orchestration",
           "next-application-structure",

--- a/skills/development/code-review-typescript/checklist.md
+++ b/skills/development/code-review-typescript/checklist.md
@@ -27,6 +27,14 @@ Extends the generic checklist. Apply every item to TypeScript-specific concerns.
   *Ref: [TypeScript module best practices](https://www.typescriptlang.org/docs/handbook/module-resolution.html)*
 - [ ] Cross-directory imports use path aliases (tsconfig `paths`), not `../../..` traversal
 
+## Tooling
+
+- [ ] pnpm 12 projects do not use Corepack as the pnpm install/bootstrap path
+- [ ] React/Vue SPA and micro-frontend builds use Rsbuild unless the project has an explicit exception
+- [ ] Unit and component tests use Vitest
+- [ ] New JS/TS lint setups use Rslint when rule coverage fits; existing ESLint configs are migrated only when migration is in scope
+- [ ] Conventional Commit enforcement uses commitlint in Node-capable repositories when commit validation is configured
+
 ## Async and Concurrency
 
 - [ ] No floating Promises — every `async` call is awaited or explicitly fire-and-forget with error handling

--- a/skills/development/github-actions-workflow/SKILL.md
+++ b/skills/development/github-actions-workflow/SKILL.md
@@ -30,6 +30,10 @@ Identify the runtime and package manager before scaffolding:
 - Test and lint commands (from `justfile`, `Makefile`, or `package.json`)
 - Deploy targets (container registry, cloud provider, static host)
 
+For pnpm 12 projects, do not install pnpm with Corepack. Bootstrap pnpm with
+`npx get-pnpm next-12`, the standalone installer, or the repository's existing
+approved setup action if it installs pnpm directly.
+
 ### Step 2 — Scaffold `.github/workflows/ci.yml`
 
 ```yaml
@@ -118,6 +122,10 @@ Cache package manager directories keyed on the lockfile hash:
 | uv (Python) | `~/.cache/uv` | `uv.lock` |
 | Composer | `~/.composer/cache` | `composer.lock` |
 
+For pnpm 12 with `actions/setup-node`, keep `cache: "pnpm"` for dependency
+caching after pnpm is installed. Do not add `corepack enable` or
+`corepack prepare` steps.
+
 ### Step 5 — Secrets
 
 - Never hardcode secrets or tokens in workflow files.
@@ -186,6 +194,7 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
           cache: "pnpm"
+      - run: npx get-pnpm next-12
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test
@@ -233,6 +242,7 @@ Rules:
 - [ ] Jobs run in correct dependency order (lint → test → build → deploy).
 - [ ] Dependency cache hits on the second run (check Actions logs).
 - [ ] Secrets referenced via `${{ secrets.* }}` — no hardcoded values.
+- [ ] pnpm 12 workflows install pnpm directly and do not use Corepack.
 - [ ] Concurrency group prevents duplicate runs on the same branch.
 - [ ] (Reusable) Called workflow declares all `inputs` and `secrets` it uses.
 - [ ] (Reusable) Cross-repo calls pin the workflow ref to a tag or SHA.

--- a/skills/development/monorepo-management/SKILL.md
+++ b/skills/development/monorepo-management/SKILL.md
@@ -44,13 +44,14 @@ Follow a consistent naming scheme:
 @acme/ui           ← shared component library
 @acme/core         ← shared domain types and utilities
 @acme/config-ts    ← shared TypeScript config
-@acme/config-eslint ← shared ESLint config
+@acme/config-rslint ← shared Rslint config
 ```
 
 Rules:
 - Use a consistent org prefix (`@acme/`, `@org/`).
 - Separate packages for separate concerns — do not bundle the UI and the API.
-- Keep shared config packages (tsconfig, eslint) in `packages/config-*/`.
+- Keep shared config packages (tsconfig, rslint, and any retained eslint config)
+  in `packages/config-*/`.
 
 ### Step 3 — Shared Tooling at Root
 
@@ -62,7 +63,7 @@ monorepo/
   pnpm-workspace.yaml   ← workspace package globs
   turbo.json            ← Turborepo pipeline
   tsconfig.base.json    ← shared TS config
-  eslint.config.ts      ← shared ESLint config
+  rslint.config.ts      ← shared Rslint config
   .gitignore
   packages/
     api/

--- a/skills/development/static-code-analysis/SKILL.md
+++ b/skills/development/static-code-analysis/SKILL.md
@@ -25,20 +25,35 @@ vendor_support:
 
 | Language | Recommended tool | Config file |
 |----------|-----------------|-------------|
-| TypeScript / JavaScript | ESLint + typescript-eslint (+ eslint-plugin-import if using `import/*` rules) | `eslint.config.ts` |
+| TypeScript / JavaScript | Rslint (`@rslint/core`) for new projects; ESLint when already entrenched or plugin coverage requires it | `rslint.config.ts` or `eslint.config.ts` |
 | Go | golangci-lint | `.golangci.yml` |
 | Python | Ruff | `ruff.toml` or `pyproject.toml` |
 | PHP | PHPStan | `phpstan.neon` |
 | Rust | Clippy (built-in) | `clippy.toml` |
 
 If a tool is already present, audit its configuration before making changes.
+Do not replace an established ESLint setup with Rslint unless migration is part
+of the task or the repo has no rules that Rslint cannot cover yet.
 
 ### Step 2 — Configure Rules
 
 Apply a strict baseline.
 If you use `import/*` rules, ensure `eslint-plugin-import` is installed and configured.
 
-**TypeScript (ESLint)**
+**TypeScript (Rslint)**
+```bash
+pnpm add -D @rslint/core
+pnpm exec rslint --init
+```
+
+Use `pnpm lint` as the project script. For repositories that want lint and type
+checking in one pass, configure parser projects and use:
+
+```bash
+pnpm exec rslint --type-check .
+```
+
+**TypeScript (ESLint fallback)**
 ```json
 {
   "rules": {
@@ -96,7 +111,7 @@ Run the auto-fixer first to resolve stylistic issues without manual effort:
 
 ```bash
 # TypeScript
-pnpm eslint . --fix
+pnpm exec rslint --fix .
 
 # Python
 ruff check . --fix
@@ -120,12 +135,19 @@ Install a pre-commit hook so violations are caught before `git push`:
 
 **Using Husky + lint-staged (JS/TS)**
 ```bash
-pnpm add -D husky lint-staged
+pnpm add -D husky lint-staged @commitlint/cli @commitlint/config-conventional
 npx husky init
 ```
 ```json
 // package.json
-"lint-staged": { "*.{ts,tsx}": "eslint --fix" }
+"lint-staged": { "*.{ts,tsx,js,jsx}": "rslint --fix" }
+```
+
+Use commitlint from a `commit-msg` hook or CI commit-range check when the repo
+uses Conventional Commits:
+
+```bash
+pnpm exec commitlint --edit "$1"
 ```
 
 **Using pre-commit (Python/Go)**
@@ -144,4 +166,5 @@ repos:
 - [ ] `<lint-command>` exits 0 with no output.
 - [ ] CI lint job passes on a clean branch.
 - [ ] Pre-commit hook blocks a commit that introduces a lint error.
+- [ ] Commitlint blocks a non-Conventional Commit message when configured.
 - [ ] No blanket `eslint-disable` or `#noqa` without explanatory comments.

--- a/skills/ui/module-federation-debugging/SKILL.md
+++ b/skills/ui/module-federation-debugging/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: module-federation-debugging
+description: >
+  Diagnose Module Federation failures with evidence-first triage across
+  manifests, remote entries, runtime errors, shared dependencies, generated
+  types, browser loading, Node/SSR loading, and hydration boundaries.
+version: 1.0.0
+tags:
+  - ui
+  - module-federation
+  - debugging
+  - observability
+  - typescript
+resources:
+  - resources/evidence-map.md
+  - resources/runtime-triage.md
+  - resources/observability-workflow.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Module Federation Debugging Skill
+
+Use this skill when a Module Federation host or remote fails to load, renders a
+blank page, hangs in a loading state, throws a `RUNTIME-xxx` error, has unclear
+shared dependency behavior, cannot resolve generated types, fails only in
+production, or behaves differently between browser and SSR.
+
+For SSR-specific architecture choices and host/remote creation, also use the
+`module-federation-ssr` skill when it is available. This skill owns the
+debugging investigation; the SSR skill owns SSR architecture boundaries.
+
+### Step 1 - Name The Failure Boundary
+
+Do not start by changing configuration. First classify the likely boundary:
+
+| Boundary | Common Signals |
+|---|---|
+| config | missing plugin, wrong plugin, bad expose key, missing async startup |
+| producer artifact | stale or missing manifest, remote entry, exposes, stats, types |
+| network | 404, 5xx, CORS, DNS, timeout, CDN, gateway, mixed content |
+| runtime | `RUNTIME-xxx`, container missing, script execution failure |
+| shared dependency | duplicate React/Vue, wrong singleton, externals conflict |
+| type contract | missing `@mf-types`, producer DTS failure, path mapping issue |
+| render | remote loaded but component throws or error boundary trips |
+| SSR/hydration | server loads differently than browser, hydration mismatch |
+| cache/version | host and remote use different deployed artifact versions |
+
+If the boundary is unclear, read
+[resources/evidence-map.md](resources/evidence-map.md) and collect the minimum
+facts needed to narrow it.
+
+### Step 2 - Collect Evidence In Order
+
+Use this order unless a hard error points to a narrower path:
+
+1. Effective host and remote Module Federation config.
+2. Runtime role: host, remote, or both.
+3. Rendering mode: CSR, client-only island in SSR app, or true SSR federation.
+4. Remote declaration, manifest URL, remote entry URL, and requested expose key.
+5. Browser Network and console evidence.
+6. Server logs and Node/SSR observability files when SSR is involved.
+7. Shared dependency versions and singleton policy.
+8. Generated type artifacts and TypeScript diagnostics.
+9. Build stats, manifest/snapshot data, and deployment version.
+
+Prefer primary evidence from the running app over assumptions from package
+names. Redact DOM, storage, cookies, tokens, headers, and user data from reports
+unless the user explicitly authorizes sharing them.
+
+### Step 3 - Use The Right Diagnostic Path
+
+Read [resources/runtime-triage.md](resources/runtime-triage.md) when there is a
+runtime error code, blank page, missing container, missing expose, script load
+failure, or shared dependency issue.
+
+Read [resources/observability-workflow.md](resources/observability-workflow.md)
+when the project has `@module-federation/observability-plugin`, a Chrome
+Loading Trace export, a `traceId`, a `read:` command, or `.mf/observability/*`
+files.
+
+If there is no report and the console/network evidence is thin, recommend
+Module Federation `2.5.0+` plus `@module-federation/observability-plugin` for
+retained diagnostics. For one-off browser debugging, use the Module Federation
+Chrome DevTools Loading Trace path when available instead of adding a permanent
+dependency.
+
+### Step 4 - Fix The Smallest Proven Cause
+
+Only change the boundary that the evidence identifies.
+
+- URL or manifest problem: fix the remote URL, public path, CDN route, or
+  deployment path.
+- Missing expose: fix the producer `exposes` key and regenerate artifacts.
+- Plugin/config problem: use the plugin that matches the detected toolchain and
+  enable async startup where required.
+- Shared dependency problem: align singleton versions and remove conflicts with
+  `externals`, aliases, or import transforms.
+- Type problem: fix producer DTS generation or consumer `@mf-types` resolution.
+- SSR problem: verify server entry, browser entry, server egress, request scope,
+  and hydration before changing fallback behavior.
+
+Avoid broad dependency upgrades, retries, and cache clearing as first fixes
+unless the evidence points there.
+
+### Step 5 - Verify From The Failing Side
+
+Run the narrowest checks that prove the fix:
+
+- `pnpm lint`, with Rslint for new TypeScript/JavaScript linting where it fits;
+- `pnpm test --run` or the repository's Vitest command for affected logic;
+- `pnpm build` for each changed host or remote;
+- direct manifest or remote entry fetch from the host runtime;
+- browser smoke check for the original loading path;
+- SSR route smoke check when server rendering or hydration was involved;
+- commitlint through the existing hook or CI range check when commit validation
+  is configured.
+
+When reporting back, state the boundary, evidence, fix, and verification. If the
+failure remains unproven, say what evidence is missing instead of guessing.
+

--- a/skills/ui/module-federation-debugging/resources/evidence-map.md
+++ b/skills/ui/module-federation-debugging/resources/evidence-map.md
@@ -1,0 +1,82 @@
+## Module Federation Debug Evidence Map
+
+Use this reference to decide which facts to collect before changing code.
+
+### Minimum Context
+
+Collect:
+
+- package manager and lockfile;
+- framework and bundler: Rsbuild, Rspack, Webpack, Modern.js, Next.js, Nuxt,
+  Vinext, or Vite;
+- Module Federation packages and versions;
+- host and remote roles;
+- CSR, client-only SSR island, or true SSR federation mode;
+- host `remotes` and remote `exposes`;
+- remote manifest or remote entry URL;
+- requested import path or `loadRemote` call;
+- failing environment: local, preview, staging, production, browser, Node, SSR,
+  CI, or type generation.
+
+### Files To Inspect
+
+Prefer the smallest set that reaches the failing boundary:
+
+- `package.json`
+- `pnpm-lock.yaml` when dependency versions matter
+- `module-federation.config.*`
+- `rsbuild.config.*`, `rspack.config.*`, `webpack.config.*`, `modern.config.*`,
+  `next.config.*`, `nuxt.config.*`, or `vite.config.*`
+- runtime plugin files referenced by the config
+- route or component file that imports the remote
+- exposed module file in the producer
+- `tsconfig*.json`
+- `@mf-types`, `.mf/typesGenerate.log`, or temporary TypeScript configs when
+  type generation failed
+- `.mf/observability/latest.json`, `events.jsonl`, `build-info.json`, or
+  `build-report.json` when present
+
+### Fast Questions To Answer
+
+- Can the host fetch the manifest or remote entry from the same runtime where
+  the failure happens?
+- Does the manifest or stats output list the requested expose key?
+- Does the remote name in the host match the producer name or manifest entry?
+- Does the remote entry type match the consumer expectation, such as global
+  script versus ESM?
+- Are host and remote resolving the same framework singleton version?
+- Did the host and remote deploy as one compatible artifact set?
+- Does the failure happen before remote load, during remote entry execution,
+  during expose factory execution, during render, or during hydration?
+
+### Useful Local Checks
+
+Fetch a remote manifest or entry:
+
+```bash
+curl -I "https://example.com/mf-manifest.json"
+curl -s "https://example.com/mf-manifest.json" | jq .
+```
+
+Enable Module Federation debug mode for a local run:
+
+```bash
+FEDERATION_DEBUG=true pnpm dev
+FEDERATION_DEBUG=true pnpm build
+```
+
+Enable browser debug mode for a page reload:
+
+```js
+localStorage.setItem('FEDERATION_DEBUG', 'true')
+```
+
+Inspect generated type output:
+
+```bash
+find . -maxdepth 3 -name '@mf-types' -o -name 'typesGenerate.log'
+```
+
+These checks guide the investigation; they are not proof by themselves. Compare
+their output with the failing environment and the exact host/remote config.
+

--- a/skills/ui/module-federation-debugging/resources/observability-workflow.md
+++ b/skills/ui/module-federation-debugging/resources/observability-workflow.md
@@ -1,0 +1,96 @@
+## Module Federation Observability Workflow
+
+Use this reference when debugging needs phase-level loading evidence.
+
+### When To Use Observability
+
+Use observability when:
+
+- a page is blank or stuck loading and URL checks are inconclusive;
+- a runtime error code does not identify the owner;
+- shared dependency selection is unclear;
+- the failure is intermittent or production-only;
+- SSR and browser behavior differ;
+- build output, runtime state, and loaded remote version need correlation.
+
+Do not require observability for every issue. Console, network, manifest, and
+config evidence may be enough for simple URL or expose mistakes.
+
+### Report Sources
+
+Valid sources include:
+
+- Module Federation Chrome DevTools Loading Trace export;
+- browser reader output from
+  `window.__FEDERATION__.__OBSERVABILITY__['runtime_host']`;
+- `.mf/observability/latest.json`;
+- `.mf/observability/events.jsonl`;
+- `.mf/observability/build-info.json`;
+- `.mf/observability/build-report.json`;
+- application telemetry records produced from `onReport`.
+
+For Module Federation `2.5.0+`, prefer
+`@module-federation/observability-plugin` when diagnostics must be retained,
+uploaded, or read from Node/SSR.
+
+For one-off browser diagnosis, the Chrome DevTools Loading Trace path can
+collect runtime loading evidence without adding a permanent application
+dependency.
+
+### Analyze Reports In Order
+
+Read:
+
+1. `diagnosis.status`
+2. `diagnosis.title`
+3. `diagnosis.ownerHint`
+4. `diagnosis.errorCode`
+5. `diagnosis.facts`
+6. `diagnosis.actions`
+7. `summary.outcome`
+8. `summary.error`
+9. `summary.phases`
+10. `summary.shared`
+11. `build`
+12. `moduleInfo`
+13. `events`
+
+Start with diagnosis and summary fields. Use raw events only when phase order,
+interleaving, or trace timing matters.
+
+### Interpret Carefully
+
+- `runtime-loaded` proves the Module Federation runtime loaded the remote
+  module.
+- `component-loaded` is only a component-level ready signal when the producer
+  emits one.
+- `shared-resolved` identifies the selected shared provider and version.
+- `failed` needs the failed phase, owner hint, and error details before fixing.
+- `recovered` means a fallback or handled path completed after an earlier
+  failure. It is not automatically a clean success.
+- Missing shared fields do not prove sharing is healthy when the runtime version
+  is old or shared events were not emitted.
+- `moduleInfo` is clipped runtime metadata. Do not treat it as a full expose,
+  component, or asset inventory.
+
+### Production Safety
+
+Keep console output small in production. Use `onReport` for retained reports and
+application telemetry. Use `onEvent` only when event-level telemetry is
+intentional.
+
+Do not paste or persist sensitive DOM, local storage, session storage, cookies,
+authorization headers, tenant identifiers, or personal data unless the user
+explicitly authorizes it and the data is needed for the diagnosis.
+
+### Final Debug Report
+
+Report back with:
+
+- report source;
+- likely owner: host, remote, shared, network, runtime, build, SSR, or unknown;
+- key evidence;
+- smallest fix applied or recommended;
+- verification performed;
+- remaining missing evidence when the failure is not fully proven.
+

--- a/skills/ui/module-federation-debugging/resources/runtime-triage.md
+++ b/skills/ui/module-federation-debugging/resources/runtime-triage.md
@@ -1,0 +1,98 @@
+## Module Federation Runtime Triage
+
+Use this reference for runtime loading failures, blank pages, missing remotes,
+shared dependency issues, and type contract failures.
+
+### Runtime Error Codes
+
+Treat `RUNTIME-xxx` codes as entry points, not final answers. Confirm the phase
+with console, network, manifest, and observability evidence.
+
+Common starting points:
+
+- `RUNTIME-001`: failed to get remote entry exports. Check wrong URL, producer
+  registration, network access, remote entry type mismatch, and missing global.
+- `RUNTIME-006`: invalid `loadShareSync` call. Check async startup and whether
+  the shared dependency was already loaded.
+- `RUNTIME-007`: failed to get remote snapshot. Check versioned remote entries,
+  deployment metadata, manifest/snapshot availability, and platform data flow.
+- `RUNTIME-008`: failed to load script resources. Check URL reachability, CORS,
+  status code, timeout, CDN, and script execution details.
+
+For other runtime codes, look up the current official troubleshooting page and
+use it with local evidence.
+
+### Manifest And Remote Entry
+
+For manifest-based remotes:
+
+- fetch `mf-manifest.json` from the same network location as the failing host;
+- inspect public path, remote entry, exposes, remotes, shared, and type URLs;
+- verify the host uses the intended remote name and URL;
+- confirm the requested expose key starts with `./` and exists in the producer.
+
+For remote entry based remotes:
+
+- verify the entry is reachable and served with the expected JavaScript content;
+- verify global script versus ESM expectations match the host config;
+- check whether the container is registered on `globalThis` or `window` when
+  that runtime expects a global producer.
+
+### Shared Dependencies
+
+Shared dependency issues often appear as hooks errors, duplicate framework
+instances, missing providers, or hydration mismatches.
+
+Check:
+
+- React apps share `react` and `react-dom` as singletons;
+- Vue apps share `vue` as a singleton;
+- host and remote versions are compatible;
+- the package is not both `shared` and `externals`;
+- aliases do not point host and remote to different physical copies;
+- Rsbuild or Modern.js `source.transformImport` is not hiding shared UI
+  libraries from Module Federation.
+
+### Type Contracts
+
+For producer type generation failures:
+
+- enable debug mode with `FEDERATION_DEBUG=true`;
+- set `dts.displayErrorInTerminal` when available;
+- inspect `.mf/typesGenerate.log` and `.mf/observability/latest.json`;
+- run TypeScript against the temporary config reported by diagnostics when
+  available.
+
+For consumer type failures:
+
+- verify `@mf-types` exists;
+- fetch the remote type zip or API from the manifest;
+- add or merge `compilerOptions.paths` only when remote type imports need it:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "*": ["./@mf-types/*"]
+    }
+  }
+}
+```
+
+Do not leave hand-written remote module declarations as permanent contracts
+when the producer can emit generated types.
+
+### SSR And Hydration
+
+When the failure involves SSR:
+
+- compare server fetch behavior with browser fetch behavior;
+- verify the remote publishes both server and client artifacts when true SSR
+  federation is required;
+- confirm browser-only APIs are not used during server render;
+- confirm request data is not stored in module-level mutable state;
+- verify the server-rendered artifact and hydrated browser artifact are the
+  same deployed version;
+- treat silent fallback from SSR to client-only rendering as a product decision,
+  not a debugging shortcut.
+

--- a/skills/ui/module-federation-ssr/SKILL.md
+++ b/skills/ui/module-federation-ssr/SKILL.md
@@ -32,6 +32,10 @@ server-rendered host/remote contracts.
 If the task is a client-rendered Rsbuild MFE with no SSR requirement, use the
 regular `module-federation` skill instead.
 
+For deep runtime debugging, observability reports, production-only failures, or
+unclear host/remote ownership, use the `module-federation-debugging` skill when
+it is available, then return here for SSR architecture decisions.
+
 ### Step 1 - Classify The Rendering Contract
 
 Determine the real rendering mode before editing configuration:
@@ -84,6 +88,8 @@ For SSR federation, verify:
 
 Read [resources/debugging-playbook.md](resources/debugging-playbook.md) when
 debugging runtime, hydration, shared dependency, manifest, or type failures.
+If the `module-federation-debugging` skill is available, use it for the detailed
+triage workflow and keep this step focused on SSR-specific evidence.
 
 For SSR failures, always collect evidence from both sides:
 
@@ -105,4 +111,3 @@ Run the narrowest checks that prove the changed boundary:
   configured remote fallback behavior;
 - commitlint through the existing hook or CI commit-range check when the
   repository enforces Conventional Commits.
-

--- a/skills/ui/module-federation-ssr/SKILL.md
+++ b/skills/ui/module-federation-ssr/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: module-federation-ssr
+description: >
+  Add, review, or debug server-side rendered Module Federation applications,
+  including Modern.js, Nuxt, Next.js legacy Pages Router, Vinext, Vite SSR, and
+  dual browser/server remote artifacts.
+version: 1.0.0
+tags:
+  - ui
+  - module-federation
+  - ssr
+  - micro-frontends
+  - typescript
+resources:
+  - resources/architecture-matrix.md
+  - resources/debugging-playbook.md
+  - resources/host-remote-recipes.md
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Module Federation SSR Skill
+
+Use this skill when a Module Federation task involves SSR, hydration, server
+entries, streamed rendering, Modern.js, Nuxt, Next.js, Vinext, Vite SSR, or
+server-rendered host/remote contracts.
+
+If the task is a client-rendered Rsbuild MFE with no SSR requirement, use the
+regular `module-federation` skill instead.
+
+### Step 1 - Classify The Rendering Contract
+
+Determine the real rendering mode before editing configuration:
+
+| Mode | Meaning |
+|---|---|
+| CSR federation | An SSR-capable app loads the remote only in the browser. |
+| SSR federation | The host server loads and renders the remote, then the browser hydrates the same graph. |
+| Dual producer | A remote publishes browser and Node artifacts for SSR consumers. |
+
+When the user says "SSR support", do not assume true SSR federation. Ask only
+when local code and deployment config cannot reveal whether the remote must
+render on the server.
+
+### Step 2 - Choose The Implementation Family
+
+Read [resources/architecture-matrix.md](resources/architecture-matrix.md) before
+choosing or recommending a framework.
+
+Default guidance:
+
+- Use Rsbuild plus `@module-federation/rsbuild-plugin` for new client-rendered
+  React/Vue host and remote applications.
+- Use Modern.js and `@module-federation/modern-js-v3` as the preferred new SSR
+  Module Federation application path when the project can adopt Modern.js.
+- Use Rslib for remotes that need to publish both browser and Node artifacts.
+- Treat Nuxt SSR federation as beta and verify deployment constraints before
+  adopting it.
+- Treat Next.js Module Federation as legacy Pages Router maintenance only. Do
+  not recommend it for new App Router SSR architecture.
+- Treat Vinext as experimental unless the repository already adopted it and owns
+  the compatibility risk.
+
+### Step 3 - Create Or Review Host And Remote Contracts
+
+Read [resources/host-remote-recipes.md](resources/host-remote-recipes.md) when
+creating or reviewing host/remotes.
+
+For SSR federation, verify:
+
+- the remote publishes matching browser and server artifacts;
+- the host can resolve the remote from its server runtime and browser runtime;
+- exposed modules are small public contracts, not route trees or implementation
+  folders;
+- request-scoped data, auth, cookies, locale, and trace context cross through
+  explicit inputs;
+- framework singletons are shared deliberately and version alignment is enforced.
+
+### Step 4 - Debug With Server And Browser Evidence
+
+Read [resources/debugging-playbook.md](resources/debugging-playbook.md) when
+debugging runtime, hydration, shared dependency, manifest, or type failures.
+
+For SSR failures, always collect evidence from both sides:
+
+- server logs and `.mf/observability/latest.json` when available;
+- browser console, Network panel, hydration warnings, and Loading Trace exports;
+- published manifest or remote entry metadata;
+- generated `@mf-types` artifacts and producer type diagnostics;
+- build facts from `.mf/observability/build-info.json` or
+  `.mf/observability/build-report.json` when build output is suspect.
+
+### Step 5 - Verify
+
+Run the narrowest checks that prove the changed boundary:
+
+- `pnpm lint`, using Rslint for new TypeScript/JavaScript linting when it fits;
+- `pnpm test --run` or the repository's Vitest script;
+- `pnpm build` for each affected host and remote;
+- an SSR route smoke check that verifies server-rendered HTML, hydration, and
+  configured remote fallback behavior;
+- commitlint through the existing hook or CI commit-range check when the
+  repository enforces Conventional Commits.
+

--- a/skills/ui/module-federation-ssr/resources/architecture-matrix.md
+++ b/skills/ui/module-federation-ssr/resources/architecture-matrix.md
@@ -1,0 +1,63 @@
+## SSR Module Federation Architecture Matrix
+
+Use this reference to decide whether a project should use true SSR federation,
+client-rendered federated islands inside an SSR app, or a different composition
+model.
+
+### Recommended Paths
+
+| Stack | Use For | Guidance |
+|---|---|---|
+| Rsbuild + `@module-federation/rsbuild-plugin` | New client-rendered React/Vue MFE hosts and remotes | Default for non-SSR federation. Keep host/remote smoke tests and manifest-based remotes. |
+| Modern.js + `@module-federation/modern-js-v3` | New React SSR MFE applications | Preferred SSR application path when the project can adopt Modern.js. Its Module Federation integration owns the server/client rendering contract. |
+| Rslib | SSR-capable remote libraries or design-system producers | Use dual browser and Node outputs when a remote can be consumed by SSR hosts. |
+| Nuxt + `@module-federation/nuxt` | Vue/Nuxt SSR federation experiments or owned beta adoption | Beta. Verify server entry generation, cache writes, deployment target, and hydration before calling it production-ready. |
+| Next.js + `@module-federation/nextjs-mf` | Existing Pages Router maintenance | Legacy only. Requires local webpack and does not cover App Router as a new default. |
+| Vinext + `@module-federation/vite` | Existing Vinext projects that accept experimental risk | Client-side MF is documented. Treat SSR federation as project-owned until proven by tests and deployment evidence. |
+| Plain Vite SSR + MF | Custom runtimes owned by the project | Do not recommend as a default. Require explicit server/client artifact and hydration validation. |
+
+### Rendering Modes
+
+CSR federation inside an SSR app is acceptable when the remote is intentionally
+client-only. Use dynamic imports, client-only wrappers, and a product-approved
+loading or fallback state. The host still owns route HTML and data fetching.
+
+True SSR federation is required when a remote must contribute to server-rendered
+HTML, SEO, initial data, or first paint. The host server must resolve the remote,
+render the exposed module, serialize compatible state, and hydrate the same
+remote in the browser.
+
+Dual producers publish browser and server artifacts for other applications.
+They should keep environment-specific exports explicit and avoid hidden process
+or browser globals.
+
+### Red Lines
+
+- Do not recommend Next.js Module Federation for new App Router SSR work.
+- Do not claim Vite SSR federation is production-ready just because Vite supports SSR.
+- Do not adopt Nuxt SSR federation on read-only or serverless targets until its
+  cache and server entry behavior is verified for that target.
+- Do not expose whole route trees, app shells, private folders, or framework
+  internals as remote contracts.
+- Do not pass auth, cookies, locale, tenant, or tracing through globals. Use
+  explicit request-scoped inputs.
+- Do not mix framework singleton versions without a documented version policy.
+- Do not use hand-written remote module declarations as a permanent type
+  contract when generated Module Federation types are available.
+- Do not silently switch from SSR to client-only rendering on remote failure
+  without a product decision.
+
+### Acceptance Criteria
+
+An SSR MFE implementation is not done until:
+
+- the host can fetch the remote manifest or entry from the server runtime;
+- the browser can fetch the matching client artifact;
+- the exposed module renders server-side without browser-only API failures;
+- hydration completes without mismatch warnings for the remote boundary;
+- shared singleton versions are compatible across host and remotes;
+- generated types are available to consumers or a temporary typed shim has an
+  owner and removal path;
+- route smoke tests cover the host/remote path and the fallback path;
+- observability or logs identify the failing phase when remote loading breaks.
+

--- a/skills/ui/module-federation-ssr/resources/debugging-playbook.md
+++ b/skills/ui/module-federation-ssr/resources/debugging-playbook.md
@@ -1,0 +1,84 @@
+## SSR Module Federation Debugging Playbook
+
+Use this reference when a server-rendered federated route fails, hydrates
+incorrectly, loads a wrong version, or cannot resolve types.
+
+### First Classification
+
+Classify the failure before changing config:
+
+| Symptom | Likely Boundary |
+|---|---|
+| Server cannot fetch manifest or remote entry | network, URL, CORS, CDN, deployment, allowlist |
+| Browser can load remote but server cannot | SSR runtime URL, private network, server egress, credentials |
+| Server renders but browser hydration warns | different artifacts, data mismatch, client-only API, singleton mismatch |
+| Remote loads but component is missing | wrong expose key, stale manifest, wrong container name |
+| TypeScript cannot resolve remote imports | missing `@mf-types`, producer DTS failure, consumer path config |
+| Random cross-request state appears | global mutable state, singleton service leakage, cached request data |
+
+### Evidence Order
+
+Collect the smallest evidence that proves the owner:
+
+1. Effective host and remote Module Federation config.
+2. Server-accessible manifest or remote entry URL.
+3. Browser Network result for the same remote.
+4. Published exposes, shared dependencies, public path, server entry, and client
+   entry from the manifest or build stats.
+5. Server logs for the request that rendered the route.
+6. Browser hydration warnings and Module Federation runtime error codes.
+7. `.mf/observability/latest.json` and `.mf/observability/events.jsonl` when the
+   observability plugin is enabled.
+8. `.mf/observability/build-info.json` or `.mf/observability/build-report.json`
+   when output shape or type generation is suspect.
+
+### Runtime And Observability
+
+For Module Federation `2.5.0+`, prefer `@module-federation/observability-plugin`
+when URL, expose, and shared dependency checks do not explain the failure.
+
+Use the report to identify:
+
+- the loading phase;
+- the owner hint, such as host, remote, shared, runtime, or build;
+- the `traceId`;
+- requested remote and expose;
+- selected shared provider and version;
+- recovered, pending, or failed outcome.
+
+For Node or SSR reports, read `.mf/observability/latest.json` first. Use
+`.mf/observability/events.jsonl` only when multiple traces or event ordering
+matter.
+
+For browser debugging, prefer the Module Federation Chrome DevTools Loading
+Trace export or an installed observability plugin report. Treat DOM, storage,
+cookies, tokens, and application state as sensitive.
+
+### SSR-Specific Checks
+
+- Confirm the host server resolves the same remote version the browser later
+  hydrates.
+- Confirm remote artifacts were built and promoted as one immutable version.
+- Confirm server-rendered code avoids `window`, `document`, `localStorage`,
+  layout measurement, and browser-only effects during render.
+- Confirm request data is not stored in module-level state or singleton services.
+- Confirm auth, cookie, tenant, locale, and tracing context are explicitly
+  passed and redacted from reports.
+- Confirm streaming boundaries and suspense fallbacks are intentional.
+- Confirm remote failure behavior is product-approved: fail route, render known
+  fallback, or client-only island.
+
+### Common Fixes
+
+- Wrong or unreachable URL: fix remote URL, public path, CDN route, or server
+  egress allowlist.
+- Missing expose: update the producer expose key and regenerate the manifest.
+- Mismatched server/client artifacts: promote one remote build version and clear
+  stale CDN/cache entries.
+- Shared mismatch: align singleton versions and remove conflicts between
+  `shared`, `externals`, aliases, and import transforms.
+- Hydration mismatch: move browser-only behavior to client effects, stabilize
+  serialized data, or make the remote client-only by design.
+- Type failures: fix producer DTS output, inspect Module Federation diagnostics,
+  and add `@mf-types` path mapping only when consumers need remote type imports.
+

--- a/skills/ui/module-federation-ssr/resources/host-remote-recipes.md
+++ b/skills/ui/module-federation-ssr/resources/host-remote-recipes.md
@@ -1,0 +1,79 @@
+## SSR Module Federation Host And Remote Recipes
+
+Use this reference when creating or reviewing host and remote setup.
+
+### Client-Rendered Rsbuild Host Or Remote
+
+Use this for non-SSR React/Vue MFE work.
+
+- Install `@module-federation/rsbuild-plugin`.
+- Keep `module-federation.config.ts` next to `rsbuild.config.ts`.
+- Enable manifest-based remotes with `mf-manifest.json`.
+- Share framework singletons deliberately: `react`, `react-dom`, and for
+  version-sensitive Bridge integrations `react-dom/`; or `vue` for Vue apps.
+- Verify with Vitest for component behavior, `pnpm build`, and a Playwright
+  host/remote smoke check.
+
+### Modern.js SSR Host Or Remote
+
+Use this as the preferred new SSR MFE application path when Modern.js is an
+acceptable framework choice.
+
+- Install the Modern.js Module Federation plugin that matches the app tools
+  major version, normally `@module-federation/modern-js-v3` for Modern.js v3.
+- Keep shared config in `module-federation.config.ts`.
+- Register the Module Federation plugin in `modern.config.*`.
+- Use the framework-supported SSR mode rather than a custom Vite SSR runtime.
+- Keep data loading request-scoped and pass data through documented loader or
+  props boundaries.
+- Smoke test rendered HTML, streaming or suspense fallback behavior, hydration,
+  and remote failure behavior.
+
+### Rslib Dual Producer
+
+Use this when a remote package must be consumed by both browser and server
+runtimes.
+
+- Build dual browser and Node outputs.
+- Keep environment-specific entry points explicit.
+- Avoid browser-only globals in server exports.
+- Publish generated types together with the remote artifacts.
+- Promote one immutable build output across environments.
+
+### Nuxt SSR Host Or Remote
+
+Use this only after accepting beta risk and deployment constraints.
+
+- Use the Nuxt Module Federation package rather than plain Vite federation when
+  true Nuxt SSR federation is required.
+- Verify both client and server entries are generated and reachable.
+- Check whether the deployment target permits the runtime cache/write behavior
+  the Nuxt integration needs.
+- Use Nuxt SSR-safe state and data APIs. Do not store request data in process
+  globals.
+- Add a route smoke test for server-rendered HTML, hydration, and fallback
+  behavior.
+
+### Next.js Host Or Remote
+
+Use this only for legacy Pages Router maintenance with an explicit exception.
+
+- Do not recommend Module Federation for new App Router SSR architecture.
+- If maintaining an existing Pages Router setup, use `@module-federation/nextjs-mf`
+  with local webpack and explicit server/client remote entry paths.
+- Prefer framework-native alternatives for new Next.js work: multi-zones, shared
+  packages, BFF boundaries, or independent deployments behind routing.
+- Document migration pressure whenever a Next Pages Router MFE is touched.
+
+### Vinext Or Plain Vite SSR
+
+Use this only when the repository already adopted the stack or explicitly owns
+the experiment.
+
+- Treat client-side federation through `@module-federation/vite` as distinct
+  from true SSR federation.
+- Require tests that prove server render, client hydration, server artifact
+  resolution, and fallback behavior.
+- Keep escape hatches documented because compatibility with the Next ecosystem
+  or Vite SSR runtime behavior may change.
+

--- a/skills/ui/module-federation/SKILL.md
+++ b/skills/ui/module-federation/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: module-federation
+description: >
+  Add, review, or debug Module Federation support in Rsbuild-first TypeScript
+  applications. Covers host/remote roles, exposes, remotes, shared dependencies,
+  generated types, runtime loading failures, and observability checks.
+version: 1.0.0
+tags:
+  - ui
+  - module-federation
+  - micro-frontends
+  - rsbuild
+  - typescript
+resources: []
+vendor_support:
+  claude: native
+  opencode: native
+  copilot: prompt-inject
+  codex: prompt-inject
+  gemini: prompt-inject
+---
+
+## Module Federation Skill
+
+Use this skill when adding Module Federation, reviewing host/remote contracts,
+debugging federated loading, or fixing type generation and shared dependency
+issues.
+
+### Step 1 - Inspect The Project
+
+Read the project root before changing files:
+
+- `package.json`
+- `pnpm-lock.yaml` when dependency versions matter
+- `rsbuild.config.*`
+- `module-federation.config.*`
+- `tsconfig*.json`
+- app entry points and route registration that import remotes or exposed modules
+
+If the project has no Rsbuild, Rspack, Webpack, Modern.js, Next, Vite, or related
+build config, treat it as a new project and recommend the official scaffold:
+
+```bash
+npm create module-federation@latest
+```
+
+For new in-repo implementation, prefer Rsbuild unless local project instructions
+name another framework-owned build system.
+
+### Step 2 - Determine The Role
+
+Classify the app before editing config:
+
+| Role | Meaning |
+|---|---|
+| `consumer` | Loads modules from remote apps through `remotes`. |
+| `provider` | Exposes modules to other apps through `exposes`. |
+| `both` | Publishes exposes and consumes remotes. |
+
+Use the package name as the starting app name, converted to snake_case. Module
+Federation app names must not contain hyphens.
+
+### Step 3 - Configure Rsbuild First
+
+For Rsbuild apps, install the official plugin:
+
+```bash
+pnpm add @module-federation/rsbuild-plugin
+```
+
+Create `module-federation.config.ts`:
+
+```ts
+import { createModuleFederationConfig } from '@module-federation/rsbuild-plugin'
+
+export default createModuleFederationConfig({
+  name: '<app_name>',
+  shareStrategy: 'loaded-first',
+  shared: {
+    react: { singleton: true },
+    'react-dom': { singleton: true },
+  },
+})
+```
+
+Register it from `rsbuild.config.ts`:
+
+```ts
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin'
+import moduleFederationConfig from './module-federation.config'
+
+export default defineConfig({
+  plugins: [
+    pluginModuleFederation(moduleFederationConfig),
+  ],
+})
+```
+
+Adjust `shared` for the actual framework:
+
+- React: `react` and `react-dom` as singletons.
+- Vue: `vue` as a singleton.
+- Mixed framework workspaces: share only dependencies intentionally used across
+  host and remote boundaries.
+
+### Step 4 - Add Exposes Or Remotes
+
+For providers, expose small stable entry points:
+
+```ts
+exposes: {
+  './Button': './src/components/Button.tsx',
+}
+```
+
+For consumers, prefer manifest-based remotes:
+
+```ts
+remotes: {
+  provider: 'provider@https://example.com/mf-manifest.json',
+}
+```
+
+Do not expose broad application folders or private implementation paths. Treat
+each exposed key as a public contract.
+
+### Step 5 - Handle Types
+
+Module Federation type generation is part of the public host/remote contract.
+
+- Producers should emit type artifacts during build.
+- Consumers should pull remote types into `@mf-types`.
+- Add or merge this path mapping only when remote type imports need it:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "*": ["./@mf-types/*"]
+    }
+  }
+}
+```
+
+For producer type failures, inspect `.mf/observability/latest.json` when present
+and run TypeScript against the temporary config path reported by Module
+Federation diagnostics. Avoid running a broad type check when the temp config
+gives a narrower failing boundary.
+
+### Step 6 - Check Shared Dependencies
+
+Before declaring a shared dependency healthy:
+
+- Confirm the package is not also listed in `externals`.
+- Confirm host and remotes resolve singleton packages to compatible versions.
+- Check for import rewriting that can hide shared UI packages from Module
+  Federation. In Rsbuild and Modern.js, inspect `source.transformImport`.
+- When duplicate shared versions appear in build artifacts, prefer an alias or
+  workspace constraint over runtime fallback behavior.
+
+### Step 7 - Debug Runtime Loading
+
+For loading failures, collect evidence in this order:
+
+1. Confirm the configured manifest or remote entry URL is reachable.
+2. Confirm the remote publishes the requested expose key.
+3. Confirm the host remote name matches the configured container or manifest.
+4. Check console and network errors for Module Federation runtime codes.
+5. Use Module Federation observability reports when URL, expose, and shared
+   dependency checks do not explain the failure.
+
+Treat captured browser state as sensitive. Redact cookies, tokens, local storage,
+session storage, and user data from saved reports and chat output.
+
+### Step 8 - Verify
+
+Run the narrowest checks that prove the change:
+
+- `pnpm lint`
+- `pnpm test --run` for Vitest projects
+- `pnpm build` for the Rsbuild production bundle
+- A host/remote smoke check when exposes, remotes, shared dependency policy, or
+  deployment URLs changed

--- a/skills/ui/module-federation/SKILL.md
+++ b/skills/ui/module-federation/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: module-federation
 description: >
-  Add, review, or debug Module Federation support in Rsbuild-first TypeScript
-  applications. Covers host/remote roles, exposes, remotes, shared dependencies,
-  generated types, runtime loading failures, and observability checks.
+  Add, review, or debug client-rendered Module Federation support in
+  Rsbuild-first TypeScript applications. Covers host/remote roles, exposes,
+  remotes, shared dependencies, generated types, runtime loading failures, and
+  observability checks.
 version: 1.0.0
 tags:
   - ui
@@ -22,9 +23,17 @@ vendor_support:
 
 ## Module Federation Skill
 
-Use this skill when adding Module Federation, reviewing host/remote contracts,
-debugging federated loading, or fixing type generation and shared dependency
-issues.
+Use this skill when adding client-rendered Module Federation, reviewing
+host/remote contracts, debugging federated loading, or fixing type generation
+and shared dependency issues.
+
+For SSR federation, hydration failures, server entries, Modern.js, Nuxt,
+Next.js, Vinext, or Vite SSR, use the `module-federation-ssr` skill when it is
+available. If only this skill is available, keep the work conservative: prefer
+Rsbuild for non-SSR federation, treat Modern.js as the preferred SSR app path,
+use Rslib for dual browser/server remote artifacts, treat Nuxt SSR federation
+as beta, and treat Next.js Module Federation as legacy Pages Router maintenance
+only.
 
 ### Step 1 - Inspect The Project
 
@@ -38,14 +47,16 @@ Read the project root before changing files:
 - app entry points and route registration that import remotes or exposed modules
 
 If the project has no Rsbuild, Rspack, Webpack, Modern.js, Next, Vite, or related
-build config, treat it as a new project and recommend the official scaffold:
+build config, treat it as a new client-rendered project and recommend the
+official scaffold:
 
 ```bash
 npm create module-federation@latest
 ```
 
 For new in-repo implementation, prefer Rsbuild unless local project instructions
-name another framework-owned build system.
+name another framework-owned build system. Do not retrofit true SSR federation
+from this skill; route that work to SSR-specific guidance first.
 
 ### Step 2 - Determine The Role
 
@@ -181,3 +192,5 @@ Run the narrowest checks that prove the change:
 - `pnpm build` for the Rsbuild production bundle
 - A host/remote smoke check when exposes, remotes, shared dependency policy, or
   deployment URLs changed
+- commitlint through the existing hook or CI commit-range check when the
+  repository enforces Conventional Commits

--- a/skills/ui/module-federation/SKILL.md
+++ b/skills/ui/module-federation/SKILL.md
@@ -35,6 +35,10 @@ use Rslib for dual browser/server remote artifacts, treat Nuxt SSR federation
 as beta, and treat Next.js Module Federation as legacy Pages Router maintenance
 only.
 
+For deep runtime debugging, production-only failures, observability reports, or
+unclear host/remote ownership, use the `module-federation-debugging` skill when
+it is available.
+
 ### Step 1 - Inspect The Project
 
 Read the project root before changing files:

--- a/tooling/lib/test.sh
+++ b/tooling/lib/test.sh
@@ -2053,7 +2053,7 @@ bash "$COMPOSE" \
   --target "$TMP/t76a" \
   > /dev/null 2>&1
 
-assert_file_contains_block "$TMP/t76a/AGENTS.md" $'| Additional | React Router, Playwright (acceptance) |\n\n## Commands' "T76A tech to commands"
+assert_file_contains_block "$TMP/t76a/AGENTS.md" $'| Additional | React Router, Rslint, commitlint, Playwright (acceptance) |\n\n## Commands' "T76A tech to commands"
 assert_file_contains_block "$TMP/t76a/AGENTS.md" $'- **Lint**: `pnpm lint`\n\n## Conventions & Patterns' "T76A commands to conventions"
 assert_file_contains_block "$TMP/t76a/AGENTS.md" $'| CI/CD | `.agentic/fragments/ci-cd.md` |\n\n## Skills' "T76A conventions to skills"
 


### PR DESCRIPTION
## Why

The TypeScript guidance was still centered on older defaults: generic pnpm usage, Vite wording for SPA profiles, ESLint-first linting, and no reusable Module Federation path.

This PR updates the library so generated project guidance reflects pnpm 12 install expectations, Rsbuild-first SPA and micro-frontend builds, Vitest testing, Rslint linting for new JS/TS setups, commitlint enforcement for Conventional Commits, and researched Module Federation guidance for both client-rendered and SSR MFE work.

## What changed

- Added a Module Federation architecture fragment covering host/remote boundaries, Rsbuild plugin usage, shared dependencies, type contracts, runtime loading checks, SSR boundaries, and CI gates.
- Added a `module-federation` UI skill for adding, reviewing, and debugging client-rendered Module Federation in Rsbuild-first TypeScript apps.
- Added a `module-federation-debugging` UI skill for evidence-first MFE diagnosis across manifests, remote entries, runtime errors, shared dependencies, generated types, browser loading, Node/SSR loading, and hydration boundaries.
- Added a `module-federation-ssr` UI skill with focused resources for SSR architecture choices, host/remote recipes, red lines, and debugging across Modern.js, Nuxt, Next.js legacy Pages Router, Vinext, Vite SSR, and dual browser/server remote artifacts.
- Added `typescript-react-module-federation-rsbuild` as a deployable React Module Federation profile.
- Updated TypeScript-bearing profiles to use pnpm 12 metadata and include Rslint/commitlint where Node tooling applies.
- Moved standalone React/Vue SPA and full-stack React/Vue UI profile wording from Vite to Rsbuild while leaving Next/Nuxt on their framework-owned build layers.
- Updated the generated-output integration expectation for `typescript-react-spa` so it matches the new Rslint and commitlint profile metadata.
- Updated docs and regenerated skill, fragment, and profile schema indexes.

## Validation

- `just index`: passed, proving generated indexes and the profile skill enum were refreshed.
- `just lint`: passed, proving fragments, profiles, vendor adapters, and skill frontmatter validate.
- `just test`: passed, proving the full integration suite accepts the updated generated output.
- `just compose typescript-react-module-federation-rsbuild /tmp/.../mfe`: passed, proving the new MFE profile composes.
- `just compose typescript-react-spa /tmp/.../react-spa`: passed, proving updated SPA profile composition still works.
- `just compose typescript-hexagonal-react-vite-ui /tmp/.../fullstack-react`: passed, proving updated nested UI profile composition still works.
- `just validate /tmp/.../mfe`: passed, proving the generated MFE AGENTS output is structurally valid.
- `just validate /tmp/.../react-spa`: passed, proving the generated React SPA AGENTS output is structurally valid.
- `just validate /tmp/.../fullstack-react`: passed, proving the generated nested full-stack AGENTS output is structurally valid.
- `just validate /tmp/agentic-mfe-debug-compose-check`: passed, proving the MFE profile still composes valid AGENTS output with the debugging skill listed.
- `just deploy typescript-react-module-federation-rsbuild /tmp/agentic-mfe-debug-deploy-check codex module-federation-debugging`: passed, proving the new debugging skill and its resources deploy selectively.
- `just deploy typescript-react-module-federation-rsbuild /tmp/agentic-mfe-ssr-deploy-check codex module-federation-ssr`: passed, proving the new SSR skill and its resources deploy selectively.
- `python3 .../skill-creator/scripts/quick_validate.py skills/ui/module-federation-ssr`: blocked locally because that validator environment is missing `yaml`; repository `just lint` covers the skill frontmatter validation path.

## Risk and rollout

Profile IDs are preserved for existing users. Some display names and generated guidance now say Rsbuild even when older profile filenames still contain `vite`; that avoids a breaking profile rename while aligning new generated output with the preferred stack.

The new debugging skill is additive and now included by the Rsbuild MFE profile. The SSR MFE guidance is intentionally conservative: Modern.js and Rslib are presented as the preferred supported paths, Nuxt SSR federation is marked beta pending project/deployment validation, Next.js Module Federation is legacy Pages Router maintenance only, and Vinext/plain Vite SSR federation are treated as project-owned experimental paths until proven by tests and deployment evidence.
